### PR TITLE
Await completion of WriteDescriptor to avoid possible failuress of next operation

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ The application contains basic features of the released BrickController 2 versio
 | :-- | :-- | :-- | :-- |
 | imurvai#78 | imurvai#79 | Buwizz v1 device is not able to keep constant channel output for longer period | Manually tested |
 | | imurvai#87 | Make BluetoothDevice.Disconnect asynchronous | Manually tested |
+| vicocz#10 | imurvai#89 | Await completion of WriteDescriptor [Android] | Manually tested |
 
 
 ## 3rd party libraries used


### PR DESCRIPTION
Ocassionally BLE read operation was failing when executed shortly after 'BluetoothLEDevice.EnableNotificationAsync'. Seems there used to be a race condition that [WriteDescriptor](https://github.com/vicocz/brickcontroller2/blob/a12c35befefb36b9245aedfdcee5f74e48be8ca3/BrickController2/BrickController2.Android/PlatformServices/BluetoothLE/BluetoothLEDevice.cs#L174) was not awaiting its completion as e.g. read / write does.
This fix resolves #10.
PR for the original BC2: imurvai#89

https://stackoverflow.com/questions/53937238/unable-to-read-characteristic-using-bluetooth-le-readcharacteristic-returns-fal