### PR TITLE
Fix detection of storage folder for both 33+ Android API and legacy ones

### DIFF
--- a/BrickController2/BrickController2.Android/PlatformServices/Permission/ReadWriteExternalStoragePermission.cs
+++ b/BrickController2/BrickController2.Android/PlatformServices/Permission/ReadWriteExternalStoragePermission.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using Android.OS;
+using System;
 using static Xamarin.Essentials.Permissions;
 using BrickController2.PlatformServices.Permission;
 
@@ -6,10 +7,15 @@ namespace BrickController2.Droid.PlatformServices.Permission
 {
     public class ReadWriteExternalStoragePermission : BasePlatformPermission, IReadWriteExternalStoragePermission
     {
-        public override (string androidPermission, bool isRuntime)[] RequiredPermissions => new List<(string androidPermission, bool isRuntime)>
-            {
-                (Android.Manifest.Permission.ReadExternalStorage, true),
-                (Android.Manifest.Permission.WriteExternalStorage, true)
-            }.ToArray();
+        public override (string androidPermission, bool isRuntime)[] RequiredPermissions => ((int)Build.VERSION.SdkInt <= 32) ?
+                // Android API 32 and older - ask for permissions
+                new (string androidPermission, bool isRuntime)[]
+                {
+                    (Android.Manifest.Permission.ReadExternalStorage, true),
+                    (Android.Manifest.Permission.WriteExternalStorage, true)
+                } :
+                // Android API 33+ does not support permissions to external storage
+                // Let it be Granted (via empty permission list)
+                Array.Empty<(string androidPermission, bool isRuntime)>();
     }
 }

--- a/BrickController2/BrickController2.Android/PlatformServices/SharedFileStorage/SharedFileStorageService.cs
+++ b/BrickController2/BrickController2.Android/PlatformServices/SharedFileStorage/SharedFileStorageService.cs
@@ -26,18 +26,44 @@ namespace BrickController2.Droid.PlatformServices.SharedFileStorage
             }
         }
 
-        public string SharedStorageDirectory
+        public string SharedStorageBaseDirectory
         {
             get
             {
                 try
                 {
 #pragma warning disable CS0618 // Type or member is obsolete
-                    var storageDirectory = Environment.ExternalStorageDirectory?.AbsolutePath;
+                    var storageDirectory = ((int)Build.VERSION.SdkInt <= 32) ?
+                        // Android API 32 and older - keep backward compatible: /storage/emulated/0/
+                        Environment.ExternalStorageDirectory?.AbsolutePath :
+                        // Android API 33+ - use /storage/emulated/0/Documents
+                        Environment.GetExternalStoragePublicDirectory(Environment.DirectoryDocuments)?.AbsolutePath;
                     var storageState = Environment.ExternalStorageState;
 #pragma warning restore CS0618 // Type or member is obsolete
 
                     if (storageDirectory == null || !Directory.Exists(storageDirectory) || !Environment.MediaMounted.Equals(storageState))
+                    {
+                        return null;
+                    }
+
+                    return storageDirectory;
+                }
+                catch (Exception)
+                {
+                    return null;
+                }
+            }
+        }
+
+        public string SharedStorageDirectory
+        {
+            get
+            {
+                try
+                {
+                    var storageDirectory = SharedStorageBaseDirectory;
+
+                    if (storageDirectory == null)
                     {
                         return null;
                     }

--- a/BrickController2/BrickController2.Android/Properties/AndroidManifest.xml
+++ b/BrickController2/BrickController2.Android/Properties/AndroidManifest.xml
@@ -8,8 +8,8 @@
 	<uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" android:maxSdkVersion="30" />
 	<uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" android:maxSdkVersion="30" />
 	<uses-permission android:name="android.permission.TRANSMIT_IR" />
-	<uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
-	<uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
+	<uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" android:maxSdkVersion="32" />
+	<uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" android:maxSdkVersion="32" />
 	<uses-feature android:name="android.hardware.bluetooth" android:required="true" />
 	<uses-feature android:name="android.hardware.bluetooth_le" android:required="true" />
 	<application android:label="BrickController2.Android" android:icon="@mipmap/ic_launcher"></application>

--- a/BrickController2/BrickController2.iOS/PlatformServices/SharedFileStorage/SharedFileStorageService.cs
+++ b/BrickController2/BrickController2.iOS/PlatformServices/SharedFileStorage/SharedFileStorageService.cs
@@ -21,7 +21,9 @@ namespace BrickController2.iOS.PlatformServices.SharedFileStorage
             }
         }
 
-        public string SharedStorageDirectory
+        public string SharedStorageDirectory => SharedStorageBaseDirectory;
+
+        public string SharedStorageBaseDirectory
         {
             get
             {

--- a/BrickController2/BrickController2/PlatformServices/SharedFileStorage/ISharedFileStorageService.cs
+++ b/BrickController2/BrickController2/PlatformServices/SharedFileStorage/ISharedFileStorageService.cs
@@ -6,6 +6,8 @@
 
         bool IsPermissionGranted { get; set; }
 
+        string SharedStorageBaseDirectory { get; }
+
         string SharedStorageDirectory { get; }
     }
 }

--- a/BrickController2/BrickController2/UI/ViewModels/CreationListPageViewModel.cs
+++ b/BrickController2/BrickController2/UI/ViewModels/CreationListPageViewModel.cs
@@ -124,7 +124,7 @@ namespace BrickController2.UI.ViewModels
                     _disappearingTokenSource.Token.ThrowIfCancellationRequested();
                 }
 
-                if (SharedFileStorageService.SharedStorageDirectory != null)
+                if (SharedFileStorageService.SharedStorageBaseDirectory != null)
                 {
                     var storagePermissionStatus = await _readWriteExternalStoragePermission.CheckStatusAsync();
                     if (storagePermissionStatus != PermissionStatus.Granted && !_isStoragePermissionRequested)


### PR DESCRIPTION
Seems the originally reported issue/fix https://github.com/imurvai/brickcontroller2/pull/104 is still not approved.

In order to have export / import available for BC2 Android version I have to:
* split `SharedStorageDirectory` to base folder detection in `SharedStorageBaseDirectory` so as BC2 folder creation happens after permissions are granted
* due to changes in Android API 33+ `Document` folder is used with BC2 folder so as it does not require permission setup

Android prier API 33 should use `/storage/emulated/0/BrickController2` - I guess this should be backward compatible I used to be when this feature worked properly.
Android with API 33+: `/storage/emulated/0/Documents/BrickController2`
![image](https://github.com/imurvai/brickcontroller2/assets/11756608/2b2ce99c-ffcf-460b-99ad-3de75e6f5cc9)

Dev tested on Android 9 and 14.