### PR TITLE
Enable scanning of devices powered by BuWizz

### DIFF
--- a/BrickController2/BrickController2/UI/Pages/DevicePage.xaml
+++ b/BrickController2/BrickController2/UI/Pages/DevicePage.xaml
@@ -129,6 +129,8 @@
 
                     </StackLayout>
                 </ScrollView>
+
+                <controls:FloatingActionButton ButtonColor="Red" ImageSource="{extensions:ImageResource Source=ic_search.png}" ImageColor="White" Command="{Binding ScanCommand}" IsVisible="{Binding CanBePowerSource}" HorizontalOptions="End" VerticalOptions="End" Margin="10"/>
             </Grid>
 
             <controls:Dialogs x:Name="Dialogs" AbsoluteLayout.LayoutBounds="0, 0, 1, 1" AbsoluteLayout.LayoutFlags="All"/>

--- a/BrickController2/BrickController2/UI/ViewModels/DevicePageViewModel.cs
+++ b/BrickController2/BrickController2/UI/ViewModels/DevicePageViewModel.cs
@@ -46,15 +46,18 @@ namespace BrickController2.UI.ViewModels
             RenameCommand = new SafeCommand(async () => await RenameDeviceAsync());
             BuWizzOutputLevelChangedCommand = new SafeCommand<int>(outputLevel => SetBuWizzOutputLevel(outputLevel));
             BuWizz2OutputLevelChangedCommand = new SafeCommand<int>(outputLevel => SetBuWizzOutputLevel(outputLevel));
+            ScanCommand = new SafeCommand(async () => await ScanAsync(), () => Device.CanBePowerSource && !_deviceManager.IsScanning);
         }
 
         public Device Device { get; }
         public bool IsBuWizzDevice => Device.DeviceType == DeviceType.BuWizz;
         public bool IsBuWizz2Device => Device.DeviceType == DeviceType.BuWizz2;
+        public bool CanBePowerSource => Device.CanBePowerSource;
 
         public ICommand RenameCommand { get; }
         public ICommand BuWizzOutputLevelChangedCommand { get; }
         public ICommand BuWizz2OutputLevelChangedCommand { get; }
+        public ICommand ScanCommand { get; }
 
         public int BuWizzOutputLevel { get; set; } = 1;
         public int BuWizz2OutputLevel { get; set; } = 1;
@@ -211,6 +214,66 @@ namespace BrickController2.UI.ViewModels
                 {
                     await Task.Delay(50);
                 }
+            }
+        }
+
+        private async Task ScanAsync()
+        {
+            if (!_deviceManager.IsBluetoothOn)
+            {
+                await _dialogService.ShowMessageBoxAsync(
+                    Translate("Warning"),
+                    Translate("BluetoothIsTurnedOff"),
+                    Translate("Ok"),
+                    _disappearingTokenSource.Token);
+            }
+
+            var percent = 0;
+            var scanResult = true;
+            await _dialogService.ShowProgressDialogAsync(
+                true,
+                async (progressDialog, token) =>
+                {
+                    if (!_isDisappearing)
+                    {
+                        using (var cts = new CancellationTokenSource())
+                        using (_disappearingTokenSource.Token.Register(() => cts.Cancel()))
+                        {
+                            Task<bool> scanTask = null;
+                            try
+                            {
+                                scanTask = _deviceManager.ScanAsync(cts.Token);
+
+                                while (!token.IsCancellationRequested && percent <= 100 && !scanTask.IsCompleted)
+                                {
+                                    progressDialog.Percent = percent;
+                                    await Task.Delay(100, token);
+                                    percent += 1;
+                                }
+                            }
+                            catch (Exception)
+                            { }
+
+                            cts.Cancel();
+
+                            if (scanTask != null)
+                            {
+                                scanResult = await scanTask;
+                            }
+                        }
+                    }
+                },
+                Translate("Scanning"),
+                Translate("SearchingForDevices"),
+                Translate("Cancel"));
+
+            if (!scanResult && !_isDisappearing)
+            {
+                await _dialogService.ShowMessageBoxAsync(
+                    Translate("Warning"),
+                    Translate("ErrorDuringScanning"),
+                    Translate("Ok"),
+                    CancellationToken.None);
             }
         }
 

--- a/BrickController2/BrickController2/UI/ViewModels/DevicePageViewModel.cs
+++ b/BrickController2/BrickController2/UI/ViewModels/DevicePageViewModel.cs
@@ -46,13 +46,16 @@ namespace BrickController2.UI.ViewModels
             RenameCommand = new SafeCommand(async () => await RenameDeviceAsync());
             BuWizzOutputLevelChangedCommand = new SafeCommand<int>(outputLevel => SetBuWizzOutputLevel(outputLevel));
             BuWizz2OutputLevelChangedCommand = new SafeCommand<int>(outputLevel => SetBuWizzOutputLevel(outputLevel));
-            ScanCommand = new SafeCommand(async () => await ScanAsync(), () => Device.CanBePowerSource && !_deviceManager.IsScanning);
+            ScanCommand = new SafeCommand(ScanAsync, () => CanExecuteScan);
         }
 
         public Device Device { get; }
         public bool IsBuWizzDevice => Device.DeviceType == DeviceType.BuWizz;
         public bool IsBuWizz2Device => Device.DeviceType == DeviceType.BuWizz2;
         public bool CanBePowerSource => Device.CanBePowerSource;
+        public bool CanExecuteScan => Device.CanBePowerSource &&
+            Device.DeviceState == DeviceState.Connected &&
+            !_deviceManager.IsScanning;
 
         public ICommand RenameCommand { get; }
         public ICommand BuWizzOutputLevelChangedCommand { get; }


### PR DESCRIPTION
This relates to https://github.com/imurvai/brickcontroller2/pull/111 which has net been merged yet.

In order to enable discovery of devices which are connected to other devices, such as e.g. BuWizz 2, I've added floating button for scaning on Device page when a device, which has `CanBePowerSource` set to `true` is connected to.

This should help to (partially) resolve #43 #48 as such devices are now able to be discovered.

![image](https://github.com/imurvai/brickcontroller2/assets/11756608/30a2f87a-422e-45eb-8c7c-91366cbce75f)

