### PR TITLE
Enable scanning of devices powered by BuWizz

### DIFF
--- a/BrickController2/BrickController2/UI/Pages/DevicePage.xaml
+++ b/BrickController2/BrickController2/UI/Pages/DevicePage.xaml
@@ -132,6 +132,8 @@
 
                     </VerticalStackLayout>
                 </ScrollView>
+
+                <controls:FloatingActionButton ButtonColor="Red" ImageSource="{extensions:ImageResource Source=ic_search.png}" ImageColor="White" Command="{Binding ScanCommand}" IsVisible="{Binding CanBePowerSource}" HorizontalOptions="End" VerticalOptions="End" Margin="10"/>
             </Grid>
 
             <controls:Dialogs x:Name="Dialogs" AbsoluteLayout.LayoutBounds="0, 0, 1, 1" AbsoluteLayout.LayoutFlags="All"/>

--- a/BrickController2/BrickController2/UI/ViewModels/DevicePageViewModel.cs
+++ b/BrickController2/BrickController2/UI/ViewModels/DevicePageViewModel.cs
@@ -228,7 +228,7 @@ namespace BrickController2.UI.ViewModels
                     Translate("Warning"),
                     Translate("BluetoothIsTurnedOff"),
                     Translate("Ok"),
-                    _disappearingTokenSource.Token);
+                    _disappearingTokenSource?.Token ?? default);
             }
 
             var percent = 0;
@@ -240,9 +240,9 @@ namespace BrickController2.UI.ViewModels
                     if (!_isDisappearing)
                     {
                         using (var cts = new CancellationTokenSource())
-                        using (_disappearingTokenSource.Token.Register(() => cts.Cancel()))
+                        using (_disappearingTokenSource?.Token.Register(() => cts.Cancel()))
                         {
-                            Task<bool> scanTask = null;
+                            Task<bool>? scanTask = null;
                             try
                             {
                                 scanTask = _deviceManager.ScanAsync(cts.Token);


### PR DESCRIPTION
In order to enable discovery of devices which are connected to other devices, such as e.g. BuWizz 2, I've added floating button for scaning on Device page when a device, which has `CanBePowerSource` set to `true` is connected to.

![image](https://github.com/imurvai/brickcontroller2/assets/11756608/30a2f87a-422e-45eb-8c7c-91366cbce75f)

