### PR TITLE
JK: SelectionDialog Scrollbar Fix

### DIFF
--- a/BrickController2/BrickController2/UI/Controls/Dialogs.xaml
+++ b/BrickController2/BrickController2/UI/Controls/Dialogs.xaml
@@ -65,7 +65,7 @@
                     <StackLayout Orientation="Vertical">
                         <Label x:Name="SelectionDialogTitle" HorizontalOptions="Center" FontAttributes="Bold" FontSize="Large"/>
                         <BoxView Style="{StaticResource DividerBoxViewStyle}" Margin="0,8,0,8"/>
-                        <CollectionView x:Name="SelectionDialogItems" SelectionMode="Single">
+                        <CollectionView x:Name="SelectionDialogItems" SelectionMode="Single" VerticalOptions="FillAndExpand">
                             <CollectionView.ItemTemplate>
                                 <DataTemplate>
                                     <Label Text="{Binding}" FontSize="Large" FontAttributes="Bold" Margin="0,4"/>


### PR DESCRIPTION
Hi @vicocz :)

I've this little [fix](https://stackoverflow.com/questions/70610332/collectionview-is-not-scrolling-without-setting-the-height-property) for the SelectionDialog not showing a vertical scrollbar.

Running as WinUI-App it's not possible to scroll:
![Screenshot BC2 DeviceSelection](https://github.com/user-attachments/assets/025b1aa4-3295-4b7e-9a70-c1e140a3f0de)

After the fix the scrollbar is shown:
![Screenshot BC2 DeviceSelection fixed](https://github.com/user-attachments/assets/0f27ff2d-3d4b-4add-bde1-7d41c9ce1557)

Btw: the large FontSize looks all but nice... ;)