### PR TITLE
Finetune SelectionDialog (and others) for a desktop app

### DIFF
--- a/BrickController2/BrickController2/App.xaml
+++ b/BrickController2/BrickController2/App.xaml
@@ -143,7 +143,10 @@
             <Setter Property="BackgroundColor" Value="{DynamicResource DialogBackgroundColor}"/>
             <Setter Property="BorderColor" Value="{DynamicResource DialogBorderColor}"/>
             <Setter Property="CornerRadius" Value="10"/>
-            <Setter Property="HasShadow" Value="True"/>
+            <Setter Property="HorizontalOptions" Value="Center"/>
+            <Setter Property="VerticalOptions" Value="Center"/>
+            <Setter Property="WidthRequest" Value="{OnIdiom 280, Desktop=360}"/>
+            <Setter Property="Padding" Value="20"/>
         </Style>
         
         <!-- Picker button -->

--- a/BrickController2/BrickController2/UI/Controls/Dialogs.xaml
+++ b/BrickController2/BrickController2/UI/Controls/Dialogs.xaml
@@ -12,19 +12,19 @@
 
             <!-- Message box -->
             <ContentView x:Name="MessageBox" IsVisible="false" AbsoluteLayout.LayoutBounds="0, 0, 1, 1" AbsoluteLayout.LayoutFlags="All">
-                <Frame x:Name="MessageBoxFrame" Style="{StaticResource DialogFrameStyle}" HorizontalOptions="Center" VerticalOptions="Center" WidthRequest="280" Padding="20">
+                <Frame x:Name="MessageBoxFrame" Style="{StaticResource DialogFrameStyle}">
                     <StackLayout Orientation="Vertical">
                         <Label x:Name="MessageBoxTitle" HorizontalOptions="Center" FontAttributes="Bold" FontSize="Large"/>
                         <Label x:Name="MessageBoxMessage" HorizontalOptions="Center"/>
                         <BoxView Style="{StaticResource DividerBoxViewStyle}" Margin="0,16,0,16"/>
-                        <Button x:Name="MessageBoxButton"/>
+                        <Button x:Name="MessageBoxButton" Margin="{OnIdiom '16,0,16,0', Desktop='96,0,96,0'}"/>
                     </StackLayout>
                 </Frame>
             </ContentView>
 
             <!-- Question dialog -->
             <ContentView x:Name="QuestionDialog" IsVisible="false" AbsoluteLayout.LayoutBounds="0, 0, 1, 1" AbsoluteLayout.LayoutFlags="All">
-                <Frame x:Name="QuestionDialogFrame" Style="{StaticResource DialogFrameStyle}" HorizontalOptions="Center" VerticalOptions="Center" WidthRequest="280" Padding="20">
+                <Frame x:Name="QuestionDialogFrame" Style="{StaticResource DialogFrameStyle}">
                     <StackLayout Orientation="Vertical">
                         <Label x:Name="QuestionDialogTitle" HorizontalOptions="Center" FontAttributes="Bold" FontSize="Large"/>
                         <Label x:Name="QuestionDialogMessage" HorizontalOptions="Center"/>
@@ -34,8 +34,8 @@
                                 <ColumnDefinition Width="*"/>
                                 <ColumnDefinition Width="*"/>
                             </Grid.ColumnDefinitions>
-                            <Button x:Name="QuestionDialogPositiveButton" Grid.Column="0" BackgroundColor="{DynamicResource PositiveColor}"/>
-                            <Button x:Name="QuestionDialogNegativeButton" Grid.Column="1" BackgroundColor="{DynamicResource NegativeColor}"/>
+                            <Button x:Name="QuestionDialogPositiveButton" Grid.Column="0" BackgroundColor="{DynamicResource PositiveColor}" Margin="16,0,8,0"/>
+                            <Button x:Name="QuestionDialogNegativeButton" Grid.Column="1" BackgroundColor="{DynamicResource NegativeColor}" Margin="8,0,16,0"/>
                         </Grid>
                     </StackLayout>
                 </Frame>
@@ -43,7 +43,7 @@
 
             <!-- Input dialog -->
             <ContentView x:Name="InputDialog" IsVisible="false" AbsoluteLayout.LayoutBounds="0, 0, 1, 1" AbsoluteLayout.LayoutFlags="All">
-                <Frame x:Name="InputDialogFrame" Style="{StaticResource DialogFrameStyle}" HorizontalOptions="Center" VerticalOptions="Start" WidthRequest="280" Margin="0,10,0,0" Padding="20">
+                <Frame x:Name="InputDialogFrame" Style="{StaticResource DialogFrameStyle}" VerticalOptions="Start" Margin="0,10,0,0">
                     <StackLayout Orientation="Vertical">
                         <Entry x:Name="InputDialogEntry" HorizontalOptions="FillAndExpand"/>
                         <BoxView Style="{StaticResource DividerBoxViewStyle}" Margin="0,16,0,16"/>
@@ -52,8 +52,8 @@
                                 <ColumnDefinition Width="*"/>
                                 <ColumnDefinition Width="*"/>
                             </Grid.ColumnDefinitions>
-                            <Button x:Name="InputDialogPositiveButton" Grid.Column="0" BackgroundColor="{DynamicResource PositiveColor}"/>
-                            <Button x:Name="InputDialogNegativeButton" Grid.Column="1" BackgroundColor="{DynamicResource NegativeColor}"/>
+                            <Button x:Name="InputDialogPositiveButton" Grid.Column="0" BackgroundColor="{DynamicResource PositiveColor}" Margin="16,0,8,0"/>
+                            <Button x:Name="InputDialogNegativeButton" Grid.Column="1" BackgroundColor="{DynamicResource NegativeColor}" Margin="8,0,16,0"/>
                         </Grid>
                     </StackLayout>
                 </Frame>
@@ -61,7 +61,7 @@
 
             <!-- Selection dialog -->
             <ContentView x:Name="SelectionDialog" IsVisible="false" AbsoluteLayout.LayoutBounds="0, 0, 1, 1" AbsoluteLayout.LayoutFlags="All">
-                <Frame x:Name="SelectionDialogFrame" Style="{StaticResource DialogFrameStyle}" HorizontalOptions="Center" VerticalOptions="Start" WidthRequest="{OnIdiom 280, Desktop=360}" Margin="0,50,0,50" Padding="20">
+                <Frame x:Name="SelectionDialogFrame" Style="{StaticResource DialogFrameStyle}" VerticalOptions="Start" Margin="0,50,0,50">
                     <StackLayout Orientation="Vertical">
                         <Label x:Name="SelectionDialogTitle" HorizontalOptions="Center" FontAttributes="Bold" FontSize="Large"/>
                         <BoxView Style="{StaticResource DividerBoxViewStyle}" Margin="0,8,0,8"/>
@@ -80,7 +80,7 @@
 
             <!-- Progress dialog -->
             <ContentView x:Name="ProgressDialog" IsVisible="false" AbsoluteLayout.LayoutBounds="0, 0, 1, 1" AbsoluteLayout.LayoutFlags="All">
-                <Frame x:Name="ProgressDialogFrame" Style="{StaticResource DialogFrameStyle}" HorizontalOptions="Center" VerticalOptions="Center" WidthRequest="280" Padding="20">
+                <Frame x:Name="ProgressDialogFrame" Style="{StaticResource DialogFrameStyle}">
                     <StackLayout Orientation="Vertical">
                         <Label x:Name="ProgressDialogTitle" HorizontalOptions="Center" FontAttributes="Bold" FontSize="Large"/>
                         <Label x:Name="ProgressDialogMessage" HorizontalOptions="Center"/>
@@ -101,7 +101,7 @@
                         <Label x:Name="GameControllerEventDialogTitle" HorizontalOptions="Center" FontAttributes="Bold" FontSize="Large"/>
                         <Label x:Name="GameControllerEventDialogMessage" HorizontalOptions="Center"/>
                         <BoxView Style="{StaticResource DividerBoxViewStyle}" Margin="0,16,0,16"/>
-                        <Button x:Name="GameControllerEventDialogCancelButton" BackgroundColor="{DynamicResource NegativeColor}"/>
+                        <Button x:Name="GameControllerEventDialogCancelButton" BackgroundColor="{DynamicResource NegativeColor}" Margin="16,0,16,0"/>
                     </StackLayout>
                 </Frame>
             </ContentView>

--- a/BrickController2/BrickController2/UI/Controls/Dialogs.xaml
+++ b/BrickController2/BrickController2/UI/Controls/Dialogs.xaml
@@ -61,19 +61,19 @@
 
             <!-- Selection dialog -->
             <ContentView x:Name="SelectionDialog" IsVisible="false" AbsoluteLayout.LayoutBounds="0, 0, 1, 1" AbsoluteLayout.LayoutFlags="All">
-                <Frame x:Name="SelectionDialogFrame" Style="{StaticResource DialogFrameStyle}" HorizontalOptions="Center" VerticalOptions="Start" WidthRequest="280" Margin="0,50,0,50" Padding="20">
+                <Frame x:Name="SelectionDialogFrame" Style="{StaticResource DialogFrameStyle}" HorizontalOptions="Center" VerticalOptions="Start" WidthRequest="{OnIdiom 280, Desktop=360}" Margin="0,50,0,50" Padding="20">
                     <StackLayout Orientation="Vertical">
                         <Label x:Name="SelectionDialogTitle" HorizontalOptions="Center" FontAttributes="Bold" FontSize="Large"/>
                         <BoxView Style="{StaticResource DividerBoxViewStyle}" Margin="0,8,0,8"/>
                         <CollectionView x:Name="SelectionDialogItems" SelectionMode="Single" VerticalOptions="FillAndExpand">
                             <CollectionView.ItemTemplate>
                                 <DataTemplate>
-                                    <Label Text="{Binding}" FontSize="Large" FontAttributes="Bold" Margin="0,4"/>
+                                    <Label Text="{Binding}" FontSize="{OnIdiom Large, Desktop=Medium}" FontAttributes="Bold" Margin="0,4"/>
                                 </DataTemplate>
                             </CollectionView.ItemTemplate>
                         </CollectionView>
                         <BoxView Style="{StaticResource DividerBoxViewStyle}" Margin="0,16,0,16"/>
-                        <Button x:Name="SelectionDialogCancelButton" BackgroundColor="{DynamicResource NegativeColor}"/>
+                        <Button x:Name="SelectionDialogCancelButton" BackgroundColor="{DynamicResource NegativeColor}" Margin="{OnIdiom '16,0,16,0', Desktop='96,0,96,0'}"/>
                     </StackLayout>
                 </Frame>
             </ContentView>


### PR DESCRIPTION
Adjusted styling of `SelectionDialog` based on the feedback from #65:
- the dialog is wider
- font size of items has been decreased to `Medium`

![image](https://github.com/user-attachments/assets/fb51f2e6-692c-461c-a39a-a4b7ee6ba48c)
 