### PR TITLE
Add quick actions for a profile: Copy, Play

### DIFF
--- a/BrickController2/BrickController2/Resources/TranslationResources.de.resx
+++ b/BrickController2/BrickController2/Resources/TranslationResources.de.resx
@@ -250,7 +250,7 @@
     <value>Die Kreation in die Zwischenablage kopieren </value>
   </data>
   <data name="CopySequence" xml:space="preserve">
-    <value>Die Sequenz in die Zwischenablage kopieren </value>
+    <value>Die Sequenz in die Zwischenablage kopieren</value>
   </data>
   <data name="Create" xml:space="preserve">
     <value>Erstellen</value>
@@ -602,5 +602,8 @@
   </data>
   <data name="OpenChannelSetup" xml:space="preserve">
     <value>Einrichtung des Kanals</value>
+  </data>
+  <data name="Copy" xml:space="preserve">
+    <value>Kopieren</value>
   </data>
 </root>

--- a/BrickController2/BrickController2/Resources/TranslationResources.resx
+++ b/BrickController2/BrickController2/Resources/TranslationResources.resx
@@ -603,4 +603,7 @@
   <data name="OpenChannelSetup" xml:space="preserve">
     <value>Setup the channel</value>
   </data>
+  <data name="Copy" xml:space="preserve">
+    <value>Copy</value>
+  </data>
 </root>

--- a/BrickController2/BrickController2/UI/Pages/CreationPage.xaml
+++ b/BrickController2/BrickController2/UI/Pages/CreationPage.xaml
@@ -50,10 +50,10 @@
                                 </SwipeView.LeftItems>
                                 <SwipeView.RightItems>
                                     <SwipeItems Mode="Reveal">
+                                        <controls:SwipeIcon Text="{extensions:Translate Play}" Icon="play_arrow" BackgroundColor="{DynamicResource SwipeItemBackgroundColor}" IsVisible="{Binding BindingContext.HasMultipleControllerProfiles, Source={x:Reference Page}}"
+                                                            Command="{Binding BindingContext.PlayControllerProfileCommand, Source={x:Reference Page}}" CommandParameter="{Binding .}"/>
                                         <controls:SwipeIcon Text="{extensions:Translate Copy}" Icon="copy" BackgroundColor="{DynamicResource SwipeItemBackgroundColor}"
                                                             Command="{Binding BindingContext.CopyControllerProfileCommand, Source={x:Reference Page}}" CommandParameter="{Binding .}"/>
-                                        <controls:SwipeIcon Text="{extensions:Translate Play}" Icon="play_arrow" BackgroundColor="{DynamicResource SwipeItemBackgroundColor}"
-                                                            Command="{Binding BindingContext.PlayControllerProfileCommand, Source={x:Reference Page}}" CommandParameter="{Binding .}"/>
                                     </SwipeItems>
                                 </SwipeView.RightItems>
                                 <VerticalStackLayout>

--- a/BrickController2/BrickController2/UI/Pages/CreationPage.xaml
+++ b/BrickController2/BrickController2/UI/Pages/CreationPage.xaml
@@ -48,6 +48,14 @@
                                         <controls:SwipeIcon Text="{extensions:Translate Delete}" Icon="cancel"  BackgroundColor="{DynamicResource DeleteSwipeItemBackgroundColor}" Command="{Binding BindingContext.DeleteControllerProfileCommand, Source={x:Reference Page}}" CommandParameter="{Binding .}"/>
                                     </SwipeItems>
                                 </SwipeView.LeftItems>
+                                <SwipeView.RightItems>
+                                    <SwipeItems Mode="Reveal">
+                                        <controls:SwipeIcon Text="{extensions:Translate Copy}" Icon="copy" BackgroundColor="{DynamicResource SwipeItemBackgroundColor}"
+                                                            Command="{Binding BindingContext.CopyControllerProfileCommand, Source={x:Reference Page}}" CommandParameter="{Binding .}"/>
+                                        <controls:SwipeIcon Text="{extensions:Translate Play}" Icon="play_arrow" BackgroundColor="{DynamicResource SwipeItemBackgroundColor}"
+                                                            Command="{Binding BindingContext.PlayControllerProfileCommand, Source={x:Reference Page}}" CommandParameter="{Binding .}"/>
+                                    </SwipeItems>
+                                </SwipeView.RightItems>
                                 <VerticalStackLayout>
                                     <Grid Style="{StaticResource CollectionItemGridStyle}">
                                         <Grid.GestureRecognizers>

--- a/BrickController2/BrickController2/UI/ViewModels/ControllerProfilePageViewModel.cs
+++ b/BrickController2/BrickController2/UI/ViewModels/ControllerProfilePageViewModel.cs
@@ -263,7 +263,9 @@ namespace BrickController2.UI.ViewModels
 
             if (validationResult == CreationValidationResult.Ok)
             {
-                await NavigationService.NavigateToAsync<PlayerPageViewModel>(new NavigationParameters(("creation", ControllerProfile.Creation!)));
+                await NavigationService.NavigateToAsync<PlayerPageViewModel>(new NavigationParameters(
+                  ("creation", ControllerProfile.Creation!),
+                  ("profile", ControllerProfile)));
             }
             else
             {

--- a/BrickController2/BrickController2/UI/ViewModels/CreationPageViewModel.cs
+++ b/BrickController2/BrickController2/UI/ViewModels/CreationPageViewModel.cs
@@ -46,6 +46,7 @@ namespace BrickController2.UI.ViewModels
             Creation = parameters.Get<Creation>("creation");
 
             ImportControllerProfileCommand = new SafeCommand(async () => await ImportControllerProfileAsync(), () => SharedFileStorageService.IsSharedStorageAvailable);
+            CopyControllerProfileCommand = new SafeCommand<ControllerProfile>(profile => _sharingManagerProfile.ShareToClipboardAsync(profile));
             PasteControllerProfileCommand = new SafeCommand(PasteControllerProfileAsync);
             ExportCreationCommand = new SafeCommand(async () => await ExportCreationAsync(), () => SharedFileStorageService.IsSharedStorageAvailable);
             CopyCreationCommand = new SafeCommand(CopyCreationAsync);
@@ -55,12 +56,14 @@ namespace BrickController2.UI.ViewModels
             AddControllerProfileCommand = new SafeCommand(async () => await AddControllerProfileAsync());
             ControllerProfileTappedCommand = new SafeCommand<ControllerProfile>(async controllerProfile => await NavigationService.NavigateToAsync<ControllerProfilePageViewModel>(new NavigationParameters(("controllerprofile", controllerProfile))));
             DeleteControllerProfileCommand = new SafeCommand<ControllerProfile>(async controllerProfile => await DeleteControllerProfileAsync(controllerProfile));
+            PlayControllerProfileCommand = new SafeCommand<ControllerProfile>(PlayAsync);
         }
 
         public Creation Creation { get; }
 
         public ISharedFileStorageService SharedFileStorageService { get; }
         public ICommand ImportControllerProfileCommand { get; }
+        public ICommand CopyControllerProfileCommand { get; }
         public ICommand PasteControllerProfileCommand { get; }
         public ICommand ExportCreationCommand { get; }
         public ICommand CopyCreationCommand { get; }
@@ -70,6 +73,7 @@ namespace BrickController2.UI.ViewModels
         public ICommand AddControllerProfileCommand { get; }
         public ICommand ControllerProfileTappedCommand { get; }
         public ICommand DeleteControllerProfileCommand { get; }
+        public ICommand PlayControllerProfileCommand { get; }
 
         public override void OnAppearing()
         {
@@ -118,7 +122,7 @@ namespace BrickController2.UI.ViewModels
             }
         }
 
-        private async Task PlayAsync()
+        private async Task PlayAsync(ControllerProfile? controllerProfile = default!)
         {
             try
             {
@@ -142,7 +146,9 @@ namespace BrickController2.UI.ViewModels
 
                 if (validationResult == CreationValidationResult.Ok)
                 {
-                    await NavigationService.NavigateToAsync<PlayerPageViewModel>(new NavigationParameters(("creation", Creation)));
+                    await NavigationService.NavigateToAsync<PlayerPageViewModel>(new NavigationParameters(
+                        ("creation", Creation),
+                        ("profile", controllerProfile!)));
                 }
                 else
                 {

--- a/BrickController2/BrickController2/UI/ViewModels/CreationPageViewModel.cs
+++ b/BrickController2/BrickController2/UI/ViewModels/CreationPageViewModel.cs
@@ -61,6 +61,8 @@ namespace BrickController2.UI.ViewModels
 
         public Creation Creation { get; }
 
+        public bool HasMultipleControllerProfiles => Creation.ControllerProfiles.Count > 1;
+
         public ISharedFileStorageService SharedFileStorageService { get; }
         public ICommand ImportControllerProfileCommand { get; }
         public ICommand CopyControllerProfileCommand { get; }
@@ -196,6 +198,8 @@ namespace BrickController2.UI.ViewModels
                         async (progressDialog, token) => controllerProfile = await _creationManager.AddControllerProfileAsync(Creation, result.Result),
                         Translate("Creating"),
                         token: _disappearingTokenSource?.Token ?? default);
+                    // notify profile count change
+                    RaisePropertyChanged(nameof(HasMultipleControllerProfiles));
 
                     await NavigationService.NavigateToAsync<ControllerProfilePageViewModel>(new NavigationParameters(("controllerprofile", controllerProfile!)));
                 }
@@ -221,6 +225,8 @@ namespace BrickController2.UI.ViewModels
                         async (progressDialog, token) => await _creationManager.DeleteControllerProfileAsync(controllerProfile),
                         Translate("Deleting"),
                         token: _disappearingTokenSource?.Token ?? default);
+                    // notify profile count change
+                    RaisePropertyChanged(nameof(HasMultipleControllerProfiles));
                 }
             }
             catch (OperationCanceledException)

--- a/BrickController2/BrickController2/UI/ViewModels/PlayerPageViewModel.cs
+++ b/BrickController2/BrickController2/UI/ViewModels/PlayerPageViewModel.cs
@@ -46,7 +46,8 @@ namespace BrickController2.UI.ViewModels
             _playLogic = playLogic;
 
             Creation = parameters.Get<Creation>("creation");
-            ActiveProfile = Creation.ControllerProfiles.First();
+            // apply choosen profile (if present) or the first one 
+            ActiveProfile = parameters.Get("profile", Creation.ControllerProfiles.First());
 
             CollectDevices();
 


### PR DESCRIPTION
Added swipe items to improve user experience:
- copy to clipboard so as a user can easily share / create a clone
- play of the dedicated profile (so as a profile can be started imediately without necessity to choose it from the list)