### PR TITLE
Prevent the app from screen locking / switching off for Play page only

### DIFF
--- a/BrickController2/BrickController2.Android/MainActivity.cs
+++ b/BrickController2/BrickController2.Android/MainActivity.cs
@@ -1,6 +1,5 @@
 ﻿using Android.App;
 using Android.Content.PM;
-using Android.OS;
 using Android.Runtime;
 using Android.Views;
 using Microsoft.Extensions.DependencyInjection;
@@ -23,18 +22,11 @@ namespace BrickController2.Droid
             ConfigChanges.SmallestScreenSize)]
     public class MainActivity : MauiAppCompatActivity
     {
-        private GameControllerService _gameControllerService;
+        private readonly GameControllerService _gameControllerService;
 
         public MainActivity()
         {
             _gameControllerService = IPlatformApplication.Current!.Services.GetRequiredService<GameControllerService>()!;
-        }
-
-        protected override void OnCreate(Bundle? bundle)
-        {
-            base.OnCreate(bundle);
-
-            Window!.AddFlags(WindowManagerFlags.KeepScreenOn);
         }
 
         public override bool OnKeyDown([GeneratedEnum] global::Android.Views.Keycode keyCode, KeyEvent? e)

--- a/BrickController2/BrickController2/UI/ViewModels/PlayerPageViewModel.cs
+++ b/BrickController2/BrickController2/UI/ViewModels/PlayerPageViewModel.cs
@@ -101,7 +101,7 @@ namespace BrickController2.UI.ViewModels
 
             _gameControllerService.GameControllerEvent -= GameControllerEventHandler!;
 
-            _playLogic.StopPlay();
+            StopPlay();
 
             if (_connectionTokenSource != null && _connectionTask != null)
             {
@@ -142,7 +142,7 @@ namespace BrickController2.UI.ViewModels
                 var deviceToConnectTo = GetNextDeviceToConnectTo();
                 if (deviceToConnectTo != null)
                 {
-                    _playLogic.StopPlay();
+                    StopPlay();
 
                     var connectionResult = DeviceConnectionResult.Ok;
 
@@ -220,7 +220,7 @@ namespace BrickController2.UI.ViewModels
                             ChangeOutputLevel(BuWizzOutputLevel, _buwizzDevices);
                             ChangeOutputLevel(BuWizz2OutputLevel, _buwizz2Devices);
 
-                            _playLogic.StartPlay();
+                            StartPlay();
                         }
                     }
                 }
@@ -229,6 +229,19 @@ namespace BrickController2.UI.ViewModels
                     await Task.Delay(50);
                 }
             }
+        }
+        private void StartPlay()
+        {
+            // prevent the app from locking/ turningoff the screen
+            Microsoft.Maui.Devices.DeviceDisplay.KeepScreenOn = true;
+            _playLogic.StartPlay();
+        }
+
+        private void StopPlay()
+        {
+            _playLogic.StopPlay();
+            // reenable screen locking 
+            Microsoft.Maui.Devices.DeviceDisplay.KeepScreenOn = false;
         }
 
         private Device? GetNextDeviceToConnectTo()

--- a/BrickController2/BrickController2/UI/ViewModels/PlayerPageViewModel.cs
+++ b/BrickController2/BrickController2/UI/ViewModels/PlayerPageViewModel.cs
@@ -232,7 +232,7 @@ namespace BrickController2.UI.ViewModels
         }
         private void StartPlay()
         {
-            // prevent the app from locking/ turningoff the screen
+            // prevent the app from locking/turning off the screen
             Microsoft.Maui.Devices.DeviceDisplay.KeepScreenOn = true;
             _playLogic.StartPlay();
         }
@@ -240,7 +240,7 @@ namespace BrickController2.UI.ViewModels
         private void StopPlay()
         {
             _playLogic.StopPlay();
-            // reenable screen locking 
+            // reenable screen locking/turning off 
             Microsoft.Maui.Devices.DeviceDisplay.KeepScreenOn = false;
         }
 


### PR DESCRIPTION
Minor improvement in order to allow the app to lock / switch off the screen is there is no creation being played at the moment.

Resolves #72 