### PR TITLE
Add command to activate BuWizz3 shelf mode

### DIFF
--- a/BrickController2/BrickController2/DeviceManagement/BuWizz2Device.cs
+++ b/BrickController2/BrickController2/DeviceManagement/BuWizz2Device.cs
@@ -6,6 +6,8 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
+using static BrickController2.Protocols.BuWizzProtocol;
+
 namespace BrickController2.DeviceManagement
 {
     internal class BuWizz2Device : BluetoothDevice
@@ -78,6 +80,14 @@ namespace BrickController2.DeviceManagement
         }
 
         public override bool CanBePowerSource => true;
+
+        public override bool CanActivateShelfMode => true;
+
+        public override async Task ActiveShelfModeAsync(CancellationToken token = default)
+        {
+            var activateShelfModeCmd = ActivteShelfMode();
+            await _bleDevice!.WriteAsync(_characteristic!, activateShelfModeCmd, token);
+        }
 
         protected override async Task<bool> ValidateServicesAsync(IEnumerable<IGattService>? services, CancellationToken token)
         {

--- a/BrickController2/BrickController2/DeviceManagement/BuWizz2Device.cs
+++ b/BrickController2/BrickController2/DeviceManagement/BuWizz2Device.cs
@@ -6,8 +6,6 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
-using static BrickController2.Protocols.BuWizzProtocol;
-
 namespace BrickController2.DeviceManagement
 {
     internal class BuWizz2Device : BluetoothDevice

--- a/BrickController2/BrickController2/DeviceManagement/BuWizz2Device.cs
+++ b/BrickController2/BrickController2/DeviceManagement/BuWizz2Device.cs
@@ -81,14 +81,6 @@ namespace BrickController2.DeviceManagement
 
         public override bool CanBePowerSource => true;
 
-        public override bool CanActivateShelfMode => true;
-
-        public override async Task ActiveShelfModeAsync(CancellationToken token = default)
-        {
-            var activateShelfModeCmd = ActivteShelfMode();
-            await _bleDevice!.WriteAsync(_characteristic!, activateShelfModeCmd, token);
-        }
-
         protected override async Task<bool> ValidateServicesAsync(IEnumerable<IGattService>? services, CancellationToken token)
         {
             var service = services?.FirstOrDefault(s => s.Uuid == SERVICE_UUID);

--- a/BrickController2/BrickController2/DeviceManagement/BuWizz3Device.cs
+++ b/BrickController2/BrickController2/DeviceManagement/BuWizz3Device.cs
@@ -130,7 +130,7 @@ namespace BrickController2.DeviceManagement
         public override async Task ActiveShelfModeAsync(CancellationToken token = default)
         {
             var activateShelfModeCmd = ActivteShelfMode();
-            await _bleDevice!.WriteAsync(_characteristic!, activateShelfModeCmd, token);
+            await _bleDevice!.WriteNoResponseAsync(_characteristic!, activateShelfModeCmd, token);
         }
 
         public override bool CanResetOutput(int channel) => channel < NUMBER_OF_PU_PORTS;

--- a/BrickController2/BrickController2/DeviceManagement/BuWizz3Device.cs
+++ b/BrickController2/BrickController2/DeviceManagement/BuWizz3Device.cs
@@ -151,6 +151,14 @@ namespace BrickController2.DeviceManagement
             return await AutoCalibrateServoAsync(channel, token).ConfigureAwait(false);
         }
 
+        public async Task ActiveShelfModeAsync(CancellationToken token = default)
+        {
+            var activateShelfModeCmd = new byte[] { 0xA1 };
+
+            await _bleDevice!.WriteAsync(_characteristic!, activateShelfModeCmd, token);
+            await Task.Delay(50, token);
+        }
+
         protected override Task<bool> ValidateServicesAsync(IEnumerable<IGattService>? services, CancellationToken token)
         {
             var service = services?.FirstOrDefault(s => s.Uuid == SERVICE_UUID);

--- a/BrickController2/BrickController2/DeviceManagement/BuWizz3Device.cs
+++ b/BrickController2/BrickController2/DeviceManagement/BuWizz3Device.cs
@@ -7,6 +7,8 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
+using static BrickController2.Protocols.BuWizzProtocol;
+
 namespace BrickController2.DeviceManagement
 {
     internal class BuWizz3Device : BluetoothDevice
@@ -123,6 +125,14 @@ namespace BrickController2.DeviceManagement
 
         public override bool CanBePowerSource => false;
 
+        public override bool CanActivateShelfMode => true;
+
+        public override async Task ActiveShelfModeAsync(CancellationToken token = default)
+        {
+            var activateShelfModeCmd = ActivteShelfMode();
+            await _bleDevice!.WriteAsync(_characteristic!, activateShelfModeCmd, token);
+        }
+
         public override bool CanResetOutput(int channel) => channel < NUMBER_OF_PU_PORTS;
 
         public override async Task ResetOutputAsync(int channel, float value, CancellationToken token)
@@ -149,14 +159,6 @@ namespace BrickController2.DeviceManagement
             }
 
             return await AutoCalibrateServoAsync(channel, token).ConfigureAwait(false);
-        }
-
-        public async Task ActiveShelfModeAsync(CancellationToken token = default)
-        {
-            var activateShelfModeCmd = new byte[] { 0xA1 };
-
-            await _bleDevice!.WriteAsync(_characteristic!, activateShelfModeCmd, token);
-            await Task.Delay(50, token);
         }
 
         protected override Task<bool> ValidateServicesAsync(IEnumerable<IGattService>? services, CancellationToken token)

--- a/BrickController2/BrickController2/DeviceManagement/Device.cs
+++ b/BrickController2/BrickController2/DeviceManagement/Device.cs
@@ -102,6 +102,11 @@ namespace BrickController2.DeviceManagement
 
         public virtual bool CanBePowerSource => false;
 
+        public virtual bool CanActivateShelfMode => false;
+
+        public virtual Task ActiveShelfModeAsync(CancellationToken token = default)
+            => throw new InvalidOperationException("Shelf mode is not supported for this type of device.");
+
         public async Task RenameDeviceAsync(Device device, string newName)
         {
             using (await _asyncLock.LockAsync())

--- a/BrickController2/BrickController2/Protocols/BuWizzProtocol.cs
+++ b/BrickController2/BrickController2/Protocols/BuWizzProtocol.cs
@@ -1,0 +1,6 @@
+﻿namespace BrickController2.Protocols;
+
+internal static class BuWizzProtocol
+{
+    public static byte[] ActivteShelfMode() => [ 0xA1 ];
+}

--- a/BrickController2/BrickController2/Resources/TranslationResources.de.resx
+++ b/BrickController2/BrickController2/Resources/TranslationResources.de.resx
@@ -637,6 +637,6 @@
     <value>Die Aktivierung des Regalmodus ist fehlgeschlagen:</value>
   </data>
   <data name="ActivateShelfModeConfirm" xml:space="preserve">
-    <value>Sind Sie sicher, dass Sie den Regalmodus für dieses BuWizz3-Gerät aktivieren möchten?</value>
+    <value>Sind Sie sicher, dass Sie den Regalmodus für dieses BuWizz3-Gerät aktivieren möchten? Dadurch wird der Akku vom Gerät getrennt und der Benutzer muss das Ladegerät anschließen, um das Gerät aufzuwecken.</value>
   </data>
 </root>

--- a/BrickController2/BrickController2/Resources/TranslationResources.de.resx
+++ b/BrickController2/BrickController2/Resources/TranslationResources.de.resx
@@ -639,4 +639,7 @@
   <data name="ActivateShelfModeConfirm" xml:space="preserve">
     <value>Sind Sie sicher, dass Sie den Regalmodus für dieses BuWizz3-Gerät aktivieren möchten? Dadurch wird der Akku vom Gerät getrennt und der Benutzer muss das Ladegerät anschließen, um das Gerät aufzuwecken.</value>
   </data>
+  <data name="Applying" xml:space="preserve">
+    <value>Bewerben...</value>
+  </data>
 </root>

--- a/BrickController2/BrickController2/Resources/TranslationResources.de.resx
+++ b/BrickController2/BrickController2/Resources/TranslationResources.de.resx
@@ -609,4 +609,13 @@
   <data name="Add" xml:space="preserve">
     <value>Hinzufügen</value>
   </data>
+  <data name="ActivateShelfMode" xml:space="preserve">
+    <value>Den Regalmodus aktivieren</value>
+  </data>
+  <data name="ActivateShelfModeFailed" xml:space="preserve">
+    <value>Die Aktivierung des Regalmodus ist fehlgeschlagen:</value>
+  </data>
+  <data name="ActivateShelfModeConfirm" xml:space="preserve">
+    <value>Sind Sie sicher, dass Sie den Regalmodus für dieses BuWizz3-Gerät aktivieren möchten?</value>
+  </data>
 </root>

--- a/BrickController2/BrickController2/Resources/TranslationResources.resx
+++ b/BrickController2/BrickController2/Resources/TranslationResources.resx
@@ -609,4 +609,13 @@
   <data name="Add" xml:space="preserve">
     <value>Add</value>
   </data>
+  <data name="ActivateShelfMode" xml:space="preserve">
+    <value>Activate shelf mode</value>
+  </data>
+  <data name="ActivateShelfModeFailed" xml:space="preserve">
+    <value>Activation of the shelf mode has failed:</value>
+  </data>
+  <data name="ActivateShelfModeConfirm" xml:space="preserve">
+    <value>Are you sure you want to active the shelf mode for this BuWizz3 device?</value>
+  </data>
 </root>

--- a/BrickController2/BrickController2/Resources/TranslationResources.resx
+++ b/BrickController2/BrickController2/Resources/TranslationResources.resx
@@ -637,6 +637,9 @@
     <value>Activation of the shelf mode has failed:</value>
   </data>
   <data name="ActivateShelfModeConfirm" xml:space="preserve">
-    <value>Are you sure you want to active the shelf mode for this BuWizz device? This will disconnect the battery from the device and will require the user to connect the charger in order to wake-up the device.</value>
+    <value>Are you sure you want to active the shelf mode for this BuWizz device? This will disconnect the battery from the device and typically requires the user to connect the charger in order to wake-up the device.</value>
+  </data>
+  <data name="Applying" xml:space="preserve">
+    <value>Applying...</value>
   </data>
 </root>

--- a/BrickController2/BrickController2/Resources/TranslationResources.resx
+++ b/BrickController2/BrickController2/Resources/TranslationResources.resx
@@ -637,6 +637,6 @@
     <value>Activation of the shelf mode has failed:</value>
   </data>
   <data name="ActivateShelfModeConfirm" xml:space="preserve">
-    <value>Are you sure you want to active the shelf mode for this BuWizz3 device?</value>
+    <value>Are you sure you want to active the shelf mode for this BuWizz device? This will disconnect the battery from the device and will require the user to connect the charger in order to wake-up the device.</value>
   </data>
 </root>

--- a/BrickController2/BrickController2/UI/Pages/DevicePage.xaml
+++ b/BrickController2/BrickController2/UI/Pages/DevicePage.xaml
@@ -20,6 +20,10 @@
             <converters:DeviceDisconnectedToBoolConverter x:Key="DeviceDisconnectedToBool"/>
         </ResourceDictionary>
     </local:PageBase.Resources>
+    
+    <ContentPage.ToolbarItems>
+        <controls:ToolbarIcon Icon="mode_standby" Text="{extensions:Translate ActivateShelfMode}" Command="{Binding ActivateShelfModeCommand}" />
+    </ContentPage.ToolbarItems>
 
     <local:PageBase.Content>
         <AbsoluteLayout HorizontalOptions="FillAndExpand" VerticalOptions="FillAndExpand">

--- a/BrickController2/BrickController2/UI/ViewModels/DevicePageViewModel.cs
+++ b/BrickController2/BrickController2/UI/ViewModels/DevicePageViewModel.cs
@@ -46,6 +46,8 @@ namespace BrickController2.UI.ViewModels
             RenameCommand = new SafeCommand(async () => await RenameDeviceAsync());
             BuWizzOutputLevelChangedCommand = new SafeCommand<int>(outputLevel => SetBuWizzOutputLevel(outputLevel));
             BuWizz2OutputLevelChangedCommand = new SafeCommand<int>(outputLevel => SetBuWizzOutputLevel(outputLevel));
+            ActivateShelfModeCommand = new SafeCommand(ActivateBuWizz3ShelfModeCommand,
+                () => Device.DeviceState == DeviceState.Connected && Device.DeviceType == DeviceType.BuWizz3);
             ScanCommand = new SafeCommand(ScanAsync, () => CanExecuteScan);
         }
 
@@ -60,6 +62,7 @@ namespace BrickController2.UI.ViewModels
         public ICommand RenameCommand { get; }
         public ICommand BuWizzOutputLevelChangedCommand { get; }
         public ICommand BuWizz2OutputLevelChangedCommand { get; }
+        public ICommand ActivateShelfModeCommand { get; }
         public ICommand ScanCommand { get; }
 
         public int BuWizzOutputLevel { get; set; } = 1;
@@ -212,12 +215,38 @@ namespace BrickController2.UI.ViewModels
                             }
                             // update command enablement
                             ScanCommand.RaiseCanExecuteChanged();
+                            ActivateShelfModeCommand.RaiseCanExecuteChanged();
                         }
                     }
                 }
                 else
                 {
                     await Task.Delay(50);
+                }
+            }
+        }
+
+        private async Task ActivateBuWizz3ShelfModeCommand()
+        {
+            if (await _dialogService.ShowQuestionDialogAsync(
+                Translate("ActivateShelfMode"),
+                Translate("ActivateShelfModeConfirm"),
+                Translate("Yes"),
+                Translate("No"),
+                _disappearingTokenSource?.Token ?? default))
+            {
+                try
+                {
+                    var buwizz = (BuWizz3Device)Device;
+                    await buwizz.ActiveShelfModeAsync();
+                }
+                catch (Exception ex)
+                {
+                    await _dialogService.ShowMessageBoxAsync(
+                        Translate("Warning"),
+                        Translate("ActivateShelfModeFailed", ex),
+                        Translate("Ok"),
+                        CancellationToken.None);
                 }
             }
         }
@@ -284,6 +313,9 @@ namespace BrickController2.UI.ViewModels
 
         private void OnDeviceDisconnected(Device device)
         {
+            // update command enablement
+            ScanCommand.RaiseCanExecuteChanged();
+            ActivateShelfModeCommand.RaiseCanExecuteChanged();
         }
 
         private void SetBuWizzOutputLevel(int level)

--- a/BrickController2/BrickController2/UI/ViewModels/DevicePageViewModel.cs
+++ b/BrickController2/BrickController2/UI/ViewModels/DevicePageViewModel.cs
@@ -236,6 +236,7 @@ namespace BrickController2.UI.ViewModels
                 {
                     var buwizz = (BuWizz3Device)Device;
                     await buwizz.ActiveShelfModeAsync();
+                    await buwizz.DisconnectAsync();
                 }
                 catch (Exception ex)
                 {

--- a/BrickController2/BrickController2/UI/ViewModels/DevicePageViewModel.cs
+++ b/BrickController2/BrickController2/UI/ViewModels/DevicePageViewModel.cs
@@ -234,13 +234,19 @@ namespace BrickController2.UI.ViewModels
             {
                 try
                 {
-                    // send command
-                    await Device.ActiveShelfModeAsync();
-                    // cancel connection
-                    _connectionTokenSource?.Cancel();
-                    // perform disconnection
-                    await Task.Delay(100);
-                    await Device.DisconnectAsync();
+                    await _dialogService.ShowProgressDialogAsync(
+                        false,
+                        async (progressDialog, token) =>
+                        {
+                            // send command and later cancel connection
+                            await Device.ActiveShelfModeAsync();
+                            _connectionTokenSource?.Cancel();
+                            // disconnection is expected to be triggered by Back
+                            await Task.Delay(500, DisappearingToken);
+                            await NavigationService.NavigateBackAsync();
+                        },
+                        Translate("Applying"),
+                        token: DisappearingToken);
                 }
                 catch (Exception ex)
                 {
@@ -248,7 +254,7 @@ namespace BrickController2.UI.ViewModels
                         Translate("Warning"),
                         Translate("ActivateShelfModeFailed", ex),
                         Translate("Ok"),
-                        CancellationToken.None);
+                        DisappearingToken);
                 }
             }
         }

--- a/BrickController2/BrickController2/UI/ViewModels/DevicePageViewModel.cs
+++ b/BrickController2/BrickController2/UI/ViewModels/DevicePageViewModel.cs
@@ -45,8 +45,8 @@ namespace BrickController2.UI.ViewModels
             RenameCommand = new SafeCommand(async () => await RenameDeviceAsync());
             BuWizzOutputLevelChangedCommand = new SafeCommand<int>(outputLevel => SetBuWizzOutputLevel(outputLevel));
             BuWizz2OutputLevelChangedCommand = new SafeCommand<int>(outputLevel => SetBuWizzOutputLevel(outputLevel));
-            ActivateShelfModeCommand = new SafeCommand(ActivateBuWizz3ShelfModeCommand,
-                () => Device.DeviceState == DeviceState.Connected && Device.DeviceType == DeviceType.BuWizz3);
+            ActivateShelfModeCommand = new SafeCommand(ActivateShelfModeCommandAsync,
+                () => Device.DeviceState == DeviceState.Connected && Device.CanActivateShelfMode);
             ScanCommand = new SafeCommand(ScanAsync, () => CanExecuteScan);
         }
 
@@ -223,7 +223,7 @@ namespace BrickController2.UI.ViewModels
             }
         }
 
-        private async Task ActivateBuWizz3ShelfModeCommand()
+        private async Task ActivateShelfModeCommandAsync()
         {
             if (await _dialogService.ShowQuestionDialogAsync(
                 Translate("ActivateShelfMode"),
@@ -234,9 +234,13 @@ namespace BrickController2.UI.ViewModels
             {
                 try
                 {
-                    var buwizz = (BuWizz3Device)Device;
-                    await buwizz.ActiveShelfModeAsync();
-                    await buwizz.DisconnectAsync();
+                    // send command
+                    await Device.ActiveShelfModeAsync();
+                    // cancel connection
+                    _connectionTokenSource?.Cancel();
+                    // perform disconnection
+                    await Task.Delay(100);
+                    await Device.DisconnectAsync();
                 }
                 catch (Exception ex)
                 {


### PR DESCRIPTION
This PR adds a new toolbar icon to enable activation of the shelf mode for BuWizz 3 devices.
![image](https://github.com/user-attachments/assets/cb3b705b-6bb3-45d1-aa32-6ae2f5f88810)

https://buwizz.com/BuWizz_3.0_API_3.6_web.pdf

>0xA1 Activate shelf mode
Activate the shelf mode in the device immediately. This will disconnect the battery from the device
and will require the user to connect the charger in order to wake-up the device. 