### PR TITLE
Add support for multiple gamecontrollers

### DIFF
--- a/BrickController2/BrickController2.Android/Extensions/InputDeviceExtensions.cs
+++ b/BrickController2/BrickController2.Android/Extensions/InputDeviceExtensions.cs
@@ -1,18 +1,17 @@
 ﻿using Android.Views;
-using BrickController2.Helpers;
 
 namespace BrickController2.Droid.Extensions;
 
 public static class InputDeviceExtensions
 {
     /// <summary>
-    /// Get an identifier string for the given inputdevice
+    /// Get an unique persistant identifier string for the given inputdevice
     /// </summary>
     /// <param name="inputDevice">inputdevice</param>
     /// <returns>deviceidentifier</returns>
-    public static string GetDeviceId(this InputDevice? inputDevice) =>
+    public static string GetUniquePersistentDeviceId(this InputDevice? inputDevice) =>
         // https://developer.android.com/develop/ui/views/touch-and-input/game-controllers/multiple-controllers
         // Note: On devices running Android 4.1(API level 16) and higher, you can obtain an input device’s descriptor using getDescriptor(), which returns a unique persistent
         // string value for the input device.Unlike a device ID, the descriptor value won't change even if the input device is disconnected, reconnected, or reconfigured. 
-        GameControllerHelper.GetControllerDeviceId(inputDevice?.ControllerNumber ?? -1);
+        inputDevice?.Descriptor ?? "NoDescriptor";
 }

--- a/BrickController2/BrickController2.Android/Extensions/InputDeviceExtensions.cs
+++ b/BrickController2/BrickController2.Android/Extensions/InputDeviceExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using Android.Views;
+using BrickController2.Helpers;
 
 namespace BrickController2.Droid.Extensions;
 
@@ -13,5 +14,5 @@ public static class InputDeviceExtensions
         // https://developer.android.com/develop/ui/views/touch-and-input/game-controllers/multiple-controllers
         // Note: On devices running Android 4.1(API level 16) and higher, you can obtain an input device’s descriptor using getDescriptor(), which returns a unique persistent
         // string value for the input device.Unlike a device ID, the descriptor value won't change even if the input device is disconnected, reconnected, or reconfigured. 
-        $"{inputDevice?.ControllerNumber ?? -1}";
+        GameControllerHelper.GetControllerDeviceId(inputDevice?.ControllerNumber ?? -1);
 }

--- a/BrickController2/BrickController2.Android/Extensions/InputDeviceExtensions.cs
+++ b/BrickController2/BrickController2.Android/Extensions/InputDeviceExtensions.cs
@@ -1,0 +1,17 @@
+﻿using Android.Views;
+
+namespace BrickController2.Droid.Extensions;
+
+public static class InputDeviceExtensions
+{
+    /// <summary>
+    /// Get an identifier string for the given inputdevice
+    /// </summary>
+    /// <param name="inputDevice">inputdevice</param>
+    /// <returns>deviceidentifier</returns>
+    public static string GetDeviceId(this InputDevice? inputDevice) =>
+        // https://developer.android.com/develop/ui/views/touch-and-input/game-controllers/multiple-controllers
+        // Note: On devices running Android 4.1(API level 16) and higher, you can obtain an input device’s descriptor using getDescriptor(), which returns a unique persistent
+        // string value for the input device.Unlike a device ID, the descriptor value won't change even if the input device is disconnected, reconnected, or reconfigured. 
+        $"{inputDevice?.ControllerNumber ?? -1}";
+}

--- a/BrickController2/BrickController2.Android/MainActivity.cs
+++ b/BrickController2/BrickController2.Android/MainActivity.cs
@@ -2,6 +2,9 @@
 using Android.Content.PM;
 using Android.Runtime;
 using Android.Views;
+using Android.Hardware.Input;
+using Android.Content;
+using Android.OS;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Maui;
 using Microsoft.Maui.ApplicationModel;
@@ -20,13 +23,73 @@ namespace BrickController2.Droid
             ConfigChanges.UiMode | 
             ConfigChanges.ScreenLayout | 
             ConfigChanges.SmallestScreenSize)]
-    public class MainActivity : MauiAppCompatActivity
+    public class MainActivity : MauiAppCompatActivity, InputManager.IInputDeviceListener
     {
         private readonly GameControllerService _gameControllerService;
+        private InputManager? _inputManager;
 
         public MainActivity()
         {
             _gameControllerService = IPlatformApplication.Current!.Services.GetRequiredService<GameControllerService>()!;
+        }
+
+        protected override void OnCreate(Bundle? savedInstanceState)
+        {
+            base.OnCreate(savedInstanceState);
+
+            _inputManager = (InputManager?)GetSystemService(Context.InputService);
+
+            // JK: either register InputDeviceListener on Create/Destroy or Resume/Pause of MainActivity
+            // current decision: on Create/Destroy
+            _gameControllerService?.MainActivityOnCreate();
+            _inputManager?.RegisterInputDeviceListener(this, null);
+        }
+
+        protected override void OnDestroy()
+        {
+            // JK: OnDestroy was never called...
+
+            // JK: either register InputDeviceListener on Create/Destroy or Resume/Pause of MainActivity
+            // current decision: on Create/Destroy
+            _inputManager?.UnregisterInputDeviceListener(this);
+            _gameControllerService?.MainActivityOnDestroy();
+
+            base.OnDestroy();
+        }
+
+        protected override void OnResume()
+        {
+            base.OnResume();
+
+            // JK: either register InputDeviceListener on Create/Destroy or Resume/Pause of MainActivity
+            // current decision: on Create/Destroy
+            //_inputManager?.RegisterInputDeviceListener(this, null);
+            _gameControllerService?.MainActivityOnResume();
+        }
+
+        protected override void OnPause()
+        {
+            base.OnPause();
+
+            // JK: either register InputDeviceListener on Create/Destroy or Resume/Pause of MainActivity
+            // current decision: on Create/Destroy
+            //_inputManager?.UnregisterInputDeviceListener(this);
+            _gameControllerService?.MainActivityOnPause();
+        }
+
+        public void OnInputDeviceAdded(int deviceId)
+        {
+            _gameControllerService?.MainActivityOnInputDeviceAdded(deviceId);
+        }
+
+        public void OnInputDeviceRemoved(int deviceId)
+        {
+            _gameControllerService?.MainActivityOnInputDeviceRemoved(deviceId);
+        }
+
+        public void OnInputDeviceChanged(int deviceId)
+        {
+            _gameControllerService?.MainActivityOnInputDeviceChanged(deviceId);
         }
 
         public override bool OnKeyDown([GeneratedEnum] global::Android.Views.Keycode keyCode, KeyEvent? e)

--- a/BrickController2/BrickController2.Android/MainActivity.cs
+++ b/BrickController2/BrickController2.Android/MainActivity.cs
@@ -39,42 +39,15 @@ namespace BrickController2.Droid
 
             _inputManager = (InputManager?)GetSystemService(Context.InputService);
 
-            // JK: either register InputDeviceListener on Create/Destroy or Resume/Pause of MainActivity
-            // current decision: on Create/Destroy
             _gameControllerService?.MainActivityOnCreate();
             _inputManager?.RegisterInputDeviceListener(this, null);
         }
 
         protected override void OnDestroy()
         {
-            // JK: OnDestroy was never called...
-
-            // JK: either register InputDeviceListener on Create/Destroy or Resume/Pause of MainActivity
-            // current decision: on Create/Destroy
             _inputManager?.UnregisterInputDeviceListener(this);
-            _gameControllerService?.MainActivityOnDestroy();
 
             base.OnDestroy();
-        }
-
-        protected override void OnResume()
-        {
-            base.OnResume();
-
-            // JK: either register InputDeviceListener on Create/Destroy or Resume/Pause of MainActivity
-            // current decision: on Create/Destroy
-            //_inputManager?.RegisterInputDeviceListener(this, null);
-            _gameControllerService?.MainActivityOnResume();
-        }
-
-        protected override void OnPause()
-        {
-            base.OnPause();
-
-            // JK: either register InputDeviceListener on Create/Destroy or Resume/Pause of MainActivity
-            // current decision: on Create/Destroy
-            //_inputManager?.UnregisterInputDeviceListener(this);
-            _gameControllerService?.MainActivityOnPause();
         }
 
         public void OnInputDeviceAdded(int deviceId)

--- a/BrickController2/BrickController2.Android/PlatformServices/GameController/GameControllerService.cs
+++ b/BrickController2/BrickController2.Android/PlatformServices/GameController/GameControllerService.cs
@@ -18,6 +18,11 @@ namespace BrickController2.Droid.PlatformServices.GameController
 
         private event EventHandler<GameControllerEventArgs>? GameControllerEventInternal;
 
+        public GameControllerService(Context context)
+        {
+            _inputManager = (InputManager)context.GetSystemService(Context.InputService)!;
+        }
+
         public event EventHandler<GameControllerEventArgs> GameControllerEvent
         {
             add
@@ -42,10 +47,8 @@ namespace BrickController2.Droid.PlatformServices.GameController
             }
         }
 
-        public GameControllerService(Context context)
-        {
-            _inputManager = (InputManager)context.GetSystemService(Context.InputService)!;
-        }
+        public bool IsControllerIdSupported => true;
+
 
         /// <summary>
         /// Handler called from MainActivity when MainActivity is created

--- a/BrickController2/BrickController2.Android/PlatformServices/GameController/GameControllerService.cs
+++ b/BrickController2/BrickController2.Android/PlatformServices/GameController/GameControllerService.cs
@@ -41,7 +41,12 @@ namespace BrickController2.Droid.PlatformServices.GameController
         {
             if ((((int)e.Source & (int)InputSourceType.Gamepad) == (int)InputSourceType.Gamepad) && e.RepeatCount == 0)
             {
-                GameControllerEventInternal?.Invoke(this, new GameControllerEventArgs(GameControllerEventType.Button, e.KeyCode.ToString(), 1.0F));
+                // https://developer.android.com/develop/ui/views/touch-and-input/game-controllers/multiple-controllers
+                // Note: On devices running Android 4.1(API level 16) and higher, you can obtain an input device’s descriptor using getDescriptor(), which returns a unique persistent
+                // string value for the input device.Unlike a device ID, the descriptor value won't change even if the input device is disconnected, reconnected, or reconfigured. 
+                string controllerDeviceId = $"{e.Device?.ControllerNumber ?? -1}";
+
+                GameControllerEventInternal?.Invoke(this, new GameControllerEventArgs(controllerDeviceId, GameControllerEventType.Button, e.KeyCode.ToString(), 1.0F));
                 return true;
             }
 
@@ -52,15 +57,23 @@ namespace BrickController2.Droid.PlatformServices.GameController
         {
             if ((((int)e.Source & (int)InputSourceType.Gamepad) == (int)InputSourceType.Gamepad) && e.RepeatCount == 0)
             {
-                GameControllerEventInternal?.Invoke(this, new GameControllerEventArgs(GameControllerEventType.Button, e.KeyCode.ToString(), 0.0F));
+                // https://developer.android.com/develop/ui/views/touch-and-input/game-controllers/multiple-controllers
+                // Note: On devices running Android 4.1(API level 16) and higher, you can obtain an input device’s descriptor using getDescriptor(), which returns a unique persistent
+                // string value for the input device.Unlike a device ID, the descriptor value won't change even if the input device is disconnected, reconnected, or reconfigured. 
+                string controllerDeviceId = $"{e.Device?.ControllerNumber ?? -1}";
+
+                GameControllerEventInternal?.Invoke(this, new GameControllerEventArgs(controllerDeviceId, GameControllerEventType.Button, e.KeyCode.ToString(), 0.0F));
                 return true;
             }
-
             return false;
         }
-
         public bool OnGenericMotionEvent(MotionEvent e)
         {
+            // https://developer.android.com/develop/ui/views/touch-and-input/game-controllers/multiple-controllers
+            // Note: On devices running Android 4.1(API level 16) and higher, you can obtain an input device’s descriptor using getDescriptor(), which returns a unique persistent
+            // string value for the input device.Unlike a device ID, the descriptor value won't change even if the input device is disconnected, reconnected, or reconfigured. 
+
+            string controllerDeviceId = $"{e.Device?.ControllerNumber ?? -1}";
             if (e.Source == InputSourceType.Joystick && e.Action == MotionEventActions.Move)
             {
                 var events = new Dictionary<(GameControllerEventType, string), float>();
@@ -111,7 +124,7 @@ namespace BrickController2.Droid.PlatformServices.GameController
                     events[(GameControllerEventType.Axis, axisCode.ToString())] = axisValue;
                 }
 
-                GameControllerEventInternal?.Invoke(this, new GameControllerEventArgs(events));
+                GameControllerEventInternal?.Invoke(this, new GameControllerEventArgs(controllerDeviceId, events));
                 return true;
             }
 

--- a/BrickController2/BrickController2.Android/PlatformServices/GameController/GameControllerService.cs
+++ b/BrickController2/BrickController2.Android/PlatformServices/GameController/GameControllerService.cs
@@ -55,36 +55,8 @@ namespace BrickController2.Droid.PlatformServices.GameController
         /// </summary>
         public void MainActivityOnCreate()
         {
-            // JK: either register InputDeviceListener on Create/Destroy or Resume/Pause of MainActivity
-            // current decision: on Create/Destroy
+            // get all known gamecontrollers
             RefreshGameControllers();
-        }
-
-        /// <summary>
-        /// Handler called from MainActivity when MainActivity is destroy
-        /// </summary>
-        public void MainActivityOnDestroy()
-        {
-        }
-
-        /// <summary>
-        /// Handler called from MainActivity when MainActivity is paused 
-        /// </summary>
-        public void MainActivityOnPause()
-        {
-        }
-
-        /// <summary>
-        /// Handler called from MainActivity when MainActivity is resumed 
-        /// </summary>
-        public void MainActivityOnResume()
-        {
-            // JK: either register InputDeviceListener on Create/Destroy or Resume/Pause of MainActivity
-            // current decision: on Create/Destroy
-
-            // while MainActivity was paused the InputDeviceListener was unregistered
-            // gamecontrollers could be added/removed so we have to Refresh
-            //RefreshGameControllers();
         }
 
         /// <summary>

--- a/BrickController2/BrickController2.Android/PlatformServices/GameController/GameControllerService.cs
+++ b/BrickController2/BrickController2.Android/PlatformServices/GameController/GameControllerService.cs
@@ -115,10 +115,9 @@ namespace BrickController2.Droid.PlatformServices.GameController
 
         public bool OnKeyDown([GeneratedEnum] Keycode keyCode, KeyEvent e)
         {
-            GamepadController? gamepadController;
             if (e.Source.HasFlag(InputSourceType.Gamepad) && 
                 e.RepeatCount == 0 &&
-                _availableControllers.TryGetValue(e.DeviceId, out gamepadController)) // fetch matching GamepadController from table
+                _availableControllers.TryGetValue(e.DeviceId, out GamepadController? gamepadController)) // fetch matching GamepadController from table
             {
                 GameControllerEventInternal?.Invoke(this, new GameControllerEventArgs(gamepadController.ControllerName, GameControllerEventType.Button, e.KeyCode.ToString(), 1.0F));
                 return true;
@@ -129,10 +128,9 @@ namespace BrickController2.Droid.PlatformServices.GameController
 
         public bool OnKeyUp([GeneratedEnum] Keycode keyCode, KeyEvent e)
         {
-            GamepadController? gamepadController;
             if (e.Source.HasFlag(InputSourceType.Gamepad) && 
                 e.RepeatCount == 0 &&
-                _availableControllers.TryGetValue(e.DeviceId, out gamepadController)) // fetch matching GamepadController from table
+                _availableControllers.TryGetValue(e.DeviceId, out GamepadController? gamepadController)) // fetch matching GamepadController from table
             {
                 GameControllerEventInternal?.Invoke(this, new GameControllerEventArgs(gamepadController.ControllerName, GameControllerEventType.Button, e.KeyCode.ToString(), 0.0F));
                 return true;
@@ -142,10 +140,9 @@ namespace BrickController2.Droid.PlatformServices.GameController
 
         public bool OnGenericMotionEvent(MotionEvent e)
         {
-            GamepadController? gamepadController;
             if (e.Source == InputSourceType.Joystick && 
                 e.Action == MotionEventActions.Move &&
-                _availableControllers.TryGetValue(e.DeviceId, out gamepadController)) // fetch matching GamepadController from table
+                _availableControllers.TryGetValue(e.DeviceId, out GamepadController? gamepadController)) // fetch matching GamepadController from table
             {
                 var events = new Dictionary<(GameControllerEventType, string), float>();
                 foreach (Axis axisCode in Enum.GetValues(typeof(Axis)))

--- a/BrickController2/BrickController2.Android/PlatformServices/GameController/GameControllerService.cs
+++ b/BrickController2/BrickController2.Android/PlatformServices/GameController/GameControllerService.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using Android.Runtime;
 using Android.Views;
 using BrickController2.PlatformServices.GameController;
+using BrickController2.Droid.Extensions;
 
 namespace BrickController2.Droid.PlatformServices.GameController
 {
@@ -41,10 +42,7 @@ namespace BrickController2.Droid.PlatformServices.GameController
         {
             if ((((int)e.Source & (int)InputSourceType.Gamepad) == (int)InputSourceType.Gamepad) && e.RepeatCount == 0)
             {
-                // https://developer.android.com/develop/ui/views/touch-and-input/game-controllers/multiple-controllers
-                // Note: On devices running Android 4.1(API level 16) and higher, you can obtain an input device’s descriptor using getDescriptor(), which returns a unique persistent
-                // string value for the input device.Unlike a device ID, the descriptor value won't change even if the input device is disconnected, reconnected, or reconfigured. 
-                string controllerDeviceId = $"{e.Device?.ControllerNumber ?? -1}";
+                string controllerDeviceId = e.Device.GetDeviceId();
 
                 GameControllerEventInternal?.Invoke(this, new GameControllerEventArgs(controllerDeviceId, GameControllerEventType.Button, e.KeyCode.ToString(), 1.0F));
                 return true;
@@ -57,10 +55,7 @@ namespace BrickController2.Droid.PlatformServices.GameController
         {
             if ((((int)e.Source & (int)InputSourceType.Gamepad) == (int)InputSourceType.Gamepad) && e.RepeatCount == 0)
             {
-                // https://developer.android.com/develop/ui/views/touch-and-input/game-controllers/multiple-controllers
-                // Note: On devices running Android 4.1(API level 16) and higher, you can obtain an input device’s descriptor using getDescriptor(), which returns a unique persistent
-                // string value for the input device.Unlike a device ID, the descriptor value won't change even if the input device is disconnected, reconnected, or reconfigured. 
-                string controllerDeviceId = $"{e.Device?.ControllerNumber ?? -1}";
+                string controllerDeviceId = e.Device.GetDeviceId();
 
                 GameControllerEventInternal?.Invoke(this, new GameControllerEventArgs(controllerDeviceId, GameControllerEventType.Button, e.KeyCode.ToString(), 0.0F));
                 return true;
@@ -69,11 +64,7 @@ namespace BrickController2.Droid.PlatformServices.GameController
         }
         public bool OnGenericMotionEvent(MotionEvent e)
         {
-            // https://developer.android.com/develop/ui/views/touch-and-input/game-controllers/multiple-controllers
-            // Note: On devices running Android 4.1(API level 16) and higher, you can obtain an input device’s descriptor using getDescriptor(), which returns a unique persistent
-            // string value for the input device.Unlike a device ID, the descriptor value won't change even if the input device is disconnected, reconnected, or reconfigured. 
-
-            string controllerDeviceId = $"{e.Device?.ControllerNumber ?? -1}";
+            string controllerDeviceId = e.Device.GetDeviceId();
             if (e.Source == InputSourceType.Joystick && e.Action == MotionEventActions.Move)
             {
                 var events = new Dictionary<(GameControllerEventType, string), float>();

--- a/BrickController2/BrickController2.Android/PlatformServices/GameController/GameControllerService.cs
+++ b/BrickController2/BrickController2.Android/PlatformServices/GameController/GameControllerService.cs
@@ -264,10 +264,7 @@ namespace BrickController2.Droid.PlatformServices.GameController
         {
             lock (_lockObject)
             {
-                if (_availableControllers.ContainsKey(deviceId))
-                {
-                    _availableControllers.Remove(deviceId);
-                }
+                _availableControllers.Remove(deviceId);
             }
         }
 

--- a/BrickController2/BrickController2.Android/PlatformServices/GameController/GameControllerService.cs
+++ b/BrickController2/BrickController2.Android/PlatformServices/GameController/GameControllerService.cs
@@ -14,7 +14,6 @@ namespace BrickController2.Droid.PlatformServices.GameController
         private readonly Dictionary<int, GamepadController> _availableControllers = [];
         private readonly IDictionary<Axis, float> _lastAxisValues = new Dictionary<Axis, float>();
         private readonly object _lockObject = new object();
-        private readonly Context _context;
         private readonly InputManager _inputManager;
 
         private event EventHandler<GameControllerEventArgs>? GameControllerEventInternal;
@@ -45,8 +44,7 @@ namespace BrickController2.Droid.PlatformServices.GameController
 
         public GameControllerService(Context context)
         {
-            _context = context;
-            _inputManager = (InputManager)_context.GetSystemService(Context.InputService)!;
+            _inputManager = (InputManager)context.GetSystemService(Context.InputService)!;
         }
 
         /// <summary>

--- a/BrickController2/BrickController2.Android/PlatformServices/GameController/GamepadController.cs
+++ b/BrickController2/BrickController2.Android/PlatformServices/GameController/GamepadController.cs
@@ -1,0 +1,29 @@
+﻿using Android.Views;
+using BrickController2.Droid.Extensions;
+using BrickController2.Helpers;
+
+namespace BrickController2.Droid.PlatformServices.GameController
+{
+    internal class GamepadController
+    {
+        private readonly GameControllerService _controllerService;
+        private readonly InputDevice _gamepad;
+
+        private readonly int _controllerIndex;
+        private readonly string _controllerName;
+        private readonly string _uniquePersistantDeviceId;
+
+        public string UniquePersistantDeviceId => _uniquePersistantDeviceId;
+        public int ControllerIndex => _controllerIndex;
+        public string ControllerName => _controllerName;
+
+        public GamepadController(GameControllerService service, InputDevice gamePad, int controllerIndex)
+        {
+            _controllerService = service;
+            _gamepad = gamePad;
+            _controllerIndex = controllerIndex;
+            _uniquePersistantDeviceId = gamePad.GetUniquePersistentDeviceId();
+            _controllerName = GameControllerHelper.GetControllerDeviceId(controllerIndex);
+        }
+    }
+}

--- a/BrickController2/BrickController2.Android/PlatformServices/GameController/GamepadController.cs
+++ b/BrickController2/BrickController2.Android/PlatformServices/GameController/GamepadController.cs
@@ -6,24 +6,60 @@ namespace BrickController2.Droid.PlatformServices.GameController
 {
     internal class GamepadController
     {
+        /// <summary>
+        /// reference to GameControllerService (for future usage)
+        /// </summary>
         private readonly GameControllerService _controllerService;
+
+        /// <summary>
+        /// reference to InputDevice (for future usage i.e. to get more infos)
+        /// </summary>
         private readonly InputDevice _gamepad;
 
+        /// <summary>
+        /// zero-based Index of this controller inside the controller management
+        /// </summary>
         private readonly int _controllerIndex;
-        private readonly string _controllerName;
+
+        /// <summary>
+        /// string to identify the controller like "Controller 1"
+        /// </summary>
+        private readonly string _controllerId;
+
+        /// <summary>
+        /// Unique and persistant identifier of device (for future usage i.e. to save some device specific settings)
+        /// this value won't change even if the input device is disconnected, reconnected, or reconfigured
+        /// </summary>
         private readonly string _uniquePersistantDeviceId;
 
-        public string UniquePersistantDeviceId => _uniquePersistantDeviceId;
-        public int ControllerIndex => _controllerIndex;
-        public string ControllerName => _controllerName;
-
+        /// <summary>
+        /// Constructor
+        /// </summary>
+        /// <param name="service">reference to GameControllerService</param>
+        /// <param name="gamePad"> reference to InputDevice</param>
+        /// <param name="controllerIndex">zero-based Index of device inside the controller management</param>
         public GamepadController(GameControllerService service, InputDevice gamePad, int controllerIndex)
         {
             _controllerService = service;
             _gamepad = gamePad;
             _controllerIndex = controllerIndex;
             _uniquePersistantDeviceId = gamePad.GetUniquePersistentDeviceId();
-            _controllerName = GameControllerHelper.GetControllerDeviceId(controllerIndex);
+            _controllerId = GameControllerHelper.GetControllerIdFromIndex(controllerIndex);
         }
+
+        /// <summary>
+        /// Unique and persistant identifier of device
+        /// </summary>
+        public string UniquePersistantDeviceId => _uniquePersistantDeviceId;
+
+        /// <summary>
+        /// Index of this controller inside the controller management
+        /// </summary>
+        public int ControllerIndex => _controllerIndex;
+
+        /// <summary>
+        /// string to identify the controller like "Controller 1"
+        /// </summary>
+        public string ControllerId => _controllerId;
     }
 }

--- a/BrickController2/BrickController2.WinUI/Extensions/ControllerExtensions.cs
+++ b/BrickController2/BrickController2.WinUI/Extensions/ControllerExtensions.cs
@@ -7,5 +7,5 @@ public static class ControllerExtensions
     // deviceId looks like "{wgi/nrid/]Xd\\h-M1mO]-il0l-4L\\-Gebf:^3->kBRhM-d4}\0"
     // A unique ID that identifies the controller. As long as the controller is connected, the ID will never change.
     // JK: RawGameController.FromGameController(gamepad) returns null on deleted gamepad
-    public static string GetUniquePersistentDeviceId(this Gamepad gamepad) => RawGameController.FromGameController(gamepad).NonRoamableId;
+    public static string? GetUniquePersistentDeviceId(this Gamepad gamepad) => RawGameController.FromGameController(gamepad)?.NonRoamableId;
 }

--- a/BrickController2/BrickController2.WinUI/Extensions/ControllerExtensions.cs
+++ b/BrickController2/BrickController2.WinUI/Extensions/ControllerExtensions.cs
@@ -4,6 +4,7 @@ namespace BrickController2.Windows.Extensions;
 
 public static class ControllerExtensions
 {
-    public static string GetDeviceId(this Gamepad gamepad) =>
-        RawGameController.FromGameController(gamepad).NonRoamableId;
+    // deviceId looks like "{wgi/nrid/]Xd\\h-M1mO]-il0l-4L\\-Gebf:^3->kBRhM-d4}\0"
+    // A unique ID that identifies the controller. As long as the controller is connected, the ID will never change.
+    public static string GetDeviceId(this Gamepad gamepad) => RawGameController.FromGameController(gamepad).NonRoamableId;
 }

--- a/BrickController2/BrickController2.WinUI/Extensions/ControllerExtensions.cs
+++ b/BrickController2/BrickController2.WinUI/Extensions/ControllerExtensions.cs
@@ -5,6 +5,5 @@ namespace BrickController2.Windows.Extensions;
 public static class ControllerExtensions
 {
     public static string GetDeviceId(this Gamepad gamepad) =>
-        // kinda hack
-        gamepad.User.NonRoamableId;
+        RawGameController.FromGameController(gamepad).NonRoamableId;
 }

--- a/BrickController2/BrickController2.WinUI/Extensions/ControllerExtensions.cs
+++ b/BrickController2/BrickController2.WinUI/Extensions/ControllerExtensions.cs
@@ -6,5 +6,6 @@ public static class ControllerExtensions
 {
     // deviceId looks like "{wgi/nrid/]Xd\\h-M1mO]-il0l-4L\\-Gebf:^3->kBRhM-d4}\0"
     // A unique ID that identifies the controller. As long as the controller is connected, the ID will never change.
-    public static string GetDeviceId(this Gamepad gamepad) => RawGameController.FromGameController(gamepad).NonRoamableId;
+    // JK: RawGameController.FromGameController(gamepad) returns null on deleted gamepad
+    public static string GetUniquePersistentDeviceId(this Gamepad gamepad) => RawGameController.FromGameController(gamepad).NonRoamableId;
 }

--- a/BrickController2/BrickController2.WinUI/PlatformServices/GameController/GameControllerService.cs
+++ b/BrickController2/BrickController2.WinUI/PlatformServices/GameController/GameControllerService.cs
@@ -53,19 +53,19 @@ public class GameControllerService : IGameControllerService
         }
     }
 
-    internal void RaiseEvent(IDictionary<(GameControllerEventType, string), float> events, string controllerDeviceId)
+    internal void RaiseEvent(IDictionary<(GameControllerEventType, string), float> events, string controllerId)
     {
         if (!events.Any())
         {
             return;
         }
 
-        GameControllerEventInternal?.Invoke(this, new GameControllerEventArgs(controllerDeviceId, events));
+        GameControllerEventInternal?.Invoke(this, new GameControllerEventArgs(controllerId, events));
     }
 
-    internal void RaiseEvent(string deviceId, string key, GameControllerEventType eventType, string controllerDeviceId, float value = 0.0f)
+    internal void RaiseEvent(string deviceId, string key, GameControllerEventType eventType, string controllerId, float value = 0.0f)
     {
-        GameControllerEventInternal?.Invoke(this, new GameControllerEventArgs(controllerDeviceId, eventType, key, value));
+        GameControllerEventInternal?.Invoke(this, new GameControllerEventArgs(controllerId, eventType, key, value));
     }
 
     private void InitializeControllers()

--- a/BrickController2/BrickController2.WinUI/PlatformServices/GameController/GameControllerService.cs
+++ b/BrickController2/BrickController2.WinUI/PlatformServices/GameController/GameControllerService.cs
@@ -99,7 +99,7 @@ public class GameControllerService : IGameControllerService
             // JK: UniquePersistentDeviceId is not available
             //var deviceId = e.GetUniquePersistentDeviceId();
 
-            string deviceId = this.FindUniquePersistentDeviceId(e);
+            string deviceId = FindUniquePersistentDeviceId(e);
 
             if (deviceId is not null &&
                 _availableControllers.TryGetValue(deviceId, out var controller))
@@ -128,7 +128,7 @@ public class GameControllerService : IGameControllerService
                 // deviceId looks like "{wgi/nrid/]Xd\\h-M1mO]-il0l-4L\\-Gebf:^3->kBRhM-d4}\0"
                 var uniquePersistentDeviceId = gamepad.GetUniquePersistentDeviceId();
                 
-                int controllerIndex = GetUnusedControllerIndex(); // get first unused index begins at 1
+                int controllerIndex = GetFirstUnusedControllerIndex(); // get first unused index begins at 1
 
                 var newController = new GamepadController(this, gamepad, controllerIndex, dispatcher!.CreateTimer());
                 _availableControllers[uniquePersistentDeviceId] = newController;
@@ -138,11 +138,15 @@ public class GameControllerService : IGameControllerService
         }
     }
 
-    private int GetUnusedControllerIndex()
+    /// <summary>
+    /// returns the first unused index of device in controller management
+    /// </summary>
+    /// <returns>first unused index</returns>
+    private int GetFirstUnusedControllerIndex()
     {
         lock (_lockObject)
         {
-            int unusedIndex = 1;
+            int unusedIndex = 0;
             while(_availableControllers.Values.Any(gamepadController => gamepadController.ControllerIndex == unusedIndex))
             {
                 unusedIndex++;

--- a/BrickController2/BrickController2.WinUI/PlatformServices/GameController/GameControllerService.cs
+++ b/BrickController2/BrickController2.WinUI/PlatformServices/GameController/GameControllerService.cs
@@ -53,6 +53,8 @@ public class GameControllerService : IGameControllerService
         }
     }
 
+    public bool IsControllerIdSupported => true;
+
     internal void RaiseEvent(IDictionary<(GameControllerEventType, string), float> events, string controllerId)
     {
         if (!events.Any())

--- a/BrickController2/BrickController2.WinUI/PlatformServices/GameController/GameControllerService.cs
+++ b/BrickController2/BrickController2.WinUI/PlatformServices/GameController/GameControllerService.cs
@@ -128,11 +128,16 @@ public class GameControllerService : IGameControllerService
             foreach (var gamepad in gamepads)
             {
                 // deviceId looks like "{wgi/nrid/]Xd\\h-M1mO]-il0l-4L\\-Gebf:^3->kBRhM-d4}\0"
-                var uniquePersistentDeviceId = gamepad.GetUniquePersistentDeviceId();
-                
+                string? uniquePersistentDeviceId = gamepad?.GetUniquePersistentDeviceId();
+
+                if(string.IsNullOrEmpty(uniquePersistentDeviceId))
+                {
+                    continue;
+                }
+
                 int controllerIndex = GetFirstUnusedControllerIndex(); // get first unused index
 
-                var newController = new GamepadController(this, gamepad, controllerIndex, dispatcher!.CreateTimer());
+                var newController = new GamepadController(this, gamepad!, controllerIndex, dispatcher!.CreateTimer());
                 _availableControllers[uniquePersistentDeviceId] = newController;
 
                 newController.Start();

--- a/BrickController2/BrickController2.WinUI/PlatformServices/GameController/GameControllerService.cs
+++ b/BrickController2/BrickController2.WinUI/PlatformServices/GameController/GameControllerService.cs
@@ -128,7 +128,7 @@ public class GameControllerService : IGameControllerService
                 // deviceId looks like "{wgi/nrid/]Xd\\h-M1mO]-il0l-4L\\-Gebf:^3->kBRhM-d4}\0"
                 var uniquePersistentDeviceId = gamepad.GetUniquePersistentDeviceId();
                 
-                int controllerIndex = GetFirstUnusedControllerIndex(); // get first unused index begins at 1
+                int controllerIndex = GetFirstUnusedControllerIndex(); // get first unused index
 
                 var newController = new GamepadController(this, gamepad, controllerIndex, dispatcher!.CreateTimer());
                 _availableControllers[uniquePersistentDeviceId] = newController;
@@ -163,6 +163,5 @@ public class GameControllerService : IGameControllerService
     private string FindUniquePersistentDeviceId(Gamepad gamepad)
     {
         return _availableControllers.FirstOrDefault(entry => entry.Value.Gamepad == gamepad).Key;
-
     }
 }

--- a/BrickController2/BrickController2.WinUI/PlatformServices/GameController/GameControllerService.cs
+++ b/BrickController2/BrickController2.WinUI/PlatformServices/GameController/GameControllerService.cs
@@ -11,7 +11,6 @@ namespace BrickController2.Windows.PlatformServices.GameController;
 
 public class GameControllerService : IGameControllerService
 {
-
     private readonly Dictionary<string, GamepadController> _availableControllers = [];
     private readonly object _lockObject = new();
     private readonly IMainThreadService _mainThreadService;
@@ -54,19 +53,19 @@ public class GameControllerService : IGameControllerService
         }
     }
 
-    internal void RaiseEvent(IDictionary<(GameControllerEventType, string), float> events)
+    internal void RaiseEvent(IDictionary<(GameControllerEventType, string), float> events, string controllerDeviceId)
     {
         if (!events.Any())
         {
             return;
         }
 
-        GameControllerEventInternal?.Invoke(this, new GameControllerEventArgs(events));
+        GameControllerEventInternal?.Invoke(this, new GameControllerEventArgs(controllerDeviceId, events));
     }
 
-    internal void RaiseEvent(string deviceId, string key, GameControllerEventType eventType, float value = 0.0f)
+    internal void RaiseEvent(string deviceId, string key, GameControllerEventType eventType, string controllerDeviceId, float value = 0.0f)
     {
-        GameControllerEventInternal?.Invoke(this, new GameControllerEventArgs(eventType, key, value));
+        GameControllerEventInternal?.Invoke(this, new GameControllerEventArgs(controllerDeviceId, eventType, key, value));
     }
 
     private void InitializeControllers()

--- a/BrickController2/BrickController2.WinUI/PlatformServices/GameController/GamepadController.cs
+++ b/BrickController2/BrickController2.WinUI/PlatformServices/GameController/GamepadController.cs
@@ -59,7 +59,7 @@ internal class GamepadController
             .Where(HasChanged)
             .ToDictionary(x => (x.EventType, x.Name), x => x.Value);
 
-        _controllerService.RaiseEvent(currentEvents);
+        _controllerService.RaiseEvent(currentEvents, DeviceId);
     }
 
     private static bool AreAlmostEqual(float a, float b) => Math.Abs(a - b) < 0.001;

--- a/BrickController2/BrickController2.WinUI/PlatformServices/GameController/GamepadController.cs
+++ b/BrickController2/BrickController2.WinUI/PlatformServices/GameController/GamepadController.cs
@@ -1,10 +1,11 @@
-﻿using BrickController2.PlatformServices.GameController;
-using BrickController2.Windows.Extensions;
-using Microsoft.Maui.Dispatching;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using Windows.Gaming.Input;
+using Microsoft.Maui.Dispatching;
+using BrickController2.Helpers;
+using BrickController2.PlatformServices.GameController;
+using BrickController2.Windows.Extensions;
 
 namespace BrickController2.Windows.PlatformServices.GameController;
 
@@ -19,29 +20,30 @@ internal class GamepadController
     private readonly Dictionary<string, float> _lastReadingValues = [];
     private readonly int _controllerIndex;
     private readonly string _controllerName;
-    private readonly string _deviceId;
+    private readonly string _uniquePersistentDeviceId;
 
-    public GamepadController(GameControllerService service, Gamepad gamepad, int controllerIndex, string controllerName, IDispatcherTimer timer)
-        : this(service, gamepad, controllerIndex, controllerName, timer, DefaultInterval)
+    public string UniquePersistentDeviceId => _uniquePersistentDeviceId;
+    public int ControllerIndex => _controllerIndex;
+    public string ControllerName => _controllerName;
+    public Gamepad Gamepad => _gamepad;
+
+    public GamepadController(GameControllerService service, Gamepad gamepad, int controllerIndex, IDispatcherTimer timer)
+        : this(service, gamepad, controllerIndex, timer, DefaultInterval)
     {
     }
 
-    private GamepadController(GameControllerService service, Gamepad gamepad, int controllerIndex, string controllerName, IDispatcherTimer timer, TimeSpan timerInterval)
+    private GamepadController(GameControllerService service, Gamepad gamepad, int controllerIndex, IDispatcherTimer timer, TimeSpan timerInterval)
     {
         _controllerService = service;
         _gamepad = gamepad;
         _timer = timer;
         _controllerIndex = controllerIndex;
-        _deviceId = _gamepad.GetDeviceId();
-        _controllerName = controllerName;
+        _uniquePersistentDeviceId = _gamepad.GetUniquePersistentDeviceId();
+        _controllerName = GameControllerHelper.GetControllerDeviceId(controllerIndex);
 
         _timer.Interval = timerInterval;
         _timer.Tick += Timer_Tick;
     }
-
-    public string DeviceId => _deviceId;
-    public int ControllerIndex => _controllerIndex;
-    public string ControllerName => _controllerName;
 
     public void Start()
     {

--- a/BrickController2/BrickController2.WinUI/PlatformServices/GameController/GamepadController.cs
+++ b/BrickController2/BrickController2.WinUI/PlatformServices/GameController/GamepadController.cs
@@ -17,23 +17,31 @@ internal class GamepadController
     private readonly IDispatcherTimer _timer;
 
     private readonly Dictionary<string, float> _lastReadingValues = [];
+    private readonly int _controllerIndex;
+    private readonly string _controllerName;
+    private readonly string _deviceId;
 
-    public GamepadController(GameControllerService service, Gamepad gamepad, IDispatcherTimer timer)
-        : this(service, gamepad, timer, DefaultInterval)
+    public GamepadController(GameControllerService service, Gamepad gamepad, int controllerIndex, string controllerName, IDispatcherTimer timer)
+        : this(service, gamepad, controllerIndex, controllerName, timer, DefaultInterval)
     {
     }
 
-    private GamepadController(GameControllerService service, Gamepad gamepad, IDispatcherTimer timer, TimeSpan timerInterval)
+    private GamepadController(GameControllerService service, Gamepad gamepad, int controllerIndex, string controllerName, IDispatcherTimer timer, TimeSpan timerInterval)
     {
         _controllerService = service;
         _gamepad = gamepad;
         _timer = timer;
+        _controllerIndex = controllerIndex;
+        _deviceId = _gamepad.GetDeviceId();
+        _controllerName = controllerName;
 
         _timer.Interval = timerInterval;
         _timer.Tick += Timer_Tick;
     }
 
-    public string DeviceId => _gamepad.GetDeviceId();
+    public string DeviceId => _deviceId;
+    public int ControllerIndex => _controllerIndex;
+    public string ControllerName => _controllerName;
 
     public void Start()
     {
@@ -59,7 +67,7 @@ internal class GamepadController
             .Where(HasChanged)
             .ToDictionary(x => (x.EventType, x.Name), x => x.Value);
 
-        _controllerService.RaiseEvent(currentEvents, DeviceId);
+        _controllerService.RaiseEvent(currentEvents, ControllerName);
     }
 
     private static bool AreAlmostEqual(float a, float b) => Math.Abs(a - b) < 0.001;

--- a/BrickController2/BrickController2.WinUI/PlatformServices/GameController/GamepadController.cs
+++ b/BrickController2/BrickController2.WinUI/PlatformServices/GameController/GamepadController.cs
@@ -18,14 +18,22 @@ internal class GamepadController
     private readonly IDispatcherTimer _timer;
 
     private readonly Dictionary<string, float> _lastReadingValues = [];
-    private readonly int _controllerIndex;
-    private readonly string _controllerName;
-    private readonly string _uniquePersistentDeviceId;
 
-    public string UniquePersistentDeviceId => _uniquePersistentDeviceId;
-    public int ControllerIndex => _controllerIndex;
-    public string ControllerName => _controllerName;
-    public Gamepad Gamepad => _gamepad;
+    /// <summary>
+    /// zero-based Index of this controller inside the controller management
+    /// </summary>
+    private readonly int _controllerIndex;
+
+    /// <summary>
+    /// string to identify the controller like "Controller 1"
+    /// </summary>
+    private readonly string _controllerId;
+
+    /// <summary>
+    /// Unique and persistant identifier of device (for future usage i.e. to save some device specific settings)
+    /// this value won't change even if the input device is disconnected, reconnected, or reconfigured
+    /// </summary>
+    private readonly string _uniquePersistentDeviceId;
 
     public GamepadController(GameControllerService service, Gamepad gamepad, int controllerIndex, IDispatcherTimer timer)
         : this(service, gamepad, controllerIndex, timer, DefaultInterval)
@@ -39,11 +47,29 @@ internal class GamepadController
         _timer = timer;
         _controllerIndex = controllerIndex;
         _uniquePersistentDeviceId = _gamepad.GetUniquePersistentDeviceId();
-        _controllerName = GameControllerHelper.GetControllerDeviceId(controllerIndex);
+        _controllerId = GameControllerHelper.GetControllerIdFromIndex(controllerIndex);
 
         _timer.Interval = timerInterval;
         _timer.Tick += Timer_Tick;
     }
+
+    /// <summary>
+    /// Unique and persistant identifier of device
+    /// </summary>
+    public string UniquePersistentDeviceId => _uniquePersistentDeviceId;
+
+    /// <summary>
+    /// Index of this controller inside the controller management
+    /// </summary>
+    public int ControllerIndex => _controllerIndex;
+
+    /// <summary>
+    /// string to identify the controller like "Controller 1"
+    /// </summary>
+    public string ControllerID => _controllerId;
+
+    public Gamepad Gamepad => _gamepad;
+
 
     public void Start()
     {
@@ -69,7 +95,7 @@ internal class GamepadController
             .Where(HasChanged)
             .ToDictionary(x => (x.EventType, x.Name), x => x.Value);
 
-        _controllerService.RaiseEvent(currentEvents, ControllerName);
+        _controllerService.RaiseEvent(currentEvents, ControllerID);
     }
 
     private static bool AreAlmostEqual(float a, float b) => Math.Abs(a - b) < 0.001;

--- a/BrickController2/BrickController2.iOS/PlatformServices/GameController/GameControllerService.cs
+++ b/BrickController2/BrickController2.iOS/PlatformServices/GameController/GameControllerService.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using BrickController2.Helpers;
 using BrickController2.PlatformServices.GameController;
 using Foundation;
 using GameController;
@@ -9,8 +10,6 @@ namespace BrickController2.iOS.PlatformServices.GameController
 {
     public class GameControllerService : IGameControllerService
     {
-        private const string ControllerDeviceId = "Controller";
-
         private enum GameControllerType
         {
             Unknown,
@@ -205,7 +204,7 @@ namespace BrickController2.iOS.PlatformServices.GameController
                 if (!_lastControllerEventValueMap.ContainsKey(name) || !AreAlmostEqual(_lastControllerEventValueMap[name], value))
                 {
                     // ToDo: find ControllerDeviceId
-                    string controllerDeviceId = ControllerDeviceId;
+                    string controllerDeviceId = GameControllerHelper.GetControllerDeviceId(1);
 
                     _lastControllerEventValueMap[name] = value;
                     GameControllerEventInternal?.Invoke(this, new GameControllerEventArgs(controllerDeviceId, GameControllerEventType.Button, name, value));
@@ -222,7 +221,7 @@ namespace BrickController2.iOS.PlatformServices.GameController
                 if (!_lastControllerEventValueMap.ContainsKey(name) || !AreAlmostEqual(_lastControllerEventValueMap[name], value))
                 {
                     // ToDo: find ControllerDeviceId
-                    string controllerDeviceId = ControllerDeviceId;
+                    string controllerDeviceId = GameControllerHelper.GetControllerDeviceId(1);
 
                     _lastControllerEventValueMap[name] = value;
                     GameControllerEventInternal?.Invoke(this, new GameControllerEventArgs(controllerDeviceId, GameControllerEventType.Axis, name, value));
@@ -247,7 +246,7 @@ namespace BrickController2.iOS.PlatformServices.GameController
                 if (!_lastControllerEventValueMap.ContainsKey(name) || !AreAlmostEqual(_lastControllerEventValueMap[name], value))
                 {
                     // ToDo: find ControllerDeviceId
-                    string controllerDeviceId = ControllerDeviceId;
+                    string controllerDeviceId = GameControllerHelper.GetControllerDeviceId(1);
 
                     GameControllerEventInternal?.Invoke(this, new GameControllerEventArgs(controllerDeviceId, GameControllerEventType.Axis, name, value));
                     _lastControllerEventValueMap[name] = value;
@@ -270,7 +269,7 @@ namespace BrickController2.iOS.PlatformServices.GameController
                 if (!_lastControllerEventValueMap.ContainsKey(name) || !AreAlmostEqual(_lastControllerEventValueMap[name], value))
                 {
                     // ToDo: find ControllerDeviceId
-                    string controllerDeviceId = ControllerDeviceId;
+                    string controllerDeviceId = GameControllerHelper.GetControllerDeviceId(1);
 
                     GameControllerEventInternal?.Invoke(this, new GameControllerEventArgs(controllerDeviceId, GameControllerEventType.Axis, name, value));
                     _lastControllerEventValueMap[name] = value;

--- a/BrickController2/BrickController2.iOS/PlatformServices/GameController/GameControllerService.cs
+++ b/BrickController2/BrickController2.iOS/PlatformServices/GameController/GameControllerService.cs
@@ -69,6 +69,8 @@ namespace BrickController2.iOS.PlatformServices.GameController
             }
         }
 
+        public bool IsControllerIdSupported => false; // ToDo: implement ControllerManagement
+
         private void FindController()
         {
             lock (_lockObject)

--- a/BrickController2/BrickController2.iOS/PlatformServices/GameController/GameControllerService.cs
+++ b/BrickController2/BrickController2.iOS/PlatformServices/GameController/GameControllerService.cs
@@ -203,7 +203,7 @@ namespace BrickController2.iOS.PlatformServices.GameController
 
                 if (!_lastControllerEventValueMap.ContainsKey(name) || !AreAlmostEqual(_lastControllerEventValueMap[name], value))
                 {
-                    // ToDo: find ControllerDeviceId
+                    // ToDo: find ControllerId
                     string controllerId = GameControllerHelper.GetControllerIdFromIndex(0);
 
                     _lastControllerEventValueMap[name] = value;
@@ -220,7 +220,7 @@ namespace BrickController2.iOS.PlatformServices.GameController
 
                 if (!_lastControllerEventValueMap.ContainsKey(name) || !AreAlmostEqual(_lastControllerEventValueMap[name], value))
                 {
-                    // ToDo: find ControllerDeviceId
+                    // ToDo: find ControllerId
                     string controllerId = GameControllerHelper.GetControllerIdFromIndex(0);
 
                     _lastControllerEventValueMap[name] = value;
@@ -245,7 +245,7 @@ namespace BrickController2.iOS.PlatformServices.GameController
 
                 if (!_lastControllerEventValueMap.ContainsKey(name) || !AreAlmostEqual(_lastControllerEventValueMap[name], value))
                 {
-                    // ToDo: find ControllerDeviceId
+                    // ToDo: find ControllerId
                     string controllerId = GameControllerHelper.GetControllerIdFromIndex(0);
 
                     GameControllerEventInternal?.Invoke(this, new GameControllerEventArgs(controllerId, GameControllerEventType.Axis, name, value));
@@ -268,7 +268,7 @@ namespace BrickController2.iOS.PlatformServices.GameController
 
                 if (!_lastControllerEventValueMap.ContainsKey(name) || !AreAlmostEqual(_lastControllerEventValueMap[name], value))
                 {
-                    // ToDo: find ControllerDeviceId
+                    // ToDo: find ControllerId
                     string controllerId = GameControllerHelper.GetControllerIdFromIndex(0);
 
                     GameControllerEventInternal?.Invoke(this, new GameControllerEventArgs(controllerId, GameControllerEventType.Axis, name, value));

--- a/BrickController2/BrickController2.iOS/PlatformServices/GameController/GameControllerService.cs
+++ b/BrickController2/BrickController2.iOS/PlatformServices/GameController/GameControllerService.cs
@@ -204,10 +204,10 @@ namespace BrickController2.iOS.PlatformServices.GameController
                 if (!_lastControllerEventValueMap.ContainsKey(name) || !AreAlmostEqual(_lastControllerEventValueMap[name], value))
                 {
                     // ToDo: find ControllerDeviceId
-                    string controllerDeviceId = GameControllerHelper.GetControllerDeviceId(1);
+                    string controllerId = GameControllerHelper.GetControllerIdFromIndex(0);
 
                     _lastControllerEventValueMap[name] = value;
-                    GameControllerEventInternal?.Invoke(this, new GameControllerEventArgs(controllerDeviceId, GameControllerEventType.Button, name, value));
+                    GameControllerEventInternal?.Invoke(this, new GameControllerEventArgs(controllerId, GameControllerEventType.Button, name, value));
                 }
             };
         }
@@ -221,10 +221,10 @@ namespace BrickController2.iOS.PlatformServices.GameController
                 if (!_lastControllerEventValueMap.ContainsKey(name) || !AreAlmostEqual(_lastControllerEventValueMap[name], value))
                 {
                     // ToDo: find ControllerDeviceId
-                    string controllerDeviceId = GameControllerHelper.GetControllerDeviceId(1);
+                    string controllerId = GameControllerHelper.GetControllerIdFromIndex(0);
 
                     _lastControllerEventValueMap[name] = value;
-                    GameControllerEventInternal?.Invoke(this, new GameControllerEventArgs(controllerDeviceId, GameControllerEventType.Axis, name, value));
+                    GameControllerEventInternal?.Invoke(this, new GameControllerEventArgs(controllerId, GameControllerEventType.Axis, name, value));
                 }
             };
         }
@@ -246,9 +246,9 @@ namespace BrickController2.iOS.PlatformServices.GameController
                 if (!_lastControllerEventValueMap.ContainsKey(name) || !AreAlmostEqual(_lastControllerEventValueMap[name], value))
                 {
                     // ToDo: find ControllerDeviceId
-                    string controllerDeviceId = GameControllerHelper.GetControllerDeviceId(1);
+                    string controllerId = GameControllerHelper.GetControllerIdFromIndex(0);
 
-                    GameControllerEventInternal?.Invoke(this, new GameControllerEventArgs(controllerDeviceId, GameControllerEventType.Axis, name, value));
+                    GameControllerEventInternal?.Invoke(this, new GameControllerEventArgs(controllerId, GameControllerEventType.Axis, name, value));
                     _lastControllerEventValueMap[name] = value;
                 }
             };
@@ -269,9 +269,9 @@ namespace BrickController2.iOS.PlatformServices.GameController
                 if (!_lastControllerEventValueMap.ContainsKey(name) || !AreAlmostEqual(_lastControllerEventValueMap[name], value))
                 {
                     // ToDo: find ControllerDeviceId
-                    string controllerDeviceId = GameControllerHelper.GetControllerDeviceId(1);
+                    string controllerId = GameControllerHelper.GetControllerIdFromIndex(0);
 
-                    GameControllerEventInternal?.Invoke(this, new GameControllerEventArgs(controllerDeviceId, GameControllerEventType.Axis, name, value));
+                    GameControllerEventInternal?.Invoke(this, new GameControllerEventArgs(controllerId, GameControllerEventType.Axis, name, value));
                     _lastControllerEventValueMap[name] = value;
                 }
             };

--- a/BrickController2/BrickController2.iOS/PlatformServices/GameController/GameControllerService.cs
+++ b/BrickController2/BrickController2.iOS/PlatformServices/GameController/GameControllerService.cs
@@ -9,6 +9,8 @@ namespace BrickController2.iOS.PlatformServices.GameController
 {
     public class GameControllerService : IGameControllerService
     {
+        private const string ControllerDeviceId = "Controller";
+
         private enum GameControllerType
         {
             Unknown,
@@ -202,8 +204,11 @@ namespace BrickController2.iOS.PlatformServices.GameController
 
                 if (!_lastControllerEventValueMap.ContainsKey(name) || !AreAlmostEqual(_lastControllerEventValueMap[name], value))
                 {
+                    // ToDo: find ControllerDeviceId
+                    string controllerDeviceId = ControllerDeviceId;
+
                     _lastControllerEventValueMap[name] = value;
-                    GameControllerEventInternal?.Invoke(this, new GameControllerEventArgs(GameControllerEventType.Button, name, value));
+                    GameControllerEventInternal?.Invoke(this, new GameControllerEventArgs(controllerDeviceId, GameControllerEventType.Button, name, value));
                 }
             };
         }
@@ -216,8 +221,11 @@ namespace BrickController2.iOS.PlatformServices.GameController
 
                 if (!_lastControllerEventValueMap.ContainsKey(name) || !AreAlmostEqual(_lastControllerEventValueMap[name], value))
                 {
+                    // ToDo: find ControllerDeviceId
+                    string controllerDeviceId = ControllerDeviceId;
+
                     _lastControllerEventValueMap[name] = value;
-                    GameControllerEventInternal?.Invoke(this, new GameControllerEventArgs(GameControllerEventType.Axis, name, value));
+                    GameControllerEventInternal?.Invoke(this, new GameControllerEventArgs(controllerDeviceId, GameControllerEventType.Axis, name, value));
                 }
             };
         }
@@ -238,7 +246,10 @@ namespace BrickController2.iOS.PlatformServices.GameController
 
                 if (!_lastControllerEventValueMap.ContainsKey(name) || !AreAlmostEqual(_lastControllerEventValueMap[name], value))
                 {
-                    GameControllerEventInternal?.Invoke(this, new GameControllerEventArgs(GameControllerEventType.Axis, name, value));
+                    // ToDo: find ControllerDeviceId
+                    string controllerDeviceId = ControllerDeviceId;
+
+                    GameControllerEventInternal?.Invoke(this, new GameControllerEventArgs(controllerDeviceId, GameControllerEventType.Axis, name, value));
                     _lastControllerEventValueMap[name] = value;
                 }
             };
@@ -258,7 +269,10 @@ namespace BrickController2.iOS.PlatformServices.GameController
 
                 if (!_lastControllerEventValueMap.ContainsKey(name) || !AreAlmostEqual(_lastControllerEventValueMap[name], value))
                 {
-                    GameControllerEventInternal?.Invoke(this, new GameControllerEventArgs(GameControllerEventType.Axis, name, value));
+                    // ToDo: find ControllerDeviceId
+                    string controllerDeviceId = ControllerDeviceId;
+
+                    GameControllerEventInternal?.Invoke(this, new GameControllerEventArgs(controllerDeviceId, GameControllerEventType.Axis, name, value));
                     _lastControllerEventValueMap[name] = value;
                 }
             };

--- a/BrickController2/BrickController2/BusinessLogic/PlayLogic.cs
+++ b/BrickController2/BrickController2/BusinessLogic/PlayLogic.cs
@@ -80,8 +80,8 @@ namespace BrickController2.BusinessLogic
             {
                 foreach (var controllerEvent in ActiveProfile.ControllerEvents)
                 {
-                    if ((string.IsNullOrEmpty(controllerEvent.ControllerDeviceId) ||      // for backward compatibility with undef ControllerDeviceId
-                        e.ControllerDeviceId == controllerEvent.ControllerDeviceId) &&
+                    if ((string.IsNullOrEmpty(controllerEvent.ControllerId) ||      // for backward compatibility with undef ControllerId
+                        e.ControllerId == controllerEvent.ControllerId) &&
                         gameControllerEvent.Key.EventType == controllerEvent.EventType &&
                         gameControllerEvent.Key.EventCode == controllerEvent.EventCode)
                     {

--- a/BrickController2/BrickController2/BusinessLogic/PlayLogic.cs
+++ b/BrickController2/BrickController2/BusinessLogic/PlayLogic.cs
@@ -80,7 +80,8 @@ namespace BrickController2.BusinessLogic
             {
                 foreach (var controllerEvent in ActiveProfile.ControllerEvents)
                 {
-                    if (e.ControllerDeviceId == controllerEvent.ControllerDeviceId &&
+                    if ((string.IsNullOrEmpty(controllerEvent.ControllerDeviceId) ||      // for backward compatibility with undef ControllerDeviceId
+                        e.ControllerDeviceId == controllerEvent.ControllerDeviceId) &&
                         gameControllerEvent.Key.EventType == controllerEvent.EventType &&
                         gameControllerEvent.Key.EventCode == controllerEvent.EventCode)
                     {

--- a/BrickController2/BrickController2/BusinessLogic/PlayLogic.cs
+++ b/BrickController2/BrickController2/BusinessLogic/PlayLogic.cs
@@ -80,7 +80,8 @@ namespace BrickController2.BusinessLogic
             {
                 foreach (var controllerEvent in ActiveProfile.ControllerEvents)
                 {
-                    if (gameControllerEvent.Key.EventType == controllerEvent.EventType &&
+                    if (e.ControllerDeviceId == controllerEvent.ControllerDeviceId &&
+                        gameControllerEvent.Key.EventType == controllerEvent.EventType &&
                         gameControllerEvent.Key.EventCode == controllerEvent.EventCode)
                     {
                         foreach (var controllerAction in controllerEvent.ControllerActions)

--- a/BrickController2/BrickController2/CreationManagement/ControllerEvent.cs
+++ b/BrickController2/BrickController2/CreationManagement/ControllerEvent.cs
@@ -11,7 +11,7 @@ namespace BrickController2.CreationManagement
     {
         private GameControllerEventType _eventType;
         private string _eventCode = string.Empty;
-        private string _controllerDeviceId = string.Empty;
+        private string _controllerId = string.Empty;
         private ObservableCollection<ControllerAction> _controllerActions = new ObservableCollection<ControllerAction>();
 
         [PrimaryKey, AutoIncrement]
@@ -26,10 +26,10 @@ namespace BrickController2.CreationManagement
         [JsonIgnore]
         public ControllerProfile? ControllerProfile { get; set; }
 
-        public string ControllerDeviceId
+        public string ControllerId
         {
-            get { return _controllerDeviceId; }
-            set { _controllerDeviceId = value; RaisePropertyChanged(); }
+            get { return _controllerId; }
+            set { _controllerId = value; RaisePropertyChanged(); }
         }
 
         public GameControllerEventType EventType
@@ -53,7 +53,7 @@ namespace BrickController2.CreationManagement
 
         public override string ToString()
         {
-            return $"{ControllerDeviceId} - {EventType} - {EventCode}";
+            return $"{ControllerId} - {EventType} - {EventCode}";
         }
     }
 }

--- a/BrickController2/BrickController2/CreationManagement/ControllerEvent.cs
+++ b/BrickController2/BrickController2/CreationManagement/ControllerEvent.cs
@@ -11,6 +11,7 @@ namespace BrickController2.CreationManagement
     {
         private GameControllerEventType _eventType;
         private string _eventCode = string.Empty;
+        private string _controllerDeviceId = string.Empty;
         private ObservableCollection<ControllerAction> _controllerActions = new ObservableCollection<ControllerAction>();
 
         [PrimaryKey, AutoIncrement]
@@ -24,6 +25,12 @@ namespace BrickController2.CreationManagement
         [ManyToOne]
         [JsonIgnore]
         public ControllerProfile? ControllerProfile { get; set; }
+
+        public string ControllerDeviceId
+        {
+            get { return _controllerDeviceId; }
+            set { _controllerDeviceId = value; RaisePropertyChanged(); }
+        }
 
         public GameControllerEventType EventType
         {
@@ -46,7 +53,7 @@ namespace BrickController2.CreationManagement
 
         public override string ToString()
         {
-            return $"{EventType} - {EventCode}";
+            return $"{ControllerDeviceId} - {EventType} - {EventCode}";
         }
     }
 }

--- a/BrickController2/BrickController2/CreationManagement/CreationManager.cs
+++ b/BrickController2/BrickController2/CreationManagement/CreationManager.cs
@@ -213,14 +213,14 @@ namespace BrickController2.CreationManagement
             }
         }
 
-        public async Task<ControllerEvent> AddOrGetControllerEventAsync(ControllerProfile controllerProfile, string controllerDeviceId, GameControllerEventType eventType, string eventCode)
+        public async Task<ControllerEvent> AddOrGetControllerEventAsync(ControllerProfile controllerProfile, string controllerId, GameControllerEventType eventType, string eventCode)
         {
             using (await _asyncLock.LockAsync())
             {
-                var controllerEvent = controllerProfile.ControllerEvents.FirstOrDefault(ce => ce.ControllerDeviceId == controllerDeviceId && ce.EventType == eventType && ce.EventCode == eventCode);
+                var controllerEvent = controllerProfile.ControllerEvents.FirstOrDefault(ce => ce.ControllerId == controllerId && ce.EventType == eventType && ce.EventCode == eventCode);
                 if (controllerEvent == null)
                 {
-                    controllerEvent = new ControllerEvent { ControllerDeviceId = controllerDeviceId, EventType = eventType, EventCode = eventCode };
+                    controllerEvent = new ControllerEvent { ControllerId = controllerId, EventType = eventType, EventCode = eventCode };
                     await _creationRepository.InsertControllerEventAsync(controllerProfile, controllerEvent);
                 }
 

--- a/BrickController2/BrickController2/CreationManagement/CreationManager.cs
+++ b/BrickController2/BrickController2/CreationManagement/CreationManager.cs
@@ -213,14 +213,14 @@ namespace BrickController2.CreationManagement
             }
         }
 
-        public async Task<ControllerEvent> AddOrGetControllerEventAsync(ControllerProfile controllerProfile, GameControllerEventType eventType, string eventCode)
+        public async Task<ControllerEvent> AddOrGetControllerEventAsync(ControllerProfile controllerProfile, string controllerDeviceId, GameControllerEventType eventType, string eventCode)
         {
             using (await _asyncLock.LockAsync())
             {
-                var controllerEvent = controllerProfile.ControllerEvents.FirstOrDefault(ce => ce.EventType == eventType && ce.EventCode == eventCode);
+                var controllerEvent = controllerProfile.ControllerEvents.FirstOrDefault(ce => ce.ControllerDeviceId == controllerDeviceId && ce.EventType == eventType && ce.EventCode == eventCode);
                 if (controllerEvent == null)
                 {
-                    controllerEvent = new ControllerEvent { EventType = eventType, EventCode = eventCode };
+                    controllerEvent = new ControllerEvent { ControllerDeviceId = controllerDeviceId, EventType = eventType, EventCode = eventCode };
                     await _creationRepository.InsertControllerEventAsync(controllerProfile, controllerEvent);
                 }
 

--- a/BrickController2/BrickController2/CreationManagement/ICreationManager.cs
+++ b/BrickController2/BrickController2/CreationManagement/ICreationManager.cs
@@ -27,7 +27,7 @@ namespace BrickController2.CreationManagement
         Task DeleteControllerProfileAsync(ControllerProfile controllerProfile);
         Task RenameControllerProfileAsync(ControllerProfile controllerProfile, string newName);
 
-        Task<ControllerEvent> AddOrGetControllerEventAsync(ControllerProfile controllerProfile, GameControllerEventType eventType, string eventCode);
+        Task<ControllerEvent> AddOrGetControllerEventAsync(ControllerProfile controllerProfile, string controllerDeviceId, GameControllerEventType eventType, string eventCode);
         Task DeleteControllerEventAsync(ControllerEvent controllerEvent);
 
         Task<ControllerAction> AddOrUpdateControllerActionAsync(

--- a/BrickController2/BrickController2/CreationManagement/ICreationManager.cs
+++ b/BrickController2/BrickController2/CreationManagement/ICreationManager.cs
@@ -27,7 +27,7 @@ namespace BrickController2.CreationManagement
         Task DeleteControllerProfileAsync(ControllerProfile controllerProfile);
         Task RenameControllerProfileAsync(ControllerProfile controllerProfile, string newName);
 
-        Task<ControllerEvent> AddOrGetControllerEventAsync(ControllerProfile controllerProfile, string controllerDeviceId, GameControllerEventType eventType, string eventCode);
+        Task<ControllerEvent> AddOrGetControllerEventAsync(ControllerProfile controllerProfile, string controllerId, GameControllerEventType eventType, string eventCode);
         Task DeleteControllerEventAsync(ControllerEvent controllerEvent);
 
         Task<ControllerAction> AddOrUpdateControllerActionAsync(

--- a/BrickController2/BrickController2/Helpers/GameControllerHelper.cs
+++ b/BrickController2/BrickController2/Helpers/GameControllerHelper.cs
@@ -3,9 +3,15 @@ namespace BrickController2.Helpers
 {
     public static class GameControllerHelper
     {
-        public static string GetControllerDeviceId(int controllerIndex)
+        /// <summary>
+        /// Creates an identifier string for the controller from the given index
+        /// </summary>
+        /// <param name="controllerIndex">zero-based index</param>
+        /// <returns>Identifier</returns>
+        public static string GetControllerIdFromIndex(int controllerIndex)
         {
-            return $"Controller {controllerIndex}";
+            // controllerIndex == 0 -> "Controller 1"
+            return $"Controller {controllerIndex + 1}";
         }
     }
 }

--- a/BrickController2/BrickController2/Helpers/GameControllerHelper.cs
+++ b/BrickController2/BrickController2/Helpers/GameControllerHelper.cs
@@ -1,0 +1,11 @@
+﻿
+namespace BrickController2.Helpers
+{
+    public static class GameControllerHelper
+    {
+        public static string GetControllerDeviceId(int controllerIndex)
+        {
+            return $"Controller {controllerIndex}";
+        }
+    }
+}

--- a/BrickController2/BrickController2/PlatformServices/GameController/GameControllerEventArgs.cs
+++ b/BrickController2/BrickController2/PlatformServices/GameController/GameControllerEventArgs.cs
@@ -23,6 +23,6 @@ namespace BrickController2.PlatformServices.GameController
         }
 
         public IReadOnlyDictionary<(GameControllerEventType EventType, string EventCode), float> ControllerEvents { get; }
-        public string ControllerDeviceId => _controllerId;
+        public string ControllerId => _controllerId;
     }
 }

--- a/BrickController2/BrickController2/PlatformServices/GameController/GameControllerEventArgs.cs
+++ b/BrickController2/BrickController2/PlatformServices/GameController/GameControllerEventArgs.cs
@@ -6,15 +6,19 @@ namespace BrickController2.PlatformServices.GameController
 {
     public class GameControllerEventArgs : EventArgs
     {
-        public GameControllerEventArgs(GameControllerEventType eventType, string eventCode, float value)
+        public readonly string ControllerDeviceId;
+
+        public GameControllerEventArgs(string controllerDeviceId, GameControllerEventType eventType, string eventCode, float value)
         {
+            this.ControllerDeviceId = controllerDeviceId;
             var events = new Dictionary<(GameControllerEventType, string), float>();
             events[(eventType, eventCode)] = value;
             ControllerEvents = events;
         }
 
-        public GameControllerEventArgs(IDictionary<(GameControllerEventType, string), float> events)
+        public GameControllerEventArgs(string controllerDeviceId, IDictionary<(GameControllerEventType, string), float> events)
         {
+            this.ControllerDeviceId = controllerDeviceId;
             ControllerEvents = new ReadOnlyDictionary<(GameControllerEventType, string), float>(events);
         }
 

--- a/BrickController2/BrickController2/PlatformServices/GameController/GameControllerEventArgs.cs
+++ b/BrickController2/BrickController2/PlatformServices/GameController/GameControllerEventArgs.cs
@@ -6,22 +6,23 @@ namespace BrickController2.PlatformServices.GameController
 {
     public class GameControllerEventArgs : EventArgs
     {
-        public readonly string ControllerDeviceId;
+        private readonly string _controllerId;
 
-        public GameControllerEventArgs(string controllerDeviceId, GameControllerEventType eventType, string eventCode, float value)
+        public GameControllerEventArgs(string controllerId, GameControllerEventType eventType, string eventCode, float value)
         {
-            this.ControllerDeviceId = controllerDeviceId;
+            _controllerId = controllerId;
             var events = new Dictionary<(GameControllerEventType, string), float>();
             events[(eventType, eventCode)] = value;
             ControllerEvents = events;
         }
 
-        public GameControllerEventArgs(string controllerDeviceId, IDictionary<(GameControllerEventType, string), float> events)
+        public GameControllerEventArgs(string controllerId, IDictionary<(GameControllerEventType, string), float> events)
         {
-            this.ControllerDeviceId = controllerDeviceId;
+            _controllerId = controllerId;
             ControllerEvents = new ReadOnlyDictionary<(GameControllerEventType, string), float>(events);
         }
 
         public IReadOnlyDictionary<(GameControllerEventType EventType, string EventCode), float> ControllerEvents { get; }
+        public string ControllerDeviceId => _controllerId;
     }
 }

--- a/BrickController2/BrickController2/PlatformServices/GameController/IGameControllerService.cs
+++ b/BrickController2/BrickController2/PlatformServices/GameController/IGameControllerService.cs
@@ -5,5 +5,7 @@ namespace BrickController2.PlatformServices.GameController
     public interface IGameControllerService
     {
         event EventHandler<GameControllerEventArgs> GameControllerEvent;
+
+        bool IsControllerIdSupported { get; }
     }
 }

--- a/BrickController2/BrickController2/Resources/TranslationResources.de.resx
+++ b/BrickController2/BrickController2/Resources/TranslationResources.de.resx
@@ -589,7 +589,7 @@
     <value>Ein neues Controllerprofil erstellen</value>
   </data>
   <data name="AddControllerEvent" xml:space="preserve">
-    <value>Ein neues Controller-event erstellen</value>
+    <value>Ein neues Controller-Event erstellen</value>
   </data>
   <data name="OpenDeviceDetails" xml:space="preserve">
     <value>Die Gerätedetails anzeigen</value>
@@ -609,7 +609,7 @@
   <data name="Add" xml:space="preserve">
     <value>Hinzufügen</value>
   </data>
-  <data name="AddControllerEventWithControllerId" xml:space="preserve">
-    <value>Ein neues Controller-event mit ControllerId erstellen</value>
+  <data name="AddControllerEventForSpecificControllerId" xml:space="preserve">
+    <value>Ein neues Controller-Event für einen bestimmten Controller erstellen</value>
   </data>
 </root>

--- a/BrickController2/BrickController2/Resources/TranslationResources.de.resx
+++ b/BrickController2/BrickController2/Resources/TranslationResources.de.resx
@@ -609,4 +609,7 @@
   <data name="Add" xml:space="preserve">
     <value>Hinzufügen</value>
   </data>
+  <data name="AddControllerEventWithControllerId" xml:space="preserve">
+    <value>Ein neues Controller-event mit ControllerId erstellen</value>
+  </data>
 </root>

--- a/BrickController2/BrickController2/Resources/TranslationResources.hu.resx
+++ b/BrickController2/BrickController2/Resources/TranslationResources.hu.resx
@@ -120,14 +120,23 @@
   <data name="About" xml:space="preserve">
     <value>Névjegy</value>
   </data>
+  <data name="AddControllerEvents" xml:space="preserve">
+    <value>Hozz létre vezérlő eseményt</value>
+  </data>
   <data name="AddControllerProfiles" xml:space="preserve">
     <value>Hozz létre vezérlő profilokat</value>
+  </data>
+  <data name="AddControlPoints" xml:space="preserve">
+    <value>Hozz létre kontrol-pontokat</value>
   </data>
   <data name="AddCreations" xml:space="preserve">
     <value>Hozz létre alkotásokat</value>
   </data>
   <data name="Address" xml:space="preserve">
     <value>Cím</value>
+  </data>
+  <data name="AddSequences" xml:space="preserve">
+    <value>Hozz létre szekvenciákat</value>
   </data>
   <data name="AdvancedSettings" xml:space="preserve">
     <value>Haladó beállítások</value>
@@ -138,6 +147,9 @@
   <data name="AreYouSureToDeleteControllerEvent" xml:space="preserve">
     <value>Biztos törölni szeretnéd ezt a vezérlő eseményt:</value>
   </data>
+  <data name="AreYouSureToDeleteControlPoint" xml:space="preserve">
+    <value>Biztos törölni szeretnéd ezt a kontrol pontot?</value>
+  </data>
   <data name="AreYouSureToDeleteCreation" xml:space="preserve">
     <value>Biztos törölni szeretnéd ezt az alkotást:</value>
   </data>
@@ -147,14 +159,29 @@
   <data name="AreYouSureToDeleteProfile" xml:space="preserve">
     <value>Biztos törölni szeretnéd ezt a profilet:</value>
   </data>
+  <data name="AreYouSureToDeleteSequence" xml:space="preserve">
+    <value>Biztos törölni szeretnéd ezt a szekvenciát:</value>
+  </data>
   <data name="AreYouSureToDeleteThisControllerAcrion" xml:space="preserve">
     <value>Biztos törölni szeretnéd ezt a vezérlő akciót?</value>
+  </data>
+  <data name="AutoCalibrate" xml:space="preserve">
+    <value>Auto kalibrálás</value>
+  </data>
+  <data name="AxisActiveZone" xml:space="preserve">
+    <value>Joy aktív zóna</value>
   </data>
   <data name="AxisCharacteristic" xml:space="preserve">
     <value>Joy karakterisztika</value>
   </data>
   <data name="AxisDeadZone" xml:space="preserve">
     <value>Joy inaktív zóna</value>
+  </data>
+  <data name="AxisType" xml:space="preserve">
+    <value>Joy típusa</value>
+  </data>
+  <data name="Battery" xml:space="preserve">
+    <value>Elem</value>
   </data>
   <data name="Blue" xml:space="preserve">
     <value>Kék</value>
@@ -174,8 +201,14 @@
   <data name="BuWizzOutputLevel" xml:space="preserve">
     <value>BuWizz kimeneti szint</value>
   </data>
+  <data name="Calibrating" xml:space="preserve">
+    <value>Kalibrálás...</value>
+  </data>
   <data name="Cancel" xml:space="preserve">
     <value>Mégse</value>
+  </data>
+  <data name="ChannelSetup" xml:space="preserve">
+    <value>Csatorna beállítás</value>
   </data>
   <data name="ChannelType" xml:space="preserve">
     <value>Csatorna típus</value>
@@ -185,6 +218,9 @@
   </data>
   <data name="Connecting" xml:space="preserve">
     <value>Kapcsolódás...</value>
+  </data>
+  <data name="ConnectingTo" xml:space="preserve">
+    <value>Kapcsolódás: </value>
   </data>
   <data name="Controller" xml:space="preserve">
     <value>Vezérlő</value>
@@ -197,6 +233,9 @@
   </data>
   <data name="ControllerTester" xml:space="preserve">
     <value>Vezérlő teszt</value>
+  </data>
+  <data name="ControlPoint" xml:space="preserve">
+    <value>Kontrol pont</value>
   </data>
   <data name="Create" xml:space="preserve">
     <value>Létrehozás</value>
@@ -215,6 +254,9 @@
   </data>
   <data name="Creations" xml:space="preserve">
     <value>Alkotások</value>
+  </data>
+  <data name="Dark" xml:space="preserve">
+    <value>Sötét</value>
   </data>
   <data name="DefaultProfile" xml:space="preserve">
     <value>Alap profil</value>
@@ -243,6 +285,15 @@
   <data name="Disconnecting" xml:space="preserve">
     <value>Szétkapcsolás...</value>
   </data>
+  <data name="DoYouWantToOverWrite" xml:space="preserve">
+    <value>Felül akarod írni?</value>
+  </data>
+  <data name="DurationMs" xml:space="preserve">
+    <value>Időtartam (ms)</value>
+  </data>
+  <data name="EnterControlPointDuration" xml:space="preserve">
+    <value>Add meg a kontrol point időtartamát 300 és 10000 ms közt.</value>
+  </data>
   <data name="EnterCreationName" xml:space="preserve">
     <value>Adj meg egy alkotás nevet</value>
   </data>
@@ -252,245 +303,23 @@
   <data name="EnterProfileName" xml:space="preserve">
     <value>Adj meg profil nevet</value>
   </data>
+  <data name="EnterSequenceName" xml:space="preserve">
+    <value>Adj meg egy szekvencia nevet</value>
+  </data>
   <data name="Error" xml:space="preserve">
     <value>Hiba</value>
   </data>
   <data name="ErrorDuringScanning" xml:space="preserve">
     <value>Hiba történt szkennelés közben.</value>
   </data>
+  <data name="ExportSuccessful" xml:space="preserve">
+    <value>Sikeres exportálás:</value>
+  </data>
   <data name="ExternalLibraries" xml:space="preserve">
     <value>Külső komponensek</value>
   </data>
   <data name="FailedToConnect" xml:space="preserve">
     <value>Kapcsolódási hiba</value>
-  </data>
-  <data name="IconSet" xml:space="preserve">
-    <value>Ikonok</value>
-  </data>
-  <data name="Inv" xml:space="preserve">
-    <value>Ford.</value>
-  </data>
-  <data name="Invert" xml:space="preserve">
-    <value>Megfordít</value>
-  </data>
-  <data name="Loading" xml:space="preserve">
-    <value>Betöltés...</value>
-  </data>
-  <data name="LocationPermissionIsNeeded" xml:space="preserve">
-    <value>Helyzet hozzáférés szükséges a Bluetooth eléréséhez</value>
-  </data>
-  <data name="MaxOutput" xml:space="preserve">
-    <value>Max kimenet</value>
-  </data>
-  <data name="Missing" xml:space="preserve">
-    <value>Hiányzik</value>
-  </data>
-  <data name="MissingDevices" xml:space="preserve">
-    <value>Az alkotás beállításokban hiányzó eszközök vannak.</value>
-  </data>
-  <data name="No" xml:space="preserve">
-    <value>Nem</value>
-  </data>
-  <data name="NoControllerActions" xml:space="preserve">
-    <value>Ehhez az alkotáshoz nincsenek vezérlő akciók adva.</value>
-  </data>
-  <data name="Ok" xml:space="preserve">
-    <value>Rendben</value>
-  </data>
-  <data name="OutputLevel" xml:space="preserve">
-    <value>Kimeneti szint</value>
-  </data>
-  <data name="PermissionRequest" xml:space="preserve">
-    <value>Hozzáférés kérés</value>
-  </data>
-  <data name="Play" xml:space="preserve">
-    <value>Játék</value>
-  </data>
-  <data name="PressButtonOrMoveJoy" xml:space="preserve">
-    <value>Nyomj meg egy gombot vagy mozgasd az egyik joy-t a vezérlőn!</value>
-  </data>
-  <data name="PressButtonsOrMoveJoys" xml:space="preserve">
-    <value>Nyomj gombokat vagy mozgass joy-okat.</value>
-  </data>
-  <data name="PressScanToDiscoverDevices" xml:space="preserve">
-    <value>Nyomd meg a scan gombot az eszközök felfedezéséhez</value>
-  </data>
-  <data name="ProfileName" xml:space="preserve">
-    <value>Profil neve</value>
-  </data>
-  <data name="ProfileNameCanNotBeEmpty" xml:space="preserve">
-    <value>A profil neve nem lehet üres</value>
-  </data>
-  <data name="Red" xml:space="preserve">
-    <value>Piros</value>
-  </data>
-  <data name="Rename" xml:space="preserve">
-    <value>Átnevezés</value>
-  </data>
-  <data name="Renaming" xml:space="preserve">
-    <value>Átnevezés...</value>
-  </data>
-  <data name="Saving" xml:space="preserve">
-    <value>Mentés...</value>
-  </data>
-  <data name="ScanForDevicesFirst" xml:space="preserve">
-    <value>Keress rá az eszközökre vezérlő esemény hozzáadása előtt!</value>
-  </data>
-  <data name="Scanning" xml:space="preserve">
-    <value>Szkennelés...</value>
-  </data>
-  <data name="SearchingForDevices" xml:space="preserve">
-    <value>Eszközök keresése.</value>
-  </data>
-  <data name="SelectDevice" xml:space="preserve">
-    <value>Válassz egy eszközt</value>
-  </data>
-  <data name="SelectDeviceBeforeSaving" xml:space="preserve">
-    <value>Válassz egy eszközt mentés előtt!</value>
-  </data>
-  <data name="ServoAngle" xml:space="preserve">
-    <value>Szervó tart.</value>
-  </data>
-  <data name="ShortChannel" xml:space="preserve">
-    <value>Cs</value>
-  </data>
-  <data name="TurnOnBluetoothToConnect" xml:space="preserve">
-    <value>Bluetooth eszköz kapcsolódáshoz kapcsold be a bluetooth-t</value>
-  </data>
-  <data name="TurnOnBluetoothToConnectBluetoothDevices" xml:space="preserve">
-    <value>Bluetooth eszköz(ök) kapcsolódásához kapcsold be a bluetooth-t</value>
-  </data>
-  <data name="Version" xml:space="preserve">
-    <value>Verzió</value>
-  </data>
-  <data name="Warning" xml:space="preserve">
-    <value>Figyelmeztetés</value>
-  </data>
-  <data name="Yes" xml:space="preserve">
-    <value>Igen</value>
-  </data>
-  <data name="AutoCalibrate" xml:space="preserve">
-    <value>Auto kalibrálás</value>
-  </data>
-  <data name="Calibrating" xml:space="preserve">
-    <value>Kalibrálás...</value>
-  </data>
-  <data name="ChannelSetup" xml:space="preserve">
-    <value>Csatorna beállítás</value>
-  </data>
-  <data name="Reset" xml:space="preserve">
-    <value>Átállít</value>
-  </data>
-  <data name="Reseting" xml:space="preserve">
-    <value>Átállítás...</value>
-  </data>
-  <data name="StepperAngle" xml:space="preserve">
-    <value>Léptetési szög</value>
-  </data>
-  <data name="Battery" xml:space="preserve">
-    <value>Elem</value>
-  </data>
-  <data name="AddSequences" xml:space="preserve">
-    <value>Hozz létre szekvenciákat</value>
-  </data>
-  <data name="AreYouSureToDeleteSequence" xml:space="preserve">
-    <value>Biztos törölni szeretnéd ezt a szekvenciát:</value>
-  </data>
-  <data name="EnterSequenceName" xml:space="preserve">
-    <value>Adj meg egy szekvencia nevet</value>
-  </data>
-  <data name="Sequence" xml:space="preserve">
-    <value>Szekvencia</value>
-  </data>
-  <data name="SequenceName" xml:space="preserve">
-    <value>Szekvencia neve</value>
-  </data>
-  <data name="SequenceNameCanNotBeEmpty" xml:space="preserve">
-    <value>A szekvencia neve nem lehet üres</value>
-  </data>
-  <data name="SequenceNameIsUsed" xml:space="preserve">
-    <value>Ez a szekvencia név már foglalt</value>
-  </data>
-  <data name="Sequences" xml:space="preserve">
-    <value>Szekvenciák</value>
-  </data>
-  <data name="AddControllerEvents" xml:space="preserve">
-    <value>Hozz létre vezérlő eseményt</value>
-  </data>
-  <data name="AddControlPoints" xml:space="preserve">
-    <value>Hozz létre kontrol-pontokat</value>
-  </data>
-  <data name="AreYouSureToDeleteControlPoint" xml:space="preserve">
-    <value>Biztos törölni szeretnéd ezt a kontrol pontot?</value>
-  </data>
-  <data name="DurationMs" xml:space="preserve">
-    <value>Időtartam (ms)</value>
-  </data>
-  <data name="ValuePercent" xml:space="preserve">
-    <value>Érték (%)</value>
-  </data>
-  <data name="ControlPoint" xml:space="preserve">
-    <value>Kontrol pont</value>
-  </data>
-  <data name="EnterControlPointDuration" xml:space="preserve">
-    <value>Add meg a kontrol point időtartamát 300 és 10000 ms közt.</value>
-  </data>
-  <data name="Value" xml:space="preserve">
-    <value>Érték</value>
-  </data>
-  <data name="ValueMustBeNumeric" xml:space="preserve">
-    <value>Az értéknek számnak kell lennie.</value>
-  </data>
-  <data name="ValueOutOfRange" xml:space="preserve">
-    <value>Az érték a határokon kívül van.</value>
-  </data>
-  <data name="SelectSequence" xml:space="preserve">
-    <value>Válassz egy szekvenciát</value>
-  </data>
-  <data name="Interpolate" xml:space="preserve">
-    <value>Interpolált</value>
-  </data>
-  <data name="Loop" xml:space="preserve">
-    <value>Ismétlődő</value>
-  </data>
-  <data name="MissingSequence" xml:space="preserve">
-    <value>Hiányzó szekvencia</value>
-  </data>
-  <data name="NoSequences" xml:space="preserve">
-    <value>Nincsenek szekvenciák.</value>
-  </data>
-  <data name="Dark" xml:space="preserve">
-    <value>Sötét</value>
-  </data>
-  <data name="Light" xml:space="preserve">
-    <value>Világos</value>
-  </data>
-  <data name="Settings" xml:space="preserve">
-    <value>Beállítások</value>
-  </data>
-  <data name="System" xml:space="preserve">
-    <value>Rendszer</value>
-  </data>
-  <data name="Theme" xml:space="preserve">
-    <value>Téma</value>
-  </data>
-  <data name="AxisActiveZone" xml:space="preserve">
-    <value>Joy aktív zóna</value>
-  </data>
-  <data name="AxisType" xml:space="preserve">
-    <value>Joy típusa</value>
-  </data>
-  <data name="ConnectingTo" xml:space="preserve">
-    <value>Kapcsolódás: </value>
-  </data>
-  <data name="ProfileLoadSaveWillNotBeAvailable" xml:space="preserve">
-    <value>Profilok kimentése és betöltése nem lesz elérhető.</value>
-  </data>
-  <data name="DoYouWantToOverWrite" xml:space="preserve">
-    <value>Felül akarod írni?</value>
-  </data>
-  <data name="ExportSuccessful" xml:space="preserve">
-    <value>Sikeres exportálás:</value>
   </data>
   <data name="FailedToExportControllerProfile" xml:space="preserve">
     <value>Nem sikerült exportálni a kontroller profilt.</value>
@@ -513,8 +342,50 @@
   <data name="FileAlreadyExists" xml:space="preserve">
     <value>A file már létezik</value>
   </data>
+  <data name="IconSet" xml:space="preserve">
+    <value>Ikonok</value>
+  </data>
   <data name="Information" xml:space="preserve">
     <value>Információ</value>
+  </data>
+  <data name="Interpolate" xml:space="preserve">
+    <value>Interpolált</value>
+  </data>
+  <data name="Inv" xml:space="preserve">
+    <value>Ford.</value>
+  </data>
+  <data name="Invert" xml:space="preserve">
+    <value>Megfordít</value>
+  </data>
+  <data name="Light" xml:space="preserve">
+    <value>Világos</value>
+  </data>
+  <data name="Loading" xml:space="preserve">
+    <value>Betöltés...</value>
+  </data>
+  <data name="LocationPermissionIsNeeded" xml:space="preserve">
+    <value>Helyzet hozzáférés szükséges a Bluetooth eléréséhez</value>
+  </data>
+  <data name="Loop" xml:space="preserve">
+    <value>Ismétlődő</value>
+  </data>
+  <data name="MaxOutput" xml:space="preserve">
+    <value>Max kimenet</value>
+  </data>
+  <data name="Missing" xml:space="preserve">
+    <value>Hiányzik</value>
+  </data>
+  <data name="MissingDevices" xml:space="preserve">
+    <value>Az alkotás beállításokban hiányzó eszközök vannak.</value>
+  </data>
+  <data name="MissingSequence" xml:space="preserve">
+    <value>Hiányzó szekvencia</value>
+  </data>
+  <data name="No" xml:space="preserve">
+    <value>Nem</value>
+  </data>
+  <data name="NoControllerActions" xml:space="preserve">
+    <value>Ehhez az alkotáshoz nincsenek vezérlő akciók adva.</value>
   </data>
   <data name="NoCreationsToImport" xml:space="preserve">
     <value>Nincsenek beimportálható alkotások.</value>
@@ -522,7 +393,136 @@
   <data name="NoProfilesToImport" xml:space="preserve">
     <value>Nincsenek beimportálható kontroller profilok.</value>
   </data>
+  <data name="NoSequences" xml:space="preserve">
+    <value>Nincsenek szekvenciák.</value>
+  </data>
   <data name="NoSequencesToImport" xml:space="preserve">
     <value>Nincsenek beimportálható szekvenciák.</value>
+  </data>
+  <data name="Ok" xml:space="preserve">
+    <value>Rendben</value>
+  </data>
+  <data name="OutputLevel" xml:space="preserve">
+    <value>Kimeneti szint</value>
+  </data>
+  <data name="PermissionRequest" xml:space="preserve">
+    <value>Hozzáférés kérés</value>
+  </data>
+  <data name="Play" xml:space="preserve">
+    <value>Játék</value>
+  </data>
+  <data name="PressButtonOrMoveJoy" xml:space="preserve">
+    <value>Nyomj meg egy gombot vagy mozgasd az egyik joy-t a vezérlőn!</value>
+  </data>
+  <data name="PressButtonsOrMoveJoys" xml:space="preserve">
+    <value>Nyomj gombokat vagy mozgass joy-okat.</value>
+  </data>
+  <data name="PressScanToDiscoverDevices" xml:space="preserve">
+    <value>Nyomd meg a scan gombot az eszközök felfedezéséhez</value>
+  </data>
+  <data name="ProfileLoadSaveWillNotBeAvailable" xml:space="preserve">
+    <value>Profilok kimentése és betöltése nem lesz elérhető.</value>
+  </data>
+  <data name="ProfileName" xml:space="preserve">
+    <value>Profil neve</value>
+  </data>
+  <data name="ProfileNameCanNotBeEmpty" xml:space="preserve">
+    <value>A profil neve nem lehet üres</value>
+  </data>
+  <data name="Red" xml:space="preserve">
+    <value>Piros</value>
+  </data>
+  <data name="Rename" xml:space="preserve">
+    <value>Átnevezés</value>
+  </data>
+  <data name="Renaming" xml:space="preserve">
+    <value>Átnevezés...</value>
+  </data>
+  <data name="Reset" xml:space="preserve">
+    <value>Átállít</value>
+  </data>
+  <data name="Reseting" xml:space="preserve">
+    <value>Átállítás...</value>
+  </data>
+  <data name="Saving" xml:space="preserve">
+    <value>Mentés...</value>
+  </data>
+  <data name="ScanForDevicesFirst" xml:space="preserve">
+    <value>Keress rá az eszközökre vezérlő esemény hozzáadása előtt!</value>
+  </data>
+  <data name="Scanning" xml:space="preserve">
+    <value>Szkennelés...</value>
+  </data>
+  <data name="SearchingForDevices" xml:space="preserve">
+    <value>Eszközök keresése.</value>
+  </data>
+  <data name="SelectDevice" xml:space="preserve">
+    <value>Válassz egy eszközt</value>
+  </data>
+  <data name="SelectDeviceBeforeSaving" xml:space="preserve">
+    <value>Válassz egy eszközt mentés előtt!</value>
+  </data>
+  <data name="SelectSequence" xml:space="preserve">
+    <value>Válassz egy szekvenciát</value>
+  </data>
+  <data name="Sequence" xml:space="preserve">
+    <value>Szekvencia</value>
+  </data>
+  <data name="SequenceName" xml:space="preserve">
+    <value>Szekvencia neve</value>
+  </data>
+  <data name="SequenceNameCanNotBeEmpty" xml:space="preserve">
+    <value>A szekvencia neve nem lehet üres</value>
+  </data>
+  <data name="SequenceNameIsUsed" xml:space="preserve">
+    <value>Ez a szekvencia név már foglalt</value>
+  </data>
+  <data name="Sequences" xml:space="preserve">
+    <value>Szekvenciák</value>
+  </data>
+  <data name="ServoAngle" xml:space="preserve">
+    <value>Szervó tart.</value>
+  </data>
+  <data name="Settings" xml:space="preserve">
+    <value>Beállítások</value>
+  </data>
+  <data name="ShortChannel" xml:space="preserve">
+    <value>Cs</value>
+  </data>
+  <data name="StepperAngle" xml:space="preserve">
+    <value>Léptetési szög</value>
+  </data>
+  <data name="System" xml:space="preserve">
+    <value>Rendszer</value>
+  </data>
+  <data name="Theme" xml:space="preserve">
+    <value>Téma</value>
+  </data>
+  <data name="TurnOnBluetoothToConnect" xml:space="preserve">
+    <value>Bluetooth eszköz kapcsolódáshoz kapcsold be a bluetooth-t</value>
+  </data>
+  <data name="TurnOnBluetoothToConnectBluetoothDevices" xml:space="preserve">
+    <value>Bluetooth eszköz(ök) kapcsolódásához kapcsold be a bluetooth-t</value>
+  </data>
+  <data name="Value" xml:space="preserve">
+    <value>Érték</value>
+  </data>
+  <data name="ValueMustBeNumeric" xml:space="preserve">
+    <value>Az értéknek számnak kell lennie.</value>
+  </data>
+  <data name="ValueOutOfRange" xml:space="preserve">
+    <value>Az érték a határokon kívül van.</value>
+  </data>
+  <data name="ValuePercent" xml:space="preserve">
+    <value>Érték (%)</value>
+  </data>
+  <data name="Version" xml:space="preserve">
+    <value>Verzió</value>
+  </data>
+  <data name="Warning" xml:space="preserve">
+    <value>Figyelmeztetés</value>
+  </data>
+  <data name="Yes" xml:space="preserve">
+    <value>Igen</value>
   </data>
 </root>

--- a/BrickController2/BrickController2/Resources/TranslationResources.resx
+++ b/BrickController2/BrickController2/Resources/TranslationResources.resx
@@ -609,4 +609,7 @@
   <data name="Add" xml:space="preserve">
     <value>Add</value>
   </data>
+  <data name="AddControllerEventWithControllerId" xml:space="preserve">
+    <value>Add a new controller event with ControllerId</value>
+  </data>
 </root>

--- a/BrickController2/BrickController2/Resources/TranslationResources.resx
+++ b/BrickController2/BrickController2/Resources/TranslationResources.resx
@@ -609,7 +609,7 @@
   <data name="Add" xml:space="preserve">
     <value>Add</value>
   </data>
-  <data name="AddControllerEventWithControllerId" xml:space="preserve">
-    <value>Add a new controller event with ControllerId</value>
+  <data name="AddControllerEventForSpecificControllerId" xml:space="preserve">
+    <value>Add a new controller event for specific game controller</value>
   </data>
 </root>

--- a/BrickController2/BrickController2/UI/Controls/Dialogs.xaml.cs
+++ b/BrickController2/BrickController2/UI/Controls/Dialogs.xaml.cs
@@ -282,7 +282,7 @@ namespace BrickController2.UI.Controls
 
                         var gameControllerEventType = controllerEvent.Key.EventType;
                         var gameControllerEventCode = controllerEvent.Key.EventCode;
-                        tcs.TrySetResult(new GameControllerEventDialogResult(true, args.ControllerDeviceId, gameControllerEventType, gameControllerEventCode));
+                        tcs.TrySetResult(new GameControllerEventDialogResult(true, args.ControllerId, gameControllerEventType, gameControllerEventCode));
                         return;
                     }
                 }

--- a/BrickController2/BrickController2/UI/Controls/Dialogs.xaml.cs
+++ b/BrickController2/BrickController2/UI/Controls/Dialogs.xaml.cs
@@ -246,7 +246,7 @@ namespace BrickController2.UI.Controls
                 GameControllerEventDialogCancelButton.Clicked -= buttonHandler!;
                 GameControllerService!.GameControllerEvent -= gameControllerEventHandler!;
                 HideViewImmediately(GameControllerEventDialog);
-                tcs.TrySetResult(new GameControllerEventDialogResult(false, GameControllerEventType.Axis, string.Empty));
+                tcs.TrySetResult(new GameControllerEventDialogResult(false, GameControllerEventDialogResult.NoControllerDeviceId, GameControllerEventType.Axis, string.Empty));
             }))
             {
                 await ShowView(GameControllerEventDialog);
@@ -261,7 +261,7 @@ namespace BrickController2.UI.Controls
                 GameControllerEventDialogCancelButton.Clicked -= buttonHandler!;
                 GameControllerService!.GameControllerEvent -= gameControllerEventHandler!;
                 await HideView(GameControllerEventDialog);
-                tcs.TrySetResult(new GameControllerEventDialogResult(false, GameControllerEventType.Axis, string.Empty));
+                tcs.TrySetResult(new GameControllerEventDialogResult(false, GameControllerEventDialogResult.NoControllerDeviceId, GameControllerEventType.Axis, string.Empty));
             }
 
             async void gameControllerEventHandler(object sender, GameControllerEventArgs args)
@@ -282,7 +282,7 @@ namespace BrickController2.UI.Controls
 
                         var gameControllerEventType = controllerEvent.Key.EventType;
                         var gameControllerEventCode = controllerEvent.Key.EventCode;
-                        tcs.TrySetResult(new GameControllerEventDialogResult(true, gameControllerEventType, gameControllerEventCode));
+                        tcs.TrySetResult(new GameControllerEventDialogResult(true, args.ControllerDeviceId, gameControllerEventType, gameControllerEventCode));
                         return;
                     }
                 }

--- a/BrickController2/BrickController2/UI/Controls/Dialogs.xaml.cs
+++ b/BrickController2/BrickController2/UI/Controls/Dialogs.xaml.cs
@@ -246,7 +246,7 @@ namespace BrickController2.UI.Controls
                 GameControllerEventDialogCancelButton.Clicked -= buttonHandler!;
                 GameControllerService!.GameControllerEvent -= gameControllerEventHandler!;
                 HideViewImmediately(GameControllerEventDialog);
-                tcs.TrySetResult(new GameControllerEventDialogResult(false, GameControllerEventDialogResult.NoControllerDeviceId, GameControllerEventType.Axis, string.Empty));
+                tcs.TrySetResult(new GameControllerEventDialogResult(false, GameControllerEventType.Axis, string.Empty));
             }))
             {
                 await ShowView(GameControllerEventDialog);
@@ -261,7 +261,7 @@ namespace BrickController2.UI.Controls
                 GameControllerEventDialogCancelButton.Clicked -= buttonHandler!;
                 GameControllerService!.GameControllerEvent -= gameControllerEventHandler!;
                 await HideView(GameControllerEventDialog);
-                tcs.TrySetResult(new GameControllerEventDialogResult(false, GameControllerEventDialogResult.NoControllerDeviceId, GameControllerEventType.Axis, string.Empty));
+                tcs.TrySetResult(new GameControllerEventDialogResult(false, GameControllerEventType.Axis, string.Empty));
             }
 
             async void gameControllerEventHandler(object sender, GameControllerEventArgs args)

--- a/BrickController2/BrickController2/UI/Converters/IsStringNotNullOrEmptyConverter.cs
+++ b/BrickController2/BrickController2/UI/Converters/IsStringNotNullOrEmptyConverter.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Globalization;
+using Microsoft.Maui.Controls;
+
+namespace BrickController2.UI.Converters
+{
+    public class IsStringNotNullOrEmptyConverter : IValueConverter
+    {
+        public object Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
+        {
+            var stringValue = (string)value!;
+            return !string.IsNullOrEmpty(stringValue);
+        }
+
+        public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/BrickController2/BrickController2/UI/Pages/ControllerProfilePage.xaml
+++ b/BrickController2/BrickController2/UI/Pages/ControllerProfilePage.xaml
@@ -69,7 +69,7 @@
                                     <controls:ColorImage Grid.Column="0" Icon="{Binding ControllerEvent.EventType, Converter={StaticResource EventTypeToImage}}" Color="{DynamicResource PrimaryColor}" WidthRequest="30" HeightRequest="30" VerticalOptions="Center"/>
                                     <StackLayout Grid.Column="1" Orientation="Horizontal" VerticalOptions="Center">
                                         <Label Text="{Binding ControllerEvent.ControllerId}" FontSize="Large" FontAttributes="Bold" IsVisible="{Binding ControllerEvent.ControllerId, Converter={StaticResource IsStringNotNullOrEmptyConverter}}"/>
-                                        <Label Text=" - " FontSize="Large" FontAttributes="Bold" IsVisible="{Binding ControllerEvent.ControllerId, Converter={StaticResource IsStringNotNullOrEmptyConverter}}"/>
+                                        <Label Text=" - " FontSize="Large" IsVisible="{Binding ControllerEvent.ControllerId, Converter={StaticResource IsStringNotNullOrEmptyConverter}}"/>
                                         <Label Text="{Binding ControllerEvent.EventCode}" FontSize="Large" FontAttributes="Bold"/>
                                     </StackLayout>
                                 </Grid>

--- a/BrickController2/BrickController2/UI/Pages/ControllerProfilePage.xaml
+++ b/BrickController2/BrickController2/UI/Pages/ControllerProfilePage.xaml
@@ -115,7 +115,7 @@
                     </CollectionView.EmptyView>
                 </CollectionView>
 
-                <controls:FloatingActionButton Grid.Row="0" Grid.RowSpan="2" Style="{StaticResource FloatingActionButtonStyle}" Icon="playlist_add" Command="{Binding AddControllerEventWithControllerIdCommand}" ToolTipProperties.Text="{extensions:Translate AddControllerEventWithControllerId}" HorizontalOptions="Center" VerticalOptions="End" Margin="10" IsVisible="{Binding IsControllerIdSupported}"/>
+                <controls:FloatingActionButton Grid.Row="0" Grid.RowSpan="2" Style="{StaticResource FloatingActionButtonStyle}" Icon="playlist_add" Command="{Binding AddControllerEventWithControllerIdCommand}" ToolTipProperties.Text="{extensions:Translate AddControllerEventWithControllerId}" HorizontalOptions="End" VerticalOptions="End" Margin="0,0,100,10" IsVisible="{Binding IsControllerIdSupported}"/>
                 <controls:FloatingActionButton Grid.Row="0" Grid.RowSpan="2" Style="{StaticResource FloatingActionButtonStyle}" Icon="add" Command="{Binding AddControllerEventCommand}" ToolTipProperties.Text="{extensions:Translate AddControllerEvent}" HorizontalOptions="End" VerticalOptions="End" Margin="10"/>
 
             </Grid>

--- a/BrickController2/BrickController2/UI/Pages/ControllerProfilePage.xaml
+++ b/BrickController2/BrickController2/UI/Pages/ControllerProfilePage.xaml
@@ -115,7 +115,7 @@
                     </CollectionView.EmptyView>
                 </CollectionView>
 
-                <controls:FloatingActionButton Grid.Row="0" Grid.RowSpan="2" Style="{StaticResource FloatingActionButtonStyle}" Icon="playlist_add" Command="{Binding AddControllerEventWithControllerIdCommand}" ToolTipProperties.Text="{extensions:Translate AddControllerEventWithControllerId}" HorizontalOptions="End" VerticalOptions="End" Margin="0,0,100,10" IsVisible="{Binding IsControllerIdSupported}"/>
+                <controls:FloatingActionButton Grid.Row="0" Grid.RowSpan="2" Style="{StaticResource FloatingActionButtonStyle}" Icon="playlist_add" Command="{Binding AddControllerEventForSpecificControllerIdCommand}" ToolTipProperties.Text="{extensions:Translate AddControllerEventForSpecificControllerId}" HorizontalOptions="End" VerticalOptions="End" Margin="0,0,100,10" IsVisible="{Binding IsControllerIdSupported}"/>
                 <controls:FloatingActionButton Grid.Row="0" Grid.RowSpan="2" Style="{StaticResource FloatingActionButtonStyle}" Icon="add" Command="{Binding AddControllerEventCommand}" ToolTipProperties.Text="{extensions:Translate AddControllerEvent}" HorizontalOptions="End" VerticalOptions="End" Margin="10"/>
 
             </Grid>

--- a/BrickController2/BrickController2/UI/Pages/ControllerProfilePage.xaml
+++ b/BrickController2/BrickController2/UI/Pages/ControllerProfilePage.xaml
@@ -68,9 +68,9 @@
                                     </Grid.ColumnDefinitions>
                                     <controls:ColorImage Grid.Column="0" Icon="{Binding ControllerEvent.EventType, Converter={StaticResource EventTypeToImage}}" Color="{DynamicResource PrimaryColor}" WidthRequest="30" HeightRequest="30" VerticalOptions="Center"/>
                                     <StackLayout Grid.Column="1" Orientation="Horizontal" VerticalOptions="Center">
-                                        <Label Text="{Binding ControllerEvent.ControllerId}" FontSize="Large" FontAttributes="Bold" IsVisible="{Binding ControllerEvent.ControllerId, Converter={StaticResource IsStringNotNullOrEmptyConverter}}"/>
-                                        <Label Text=" - " FontSize="Large" IsVisible="{Binding ControllerEvent.ControllerId, Converter={StaticResource IsStringNotNullOrEmptyConverter}}"/>
                                         <Label Text="{Binding ControllerEvent.EventCode}" FontSize="Large" FontAttributes="Bold"/>
+                                        <Label Text="-" FontSize="Large" IsVisible="{Binding ControllerEvent.ControllerId, Converter={StaticResource IsStringNotNullOrEmptyConverter}}" Margin="5,0,5,0"/>
+                                        <Label Text="{Binding ControllerEvent.ControllerId}" FontSize="Large" FontAttributes="Bold" IsVisible="{Binding ControllerEvent.ControllerId, Converter={StaticResource IsStringNotNullOrEmptyConverter}}"/>
                                     </StackLayout>
                                 </Grid>
                             </SwipeView>

--- a/BrickController2/BrickController2/UI/Pages/ControllerProfilePage.xaml
+++ b/BrickController2/BrickController2/UI/Pages/ControllerProfilePage.xaml
@@ -17,6 +17,7 @@
         <ResourceDictionary>
             <converters:GameControllerEventTypeToImageConverter x:Key="EventTypeToImage"/>
             <converters:InverseBoolConverter x:Key="InverseBool"/>
+            <converters:IsStringNotNullOrEmptyConverter x:Key="IsStringNotNullOrEmptyConverter" />
         </ResourceDictionary>
     </local:PageBase.Resources>
 
@@ -67,8 +68,8 @@
                                     </Grid.ColumnDefinitions>
                                     <controls:ColorImage Grid.Column="0" Icon="{Binding ControllerEvent.EventType, Converter={StaticResource EventTypeToImage}}" Color="{DynamicResource PrimaryColor}" WidthRequest="30" HeightRequest="30" VerticalOptions="Center"/>
                                     <StackLayout Grid.Column="1" Orientation="Horizontal" VerticalOptions="Center">
-                                        <Label Text="{Binding ControllerEvent.ControllerId}" FontSize="Large" FontAttributes="Bold"/>
-                                        <Label Text=" - " FontSize="Large" FontAttributes="Bold"/>
+                                        <Label Text="{Binding ControllerEvent.ControllerId}" FontSize="Large" FontAttributes="Bold" IsVisible="{Binding ControllerEvent.ControllerId, Converter={StaticResource IsStringNotNullOrEmptyConverter}}"/>
+                                        <Label Text=" - " FontSize="Large" FontAttributes="Bold" IsVisible="{Binding ControllerEvent.ControllerId, Converter={StaticResource IsStringNotNullOrEmptyConverter}}"/>
                                         <Label Text="{Binding ControllerEvent.EventCode}" FontSize="Large" FontAttributes="Bold"/>
                                     </StackLayout>
                                 </Grid>

--- a/BrickController2/BrickController2/UI/Pages/ControllerProfilePage.xaml
+++ b/BrickController2/BrickController2/UI/Pages/ControllerProfilePage.xaml
@@ -115,7 +115,7 @@
                     </CollectionView.EmptyView>
                 </CollectionView>
 
-                <controls:FloatingActionButton Grid.Row="0" Grid.RowSpan="2" Style="{StaticResource FloatingActionButtonStyle}" Icon="playlist_add" Command="{Binding AddControllerEventWithControllerIdCommand}" ToolTipProperties.Text="{extensions:Translate AddControllerEventWithControllerId}" HorizontalOptions="Center" VerticalOptions="End" Margin="10"/>
+                <controls:FloatingActionButton Grid.Row="0" Grid.RowSpan="2" Style="{StaticResource FloatingActionButtonStyle}" Icon="playlist_add" Command="{Binding AddControllerEventWithControllerIdCommand}" ToolTipProperties.Text="{extensions:Translate AddControllerEventWithControllerId}" HorizontalOptions="Center" VerticalOptions="End" Margin="10" IsVisible="{Binding IsControllerIdSupported}"/>
                 <controls:FloatingActionButton Grid.Row="0" Grid.RowSpan="2" Style="{StaticResource FloatingActionButtonStyle}" Icon="add" Command="{Binding AddControllerEventCommand}" ToolTipProperties.Text="{extensions:Translate AddControllerEvent}" HorizontalOptions="End" VerticalOptions="End" Margin="10"/>
 
             </Grid>

--- a/BrickController2/BrickController2/UI/Pages/ControllerProfilePage.xaml
+++ b/BrickController2/BrickController2/UI/Pages/ControllerProfilePage.xaml
@@ -67,7 +67,7 @@
                                     </Grid.ColumnDefinitions>
                                     <controls:ColorImage Grid.Column="0" Icon="{Binding ControllerEvent.EventType, Converter={StaticResource EventTypeToImage}}" Color="{DynamicResource PrimaryColor}" WidthRequest="30" HeightRequest="30" VerticalOptions="Center"/>
                                     <StackLayout Grid.Column="1" Orientation="Horizontal" VerticalOptions="Center">
-                                        <Label Text="{Binding ControllerEvent.ControllerDeviceId}" FontSize="Large" FontAttributes="Bold"/>
+                                        <Label Text="{Binding ControllerEvent.ControllerId}" FontSize="Large" FontAttributes="Bold"/>
                                         <Label Text=" - " FontSize="Large" FontAttributes="Bold"/>
                                         <Label Text="{Binding ControllerEvent.EventCode}" FontSize="Large" FontAttributes="Bold"/>
                                     </StackLayout>

--- a/BrickController2/BrickController2/UI/Pages/ControllerProfilePage.xaml
+++ b/BrickController2/BrickController2/UI/Pages/ControllerProfilePage.xaml
@@ -67,6 +67,7 @@
                                     </Grid.ColumnDefinitions>
                                     <controls:ColorImage Grid.Column="0" Icon="{Binding ControllerEvent.EventType, Converter={StaticResource EventTypeToImage}}" Color="{DynamicResource PrimaryColor}" WidthRequest="30" HeightRequest="30" VerticalOptions="Center"/>
                                     <StackLayout Grid.Column="1" Orientation="Horizontal" VerticalOptions="Center">
+                                        <Label Text="{Binding ControllerEvent.ControllerDeviceId}" FontSize="Large" FontAttributes="Bold"/>
                                         <Label Text="{Binding ControllerEvent.EventCode}" FontSize="Large" FontAttributes="Bold"/>
                                     </StackLayout>
                                 </Grid>

--- a/BrickController2/BrickController2/UI/Pages/ControllerProfilePage.xaml
+++ b/BrickController2/BrickController2/UI/Pages/ControllerProfilePage.xaml
@@ -115,6 +115,7 @@
                     </CollectionView.EmptyView>
                 </CollectionView>
 
+                <controls:FloatingActionButton Grid.Row="0" Grid.RowSpan="2" Style="{StaticResource FloatingActionButtonStyle}" Icon="playlist_add" Command="{Binding AddControllerEventWithControllerIdCommand}" ToolTipProperties.Text="{extensions:Translate AddControllerEventWithControllerId}" HorizontalOptions="Center" VerticalOptions="End" Margin="10"/>
                 <controls:FloatingActionButton Grid.Row="0" Grid.RowSpan="2" Style="{StaticResource FloatingActionButtonStyle}" Icon="add" Command="{Binding AddControllerEventCommand}" ToolTipProperties.Text="{extensions:Translate AddControllerEvent}" HorizontalOptions="End" VerticalOptions="End" Margin="10"/>
 
             </Grid>

--- a/BrickController2/BrickController2/UI/Pages/ControllerProfilePage.xaml
+++ b/BrickController2/BrickController2/UI/Pages/ControllerProfilePage.xaml
@@ -68,6 +68,7 @@
                                     <controls:ColorImage Grid.Column="0" Icon="{Binding ControllerEvent.EventType, Converter={StaticResource EventTypeToImage}}" Color="{DynamicResource PrimaryColor}" WidthRequest="30" HeightRequest="30" VerticalOptions="Center"/>
                                     <StackLayout Grid.Column="1" Orientation="Horizontal" VerticalOptions="Center">
                                         <Label Text="{Binding ControllerEvent.ControllerDeviceId}" FontSize="Large" FontAttributes="Bold"/>
+                                        <Label Text=" - " FontSize="Large" FontAttributes="Bold"/>
                                         <Label Text="{Binding ControllerEvent.EventCode}" FontSize="Large" FontAttributes="Bold"/>
                                     </StackLayout>
                                 </Grid>

--- a/BrickController2/BrickController2/UI/Pages/ControllerTesterPage.xaml
+++ b/BrickController2/BrickController2/UI/Pages/ControllerTesterPage.xaml
@@ -6,6 +6,7 @@
     xmlns:extensions="clr-namespace:BrickController2.UI.MarkupExtensions"
     xmlns:ios="clr-namespace:Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific;assembly=Microsoft.Maui.Controls"
     xmlns:local="clr-namespace:BrickController2.UI.Pages"
+    xmlns:vm="clr-namespace:BrickController2.UI.ViewModels"
     x:Class="BrickController2.UI.Pages.ControllerTesterPage"
     Title="{extensions:Translate ControllerTester}"
     ios:Page.UseSafeArea="True"
@@ -27,13 +28,13 @@
                     <CollectionView.ItemTemplate>
                         <DataTemplate>
                             <StackLayout Orientation="Vertical" Padding="10">
-                                <StackLayout Orientation="Horizontal">
-                                    <Label Text="ControllerId: " FontSize="Medium"/>
+                                <StackLayout Orientation="Horizontal" IsVisible="{Binding Source={RelativeSource AncestorType={x:Type vm:ControllerTesterPageViewModel}}, Path=IsControllerIdSupported}">
+                                    <Label Text="ControllerId:" FontSize="Medium" Margin="0,0,5,0"/>
                                     <Label Text="{Binding ControllerId}" FontSize="Medium"/>
                                 </StackLayout>
                                 <StackLayout Orientation="Horizontal">
                                     <Label Text="{Binding EventCode}" FontSize="Large" FontAttributes="Bold"/>
-                                    <Label Text=" - " FontSize="Large"/>
+                                    <Label Text="-" FontSize="Large" Margin="5,0,5,0"/>
                                     <Label Text="{Binding Value}" FontSize="Large"/>
                                 </StackLayout>
                                 <Label Text="{Binding EventType}" FontSize="Medium"/>

--- a/BrickController2/BrickController2/UI/Pages/ControllerTesterPage.xaml
+++ b/BrickController2/BrickController2/UI/Pages/ControllerTesterPage.xaml
@@ -28,6 +28,10 @@
                         <DataTemplate>
                             <StackLayout Orientation="Vertical" Padding="10">
                                 <StackLayout Orientation="Horizontal">
+                                    <Label Text="ControllerId: " FontSize="Medium"/>
+                                    <Label Text="{Binding ControllerDeviceId}" FontSize="Medium"/>
+                                </StackLayout>
+                                <StackLayout Orientation="Horizontal">
                                     <Label Text="{Binding EventCode}" FontSize="Large" FontAttributes="Bold"/>
                                     <Label Text=" - " FontSize="Large"/>
                                     <Label Text="{Binding Value}" FontSize="Large"/>

--- a/BrickController2/BrickController2/UI/Pages/ControllerTesterPage.xaml
+++ b/BrickController2/BrickController2/UI/Pages/ControllerTesterPage.xaml
@@ -29,7 +29,7 @@
                             <StackLayout Orientation="Vertical" Padding="10">
                                 <StackLayout Orientation="Horizontal">
                                     <Label Text="ControllerId: " FontSize="Medium"/>
-                                    <Label Text="{Binding ControllerDeviceId}" FontSize="Medium"/>
+                                    <Label Text="{Binding ControllerId}" FontSize="Medium"/>
                                 </StackLayout>
                                 <StackLayout Orientation="Horizontal">
                                     <Label Text="{Binding EventCode}" FontSize="Large" FontAttributes="Bold"/>

--- a/BrickController2/BrickController2/UI/Pages/ControllerTesterPage.xaml
+++ b/BrickController2/BrickController2/UI/Pages/ControllerTesterPage.xaml
@@ -29,6 +29,7 @@
                             <StackLayout Orientation="Vertical" Padding="10">
                                 <StackLayout Orientation="Horizontal">
                                     <Label Text="ControllerId: " FontSize="Medium"/>
+                                    <Label Text=" - " FontSize="Medium"/>
                                     <Label Text="{Binding ControllerDeviceId}" FontSize="Medium"/>
                                 </StackLayout>
                                 <StackLayout Orientation="Horizontal">

--- a/BrickController2/BrickController2/UI/Pages/ControllerTesterPage.xaml
+++ b/BrickController2/BrickController2/UI/Pages/ControllerTesterPage.xaml
@@ -29,7 +29,6 @@
                             <StackLayout Orientation="Vertical" Padding="10">
                                 <StackLayout Orientation="Horizontal">
                                     <Label Text="ControllerId: " FontSize="Medium"/>
-                                    <Label Text=" - " FontSize="Medium"/>
                                     <Label Text="{Binding ControllerDeviceId}" FontSize="Medium"/>
                                 </StackLayout>
                                 <StackLayout Orientation="Horizontal">

--- a/BrickController2/BrickController2/UI/Services/Dialog/DialogService.cs
+++ b/BrickController2/BrickController2/UI/Services/Dialog/DialogService.cs
@@ -51,7 +51,7 @@ namespace BrickController2.UI.Services.Dialog
                 _dialogServer.GameControllerService = _gameControllerService;
             }
 
-            return _dialogServer?.ShowGameControllerEventDialogAsync(title, message, cancelButtonText, token) ?? Task.FromResult(new GameControllerEventDialogResult(false, GameControllerEventType.Axis, string.Empty));
+            return _dialogServer?.ShowGameControllerEventDialogAsync(title, message, cancelButtonText, token) ?? Task.FromResult(new GameControllerEventDialogResult(false, GameControllerEventDialogResult.NoControllerDeviceId, GameControllerEventType.Axis, string.Empty));
         }
 
         public void RegisterDialogServer(IDialogServer dialogServer)

--- a/BrickController2/BrickController2/UI/Services/Dialog/DialogService.cs
+++ b/BrickController2/BrickController2/UI/Services/Dialog/DialogService.cs
@@ -51,7 +51,7 @@ namespace BrickController2.UI.Services.Dialog
                 _dialogServer.GameControllerService = _gameControllerService;
             }
 
-            return _dialogServer?.ShowGameControllerEventDialogAsync(title, message, cancelButtonText, token) ?? Task.FromResult(new GameControllerEventDialogResult(false, GameControllerEventDialogResult.NoControllerDeviceId, GameControllerEventType.Axis, string.Empty));
+            return _dialogServer?.ShowGameControllerEventDialogAsync(title, message, cancelButtonText, token) ?? Task.FromResult(new GameControllerEventDialogResult(false, GameControllerEventType.Axis, string.Empty));
         }
 
         public void RegisterDialogServer(IDialogServer dialogServer)

--- a/BrickController2/BrickController2/UI/Services/Dialog/GameControllerEventDialogResult.cs
+++ b/BrickController2/BrickController2/UI/Services/Dialog/GameControllerEventDialogResult.cs
@@ -4,15 +4,19 @@ namespace BrickController2.UI.Services.Dialog
 {
     public class GameControllerEventDialogResult
     {
-        public GameControllerEventDialogResult(bool isOk, GameControllerEventType eventType, string eventCode)
+        public const string NoControllerDeviceId = "NoControllerDeviceId";
+
+        public GameControllerEventDialogResult(bool isOk, string controllerDeviceId, GameControllerEventType eventType, string eventCode)
         {
             IsOk = isOk;
             EventType = eventType;
             EventCode = eventCode;
+            ControllerDeviceId = controllerDeviceId;
         }
 
         public bool IsOk { get; }
         public GameControllerEventType EventType { get; }
         public string EventCode { get; }
+        public string ControllerDeviceId { get; }
     }
 }

--- a/BrickController2/BrickController2/UI/Services/Dialog/GameControllerEventDialogResult.cs
+++ b/BrickController2/BrickController2/UI/Services/Dialog/GameControllerEventDialogResult.cs
@@ -9,17 +9,17 @@ namespace BrickController2.UI.Services.Dialog
         {
         }
 
-        public GameControllerEventDialogResult(bool isOk, string controllerDeviceId, GameControllerEventType eventType, string eventCode)
+        public GameControllerEventDialogResult(bool isOk, string controllerId, GameControllerEventType eventType, string eventCode)
         {
             IsOk = isOk;
             EventType = eventType;
             EventCode = eventCode;
-            ControllerDeviceId = controllerDeviceId;
+            ControllerId = controllerId;
         }
 
         public bool IsOk { get; }
         public GameControllerEventType EventType { get; }
         public string EventCode { get; }
-        public string ControllerDeviceId { get; }
+        public string ControllerId { get; }
     }
 }

--- a/BrickController2/BrickController2/UI/Services/Dialog/GameControllerEventDialogResult.cs
+++ b/BrickController2/BrickController2/UI/Services/Dialog/GameControllerEventDialogResult.cs
@@ -4,7 +4,10 @@ namespace BrickController2.UI.Services.Dialog
 {
     public class GameControllerEventDialogResult
     {
-        public const string NoControllerDeviceId = "NoControllerDeviceId";
+        public GameControllerEventDialogResult(bool isOk, GameControllerEventType eventType, string eventCode)
+            : this(isOk, string.Empty, eventType, eventCode)
+        {
+        }
 
         public GameControllerEventDialogResult(bool isOk, string controllerDeviceId, GameControllerEventType eventType, string eventCode)
         {

--- a/BrickController2/BrickController2/UI/ViewModels/ControllerProfilePageViewModel.cs
+++ b/BrickController2/BrickController2/UI/ViewModels/ControllerProfilePageViewModel.cs
@@ -232,7 +232,7 @@ namespace BrickController2.UI.ViewModels
                     ControllerEvent? controllerEvent = null;
                     await _dialogService.ShowProgressDialogAsync(
                         false,
-                        async (progressDialog, token) => controllerEvent = await _creationManager.AddOrGetControllerEventAsync(ControllerProfile, result.EventType, result.EventCode),
+                        async (progressDialog, token) => controllerEvent = await _creationManager.AddOrGetControllerEventAsync(ControllerProfile, result.ControllerDeviceId, result.EventType, result.EventCode),
                         Translate("Creating"),
                         token: _disappearingTokenSource?.Token ?? default);
 
@@ -295,7 +295,7 @@ namespace BrickController2.UI.ViewModels
 
                 await _dialogService.ShowProgressDialogAsync(
                     false,
-                    async (progressDialog, token) => await _creationManager.AddOrGetControllerEventAsync(ControllerProfile, controllerEvent.EventType, controllerEvent.EventCode),
+                    async (progressDialog, token) => await _creationManager.AddOrGetControllerEventAsync(ControllerProfile, controllerEvent.ControllerDeviceId, controllerEvent.EventType, controllerEvent.EventCode),
                     Translate("Creating"),
                     token: _disappearingTokenSource?.Token ?? default);
 

--- a/BrickController2/BrickController2/UI/ViewModels/ControllerProfilePageViewModel.cs
+++ b/BrickController2/BrickController2/UI/ViewModels/ControllerProfilePageViewModel.cs
@@ -232,7 +232,7 @@ namespace BrickController2.UI.ViewModels
                     ControllerEvent? controllerEvent = null;
                     await _dialogService.ShowProgressDialogAsync(
                         false,
-                        async (progressDialog, token) => controllerEvent = await _creationManager.AddOrGetControllerEventAsync(ControllerProfile, result.ControllerDeviceId, result.EventType, result.EventCode),
+                        async (progressDialog, token) => controllerEvent = await _creationManager.AddOrGetControllerEventAsync(ControllerProfile, result.ControllerId, result.EventType, result.EventCode),
                         Translate("Creating"),
                         token: _disappearingTokenSource?.Token ?? default);
 
@@ -295,7 +295,7 @@ namespace BrickController2.UI.ViewModels
 
                 await _dialogService.ShowProgressDialogAsync(
                     false,
-                    async (progressDialog, token) => await _creationManager.AddOrGetControllerEventAsync(ControllerProfile, controllerEvent.ControllerDeviceId, controllerEvent.EventType, controllerEvent.EventCode),
+                    async (progressDialog, token) => await _creationManager.AddOrGetControllerEventAsync(ControllerProfile, controllerEvent.ControllerId, controllerEvent.EventType, controllerEvent.EventCode),
                     Translate("Creating"),
                     token: _disappearingTokenSource?.Token ?? default);
 

--- a/BrickController2/BrickController2/UI/ViewModels/ControllerProfilePageViewModel.cs
+++ b/BrickController2/BrickController2/UI/ViewModels/ControllerProfilePageViewModel.cs
@@ -27,6 +27,7 @@ namespace BrickController2.UI.ViewModels
         private readonly ISharingManager<ControllerProfile> _sharingManager;
         private readonly IDialogService _dialogService;
         private readonly IPlayLogic _playLogic;
+        private readonly IGameControllerService _gameControllerService;
 
         private CancellationTokenSource? _disappearingTokenSource;
 
@@ -41,6 +42,7 @@ namespace BrickController2.UI.ViewModels
             IDialogService dialogService,
             ISharedFileStorageService sharedFileStorageService,
             IPlayLogic playLogic,
+            IGameControllerService gameControllerService,
             NavigationParameters parameters)
             : base(navigationService, translationService)
         {
@@ -50,6 +52,7 @@ namespace BrickController2.UI.ViewModels
             _dialogService = dialogService;
             SharedFileStorageService = sharedFileStorageService;
             _playLogic = playLogic;
+            _gameControllerService = gameControllerService;
 
             ControllerProfile = parameters.Get<ControllerProfile>("controllerprofile");
 
@@ -89,6 +92,8 @@ namespace BrickController2.UI.ViewModels
             get { return _controllerEvents; }
             set { _controllerEvents = value; RaisePropertyChanged(); }
         }
+
+        public bool IsControllerIdSupported => _gameControllerService.IsControllerIdSupported;
 
         public ICommand ExportControllerProfileCommand { get; }
         public ICommand CopyControllerProfileCommand { get; }

--- a/BrickController2/BrickController2/UI/ViewModels/ControllerProfilePageViewModel.cs
+++ b/BrickController2/BrickController2/UI/ViewModels/ControllerProfilePageViewModel.cs
@@ -16,6 +16,7 @@ using BrickController2.PlatformServices.SharedFileStorage;
 using BrickController2.Helpers;
 using DeviceType = BrickController2.DeviceManagement.DeviceType;
 using BrickController2.CreationManagement.Sharing;
+using BrickController2.PlatformServices.GameController;
 
 namespace BrickController2.UI.ViewModels
 {
@@ -55,7 +56,8 @@ namespace BrickController2.UI.ViewModels
             ExportControllerProfileCommand = new SafeCommand(async () => await ExportControllerProfileAsync(), () => SharedFileStorageService.IsSharedStorageAvailable);
             CopyControllerProfileCommand = new SafeCommand(CopyControllerProfileAsync);
             RenameProfileCommand = new SafeCommand(async () => await RenameControllerProfileAsync());
-            AddControllerEventCommand = new SafeCommand(async () => await AddControllerEventAsync());
+            AddControllerEventCommand = new SafeCommand(async () => await AddControllerEventAsync(false));
+            AddControllerEventWithControllerIdCommand = new SafeCommand(async () => await AddControllerEventAsync(true));
             PlayCommand = new SafeCommand(async () => await PlayAsync());
             ControllerActionTappedCommand = new SafeCommand<ControllerActionViewModel>(async controllerActionViewModel => await NavigationService.NavigateToAsync<ControllerActionPageViewModel>(new NavigationParameters(("controlleraction", controllerActionViewModel.ControllerAction))));
             DeleteControllerEventCommand = new SafeCommand<ControllerEvent>(async controllerEvent => await DeleteControllerEventAsync(controllerEvent));
@@ -92,6 +94,7 @@ namespace BrickController2.UI.ViewModels
         public ICommand CopyControllerProfileCommand { get; }
         public ICommand RenameProfileCommand { get; }
         public ICommand AddControllerEventCommand { get; }
+        public ICommand AddControllerEventWithControllerIdCommand { get; }
         public ICommand PlayCommand { get; }
         public ICommand ControllerActionTappedCommand { get; }
         public ICommand DeleteControllerEventCommand { get; }
@@ -208,7 +211,7 @@ namespace BrickController2.UI.ViewModels
             }
         }
 
-        private async Task AddControllerEventAsync()
+        private async Task AddControllerEventAsync(bool addControllerId)
         {
             try
             {
@@ -232,7 +235,7 @@ namespace BrickController2.UI.ViewModels
                     ControllerEvent? controllerEvent = null;
                     await _dialogService.ShowProgressDialogAsync(
                         false,
-                        async (progressDialog, token) => controllerEvent = await _creationManager.AddOrGetControllerEventAsync(ControllerProfile, result.ControllerId, result.EventType, result.EventCode),
+                        async (progressDialog, token) => controllerEvent = await _creationManager.AddOrGetControllerEventAsync(ControllerProfile, addControllerId ? result.ControllerId : string.Empty, result.EventType, result.EventCode),
                         Translate("Creating"),
                         token: _disappearingTokenSource?.Token ?? default);
 

--- a/BrickController2/BrickController2/UI/ViewModels/ControllerProfilePageViewModel.cs
+++ b/BrickController2/BrickController2/UI/ViewModels/ControllerProfilePageViewModel.cs
@@ -60,7 +60,7 @@ namespace BrickController2.UI.ViewModels
             CopyControllerProfileCommand = new SafeCommand(CopyControllerProfileAsync);
             RenameProfileCommand = new SafeCommand(async () => await RenameControllerProfileAsync());
             AddControllerEventCommand = new SafeCommand(async () => await AddControllerEventAsync(false));
-            AddControllerEventWithControllerIdCommand = new SafeCommand(async () => await AddControllerEventAsync(true));
+            AddControllerEventForSpecificControllerIdCommand = new SafeCommand(async () => await AddControllerEventAsync(true));
             PlayCommand = new SafeCommand(async () => await PlayAsync());
             ControllerActionTappedCommand = new SafeCommand<ControllerActionViewModel>(async controllerActionViewModel => await NavigationService.NavigateToAsync<ControllerActionPageViewModel>(new NavigationParameters(("controlleraction", controllerActionViewModel.ControllerAction))));
             DeleteControllerEventCommand = new SafeCommand<ControllerEvent>(async controllerEvent => await DeleteControllerEventAsync(controllerEvent));
@@ -99,7 +99,7 @@ namespace BrickController2.UI.ViewModels
         public ICommand CopyControllerProfileCommand { get; }
         public ICommand RenameProfileCommand { get; }
         public ICommand AddControllerEventCommand { get; }
-        public ICommand AddControllerEventWithControllerIdCommand { get; }
+        public ICommand AddControllerEventForSpecificControllerIdCommand { get; }
         public ICommand PlayCommand { get; }
         public ICommand ControllerActionTappedCommand { get; }
         public ICommand DeleteControllerEventCommand { get; }

--- a/BrickController2/BrickController2/UI/ViewModels/ControllerTesterPageViewModel.cs
+++ b/BrickController2/BrickController2/UI/ViewModels/ControllerTesterPageViewModel.cs
@@ -36,7 +36,7 @@ namespace BrickController2.UI.ViewModels
         {
             foreach (var controllerEvent in args.ControllerEvents)
             {
-                var controllerEventViewModel = ControllerEventList.FirstOrDefault(ce => ce.ControllerDeviceId == args.ControllerDeviceId && ce.EventType == controllerEvent.Key.EventType && ce.EventCode == controllerEvent.Key.EventCode);
+                var controllerEventViewModel = ControllerEventList.FirstOrDefault(ce => ce.ControllerId == args.ControllerId && ce.EventType == controllerEvent.Key.EventType && ce.EventCode == controllerEvent.Key.EventCode);
                 if (0.1F < Math.Abs(controllerEvent.Value))
                 {
                     if (controllerEventViewModel != null)
@@ -45,7 +45,7 @@ namespace BrickController2.UI.ViewModels
                     }
                     else
                     {
-                        ControllerEventList.Add(new GameControllerEventViewModel(args.ControllerDeviceId, controllerEvent.Key.EventType, controllerEvent.Key.EventCode, controllerEvent.Value));
+                        ControllerEventList.Add(new GameControllerEventViewModel(args.ControllerId, controllerEvent.Key.EventType, controllerEvent.Key.EventCode, controllerEvent.Value));
                     }
                 }
                 else

--- a/BrickController2/BrickController2/UI/ViewModels/ControllerTesterPageViewModel.cs
+++ b/BrickController2/BrickController2/UI/ViewModels/ControllerTesterPageViewModel.cs
@@ -36,7 +36,7 @@ namespace BrickController2.UI.ViewModels
         {
             foreach (var controllerEvent in args.ControllerEvents)
             {
-                var controllerEventViewModel = ControllerEventList.FirstOrDefault(ce => ce.EventType == controllerEvent.Key.EventType && ce.EventCode == controllerEvent.Key.EventCode);
+                var controllerEventViewModel = ControllerEventList.FirstOrDefault(ce => ce.ControllerDeviceId == args.ControllerDeviceId && ce.EventType == controllerEvent.Key.EventType && ce.EventCode == controllerEvent.Key.EventCode);
                 if (0.1F < Math.Abs(controllerEvent.Value))
                 {
                     if (controllerEventViewModel != null)
@@ -45,7 +45,7 @@ namespace BrickController2.UI.ViewModels
                     }
                     else
                     {
-                        ControllerEventList.Add(new GameControllerEventViewModel(controllerEvent.Key.EventType, controllerEvent.Key.EventCode, controllerEvent.Value));
+                        ControllerEventList.Add(new GameControllerEventViewModel(args.ControllerDeviceId, controllerEvent.Key.EventType, controllerEvent.Key.EventCode, controllerEvent.Value));
                     }
                 }
                 else

--- a/BrickController2/BrickController2/UI/ViewModels/ControllerTesterPageViewModel.cs
+++ b/BrickController2/BrickController2/UI/ViewModels/ControllerTesterPageViewModel.cs
@@ -20,6 +20,8 @@ namespace BrickController2.UI.ViewModels
             _gameControllerService = gameControllerService;
         }
 
+        public bool IsControllerIdSupported => _gameControllerService.IsControllerIdSupported;
+
         public override void OnAppearing()
         {
             _gameControllerService.GameControllerEvent += GameControllerEventHandler!;

--- a/BrickController2/BrickController2/UI/ViewModels/GameControllerEventViewModel.cs
+++ b/BrickController2/BrickController2/UI/ViewModels/GameControllerEventViewModel.cs
@@ -7,8 +7,9 @@ namespace BrickController2.UI.ViewModels
     {
         private float _value;
 
-        public GameControllerEventViewModel(GameControllerEventType eventType, string eventCode, float value)
+        public GameControllerEventViewModel(string controllerDeviceId, GameControllerEventType eventType, string eventCode, float value)
         {
+            ControllerDeviceId = controllerDeviceId;
             EventType = eventType;
             EventCode = eventCode;
             Value = value;
@@ -16,6 +17,8 @@ namespace BrickController2.UI.ViewModels
 
         public GameControllerEventType EventType { get; }
         public string EventCode { get; }
+
+        public string ControllerDeviceId { get; }
 
         public float Value
         {

--- a/BrickController2/BrickController2/UI/ViewModels/GameControllerEventViewModel.cs
+++ b/BrickController2/BrickController2/UI/ViewModels/GameControllerEventViewModel.cs
@@ -7,9 +7,9 @@ namespace BrickController2.UI.ViewModels
     {
         private float _value;
 
-        public GameControllerEventViewModel(string controllerDeviceId, GameControllerEventType eventType, string eventCode, float value)
+        public GameControllerEventViewModel(string controllerId, GameControllerEventType eventType, string eventCode, float value)
         {
-            ControllerDeviceId = controllerDeviceId;
+            ControllerId = controllerId;
             EventType = eventType;
             EventCode = eventCode;
             Value = value;
@@ -18,7 +18,7 @@ namespace BrickController2.UI.ViewModels
         public GameControllerEventType EventType { get; }
         public string EventCode { get; }
 
-        public string ControllerDeviceId { get; }
+        public string ControllerId { get; }
 
         public float Value
         {


### PR DESCRIPTION
Hi @vicocz :)

I would like to merge some features of my branch to yours...

Here is a first simple one: with some little changes I added **support to distinguish the source of the input-events** (from the gamecontroller) by adding the field/property "ControllerEvent.ControllerDeviceId" wich is setted in the event handler methode when happening.

I extended the overwritten ControllerEvent.ToString() with that ControllerDeviceId so you can see the different input sources in the Controller-page.

It's working an Android and Windows but not on iOS - I don't have a device to implement...