### PR TITLE
Allow to reset all device settings to defaults

### DIFF
--- a/BrickController2/BrickController2/DeviceManagement/Device.cs
+++ b/BrickController2/BrickController2/DeviceManagement/Device.cs
@@ -155,7 +155,8 @@ namespace BrickController2.DeviceManagement
             _settings[settingName] = new DeviceSetting
             {
                 Name = settingName,
-                Value = foundSetting.GetValue(defaultValue)
+                Value = foundSetting.GetValue(defaultValue),
+                DefaultValue = defaultValue
             };
         }
 

--- a/BrickController2/BrickController2/DeviceManagement/DeviceSetting.cs
+++ b/BrickController2/BrickController2/DeviceManagement/DeviceSetting.cs
@@ -10,10 +10,12 @@ public record DeviceSetting
     public string Name { get; init; } = default!;
 
     /// <summary>Current setting value</summary>
+    /// <remarks>Type should match <see cref="DefaultValue"/></remarks>
     [JsonProperty]
     public object Value { get; set; } = default!;
 
     /// <summary>Default setting value</summary>
+    /// <remarks>This is not persisted, but kept in memory only</remarks>
     [JsonIgnore]
     public object DefaultValue { get; init; } = default!;
 

--- a/BrickController2/BrickController2/DeviceManagement/DeviceSetting.cs
+++ b/BrickController2/BrickController2/DeviceManagement/DeviceSetting.cs
@@ -13,6 +13,10 @@ public record DeviceSetting
     [JsonProperty]
     public object Value { get; set; } = default!;
 
+    /// <summary>Default setting value</summary>
+    [JsonIgnore]
+    public object DefaultValue { get; init; } = default!;
+
     /// <summary>Type of setting value</summary>
     [JsonIgnore]
     public Type Type => Value?.GetType() ?? typeof(void);

--- a/BrickController2/BrickController2/Resources/TranslationResources.de.resx
+++ b/BrickController2/BrickController2/Resources/TranslationResources.de.resx
@@ -660,4 +660,7 @@
   <data name="Off" xml:space="preserve">
     <value>Aus</value>
   </data>
+  <data name="ResetToDefaults" xml:space="preserve">
+    <value>Die Einstellungen zurücksetzen</value>
+  </data>
 </root>

--- a/BrickController2/BrickController2/Resources/TranslationResources.resx
+++ b/BrickController2/BrickController2/Resources/TranslationResources.resx
@@ -618,7 +618,7 @@
   <data name="Add" xml:space="preserve">
     <value>Add</value>
   </data>
- <data name="ShareCreationAsFile" xml:space="preserve">
+  <data name="ShareCreationAsFile" xml:space="preserve">
     <value>Share the creation as file</value>
   </data>
   <data name="ShareCreationAsText" xml:space="preserve">
@@ -662,5 +662,8 @@
   </data>
   <data name="Off" xml:space="preserve">
     <value>Off</value>
+  </data>
+  <data name="ResetToDefaults" xml:space="preserve">
+    <value>Reset settings to default</value>
   </data>
 </root>

--- a/BrickController2/BrickController2/UI/Pages/DeviceSettingsPage.xaml
+++ b/BrickController2/BrickController2/UI/Pages/DeviceSettingsPage.xaml
@@ -29,10 +29,10 @@
                                 <RowDefinition Height="Auto"/>
                             </Grid.RowDefinitions>
 
-                            <Label Grid.Column="0" Text="{Binding DisplayName}" FontSize="Large" VerticalOptions="Center"/>
+                            <Label Grid.Column="0" Text="{Binding DisplayName}" FontSize="Medium" VerticalOptions="Center"/>
                             <HorizontalStackLayout Grid.Column="1" Spacing="20">
                                 <Switch IsToggled="{Binding Value}" HorizontalOptions="Center" />
-                                <Label Text="{extensions:Translate On}" FontSize="Medium" VerticalOptions="Center" IsVisible="{Binding Value}"/>
+                                <Label Text="{extensions:Translate On}" FontSize="Medium" FontAttributes="Bold" VerticalOptions="Center" IsVisible="{Binding Value}"/>
                                 <Label Text="{extensions:Translate Off}" FontSize="Medium" VerticalOptions="Center" IsVisible="{Binding Value, Converter={StaticResource InverseBool}}"/>
                             </HorizontalStackLayout>
                         </Grid>
@@ -50,7 +50,7 @@
                                 <RowDefinition Height="Auto"/>
                             </Grid.RowDefinitions>
 
-                            <Label Grid.Column="0" Text="{Binding DisplayName}" FontSize="Large" VerticalOptions="Center"/>
+                            <Label Grid.Column="0" Text="{Binding DisplayName}" FontSize="Medium" VerticalOptions="Center"/>
                             <Button Grid.Column="1" Text="{Binding CurrentItem}" Command="{Binding SelectItemCommand}" Style="{StaticResource PickerButtonStyle}" HorizontalOptions="FillAndExpand"/>
                         </Grid>
                     </DataTemplate>
@@ -79,10 +79,10 @@
                 </Grid>
 
                 <!-- Setting list -->
-                <CollectionView Grid.Row="1" ItemsSource="{Binding Settings}" SelectionMode="None" Margin="10,20,10,10"
+                <CollectionView Grid.Row="1" ItemsSource="{Binding Settings}" SelectionMode="None" Margin="10,10,10,10"
                                 ItemTemplate="{StaticResource TemplatesSelector}">
                     <CollectionView.ItemsLayout>
-                        <GridItemsLayout Orientation="Vertical" VerticalItemSpacing="30" />
+                        <GridItemsLayout Orientation="Vertical" VerticalItemSpacing="10" />
                     </CollectionView.ItemsLayout>
                 </CollectionView>
 

--- a/BrickController2/BrickController2/UI/Pages/DeviceSettingsPage.xaml
+++ b/BrickController2/BrickController2/UI/Pages/DeviceSettingsPage.xaml
@@ -59,6 +59,11 @@
         </ResourceDictionary>
     </local:PageBase.Resources>
 
+    <ContentPage.ToolbarItems>
+        <controls:ToolbarIcon Icon="settings_backup_restore" Text="{extensions:Translate ResetToDefaults}" Command="{Binding ResetToDefaultsCommand}" />
+        <controls:ToolbarIcon Icon="done_outline" Text="{extensions:Translate ApplyChanges}" Command="{Binding SaveSettingsCommand}" />
+    </ContentPage.ToolbarItems>
+    
     <local:PageBase.Content>
         <AbsoluteLayout HorizontalOptions="FillAndExpand" VerticalOptions="FillAndExpand">
             <Grid RowSpacing="0" AbsoluteLayout.LayoutBounds="0, 0, 1, 1" AbsoluteLayout.LayoutFlags="All">

--- a/BrickController2/BrickController2/UI/Pages/DeviceSettingsPage.xaml
+++ b/BrickController2/BrickController2/UI/Pages/DeviceSettingsPage.xaml
@@ -17,6 +17,11 @@
     <local:PageBase.Resources>
         <ResourceDictionary>
             <converters:InverseBoolConverter x:Key="InverseBool"/>
+            <Style x:Key="settingLabel" TargetType="Label">
+                <Setter Property="HorizontalOptions" Value="Start" />
+                <Setter Property="VerticalOptions" Value="Center" />
+                <Setter Property="FontSize" Value="Medium" />
+            </Style>
             <t:DataTemplatesSelector x:Key="TemplatesSelector">
                 <t:DataTemplatesSelector.BoolDataTemplate>
                     <DataTemplate>
@@ -29,11 +34,11 @@
                                 <RowDefinition Height="Auto"/>
                             </Grid.RowDefinitions>
 
-                            <Label Grid.Column="0" Text="{Binding DisplayName}" FontSize="Medium" VerticalOptions="Center"/>
+                            <Label Grid.Column="0" Text="{Binding DisplayName}" Style="{StaticResource Key=settingLabel}"/>
                             <HorizontalStackLayout Grid.Column="1" Spacing="20">
                                 <Switch IsToggled="{Binding Value}" HorizontalOptions="Center" />
-                                <Label Text="{extensions:Translate On}" FontSize="Medium" FontAttributes="Bold" VerticalOptions="Center" IsVisible="{Binding Value}"/>
-                                <Label Text="{extensions:Translate Off}" FontSize="Medium" VerticalOptions="Center" IsVisible="{Binding Value, Converter={StaticResource InverseBool}}"/>
+                                <Label Text="{extensions:Translate On}" Style="{StaticResource Key=settingLabel}" IsVisible="{Binding Value}"/>
+                                <Label Text="{extensions:Translate Off}" Style="{StaticResource Key=settingLabel}" IsVisible="{Binding Value, Converter={StaticResource InverseBool}}"/>
                             </HorizontalStackLayout>
                         </Grid>
                     </DataTemplate>
@@ -50,7 +55,7 @@
                                 <RowDefinition Height="Auto"/>
                             </Grid.RowDefinitions>
 
-                            <Label Grid.Column="0" Text="{Binding DisplayName}" FontSize="Medium" VerticalOptions="Center"/>
+                            <Label Grid.Column="0" Text="{Binding DisplayName}" Style="{StaticResource Key=settingLabel}"/>
                             <Button Grid.Column="1" Text="{Binding CurrentItem}" Command="{Binding SelectItemCommand}" Style="{StaticResource PickerButtonStyle}" HorizontalOptions="FillAndExpand"/>
                         </Grid>
                     </DataTemplate>
@@ -75,7 +80,7 @@
 
                 <!-- Header -->
                 <Grid Grid.Row="0" Style="{StaticResource HeaderGridStyle}">
-                    <Label Text="{Binding Device.Name}" TextColor="{DynamicResource EditableTextColor}" FontSize="Large" FontAttributes="Bold" HorizontalOptions="Start" VerticalOptions="Center" />
+                    <Label Text="{Binding Device.Name}" TextColor="{DynamicResource PrimaryTextColor}" FontSize="Large" FontAttributes="Bold" HorizontalOptions="Start" VerticalOptions="Center" />
                 </Grid>
 
                 <!-- Setting list -->

--- a/BrickController2/BrickController2/UI/ViewModels/DeviceBoolSettingViewModel.cs
+++ b/BrickController2/BrickController2/UI/ViewModels/DeviceBoolSettingViewModel.cs
@@ -17,11 +17,17 @@ namespace BrickController2.UI.ViewModels
             {
                 if (Setting.Value != value)
                 {
-                    HasChanged |= true;
                     Setting.Value = value;
+                    HasChanged |= true;
                     RaisePropertyChanged();
+                    Parent.OnSettingChanged();
                 }
             }
+        }
+
+        internal override void ResetToDefault()
+        {
+            Value = Setting.DefaultValue;
         }
     }
 }

--- a/BrickController2/BrickController2/UI/ViewModels/DeviceBoolSettingViewModel.cs
+++ b/BrickController2/BrickController2/UI/ViewModels/DeviceBoolSettingViewModel.cs
@@ -18,7 +18,6 @@ namespace BrickController2.UI.ViewModels
                 if (Setting.Value != value)
                 {
                     Setting.Value = value;
-                    HasChanged |= true;
                     RaisePropertyChanged();
                     Parent.OnSettingChanged();
                 }

--- a/BrickController2/BrickController2/UI/ViewModels/DeviceEnumSettingViewModel.cs
+++ b/BrickController2/BrickController2/UI/ViewModels/DeviceEnumSettingViewModel.cs
@@ -29,11 +29,17 @@ namespace BrickController2.UI.ViewModels
                 var enumValue = Enum.Parse(Setting.Type, value);
                 if (!enumValue.Equals(Setting.Value))
                 {
-                    HasChanged |= true;
                     Setting.Value = enumValue;
+                    HasChanged |= true;
                     RaisePropertyChanged();
+                    Parent.OnSettingChanged();
                 }
             }
+        }
+
+        internal override void ResetToDefault()
+        {
+            CurrentItem = Enum.GetName(Setting.Type, Setting.DefaultValue)!;
         }
 
         private async Task SelectItemAsync()

--- a/BrickController2/BrickController2/UI/ViewModels/DeviceEnumSettingViewModel.cs
+++ b/BrickController2/BrickController2/UI/ViewModels/DeviceEnumSettingViewModel.cs
@@ -30,7 +30,6 @@ namespace BrickController2.UI.ViewModels
                 if (!enumValue.Equals(Setting.Value))
                 {
                     Setting.Value = enumValue;
-                    HasChanged |= true;
                     RaisePropertyChanged();
                     Parent.OnSettingChanged();
                 }

--- a/BrickController2/BrickController2/UI/ViewModels/DeviceSettingViewModelBase.cs
+++ b/BrickController2/BrickController2/UI/ViewModels/DeviceSettingViewModelBase.cs
@@ -9,12 +9,14 @@ namespace BrickController2.UI.ViewModels
 {
     public abstract class DeviceSettingViewModelBase : NotifyPropertyChangedSource
     {
+        private readonly object _originalValue;
         protected readonly ITranslationService TranslationService;
 
         protected DeviceSettingViewModelBase(DeviceSettingsPageViewModel parent,
             DeviceSetting setting,
             ITranslationService translationService)
         {
+            _originalValue = setting.Value;
             Setting = setting with { };
             Parent = parent;
             TranslationService = translationService;
@@ -22,9 +24,9 @@ namespace BrickController2.UI.ViewModels
 
         public string DisplayName => TranslationService.Translate(Setting.Name);
 
-        public bool HasChanged { get; protected set; }
+        public bool HasChanged => !Setting.Value.Equals(_originalValue);
 
-        public bool IsDefaultValue => Setting.Value.Equals(Setting.DefaultValue);
+        public bool HasNonDefaultValue => !Setting.Value.Equals(Setting.DefaultValue);
 
         public DeviceSetting Setting { get; }
         public DeviceSettingsPageViewModel Parent { get; }

--- a/BrickController2/BrickController2/UI/ViewModels/DeviceSettingViewModelBase.cs
+++ b/BrickController2/BrickController2/UI/ViewModels/DeviceSettingViewModelBase.cs
@@ -24,8 +24,12 @@ namespace BrickController2.UI.ViewModels
 
         public bool HasChanged { get; protected set; }
 
+        public bool IsDefaultValue => Setting.Value.Equals(Setting.DefaultValue);
+
         public DeviceSetting Setting { get; }
         public DeviceSettingsPageViewModel Parent { get; }
+
+        internal abstract void ResetToDefault();
 
         protected Task<SelectionDialogResult<T>> ShowSelectionDialogAsync<T>(IEnumerable<T> items) where T : notnull
             => Parent.DialogService.ShowSelectionDialogAsync(

--- a/BrickController2/BrickController2/UI/ViewModels/DeviceSettingsPageViewModel.cs
+++ b/BrickController2/BrickController2/UI/ViewModels/DeviceSettingsPageViewModel.cs
@@ -56,16 +56,27 @@ public class DeviceSettingsPageViewModel : PageViewModelBase
 
     private async Task ApplyChanges()
     {
-        // update changed settings on exit
-        var changedSettings = Settings
-            .Where(s => s.HasChanged)
-            .Select(s => s.Setting)
-            .ToArray();
+        try
+        {
+            await DialogService.ShowProgressDialogAsync(
+                false,
+                async (progressDialog, token) =>
+                {
+                    var changedSettings = Settings
+                        .Where(s => s.HasChanged)
+                        .Select(s => s.Setting)
+                        .ToArray();
 
-        if (changedSettings.Any())
-            await Device.UpdateDeviceSettingsAsync(changedSettings);
+                    await Device.UpdateDeviceSettingsAsync(changedSettings);
+                },
+                Translate("Saving"),
+                token: DisappearingToken);
 
-        await NavigationService.NavigateBackAsync();
+            await NavigationService.NavigateBackAsync();
+        }
+        catch (OperationCanceledException)
+        {
+        }
     }
 
     private void ResetToDefaults()

--- a/BrickController2/BrickController2/UI/ViewModels/DeviceSettingsPageViewModel.cs
+++ b/BrickController2/BrickController2/UI/ViewModels/DeviceSettingsPageViewModel.cs
@@ -24,7 +24,7 @@ public class DeviceSettingsPageViewModel : PageViewModelBase
         DialogService = dialogService;
 
         SaveSettingsCommand = new SafeCommand(ApplyChanges, () => Settings.Any(x => x.HasChanged));
-        ResetToDefaultsCommand = new SafeCommand(ResetToDefaults, () => Settings.Any(x => !x.IsDefaultValue));
+        ResetToDefaultsCommand = new SafeCommand(ResetToDefaults, () => Settings.Any(x => x.HasNonDefaultValue));
     }
 
     public ICommand SaveSettingsCommand { get; }
@@ -70,7 +70,7 @@ public class DeviceSettingsPageViewModel : PageViewModelBase
 
     private void ResetToDefaults()
     {
-        foreach (var setting in Settings.Where(s => !s.IsDefaultValue))
+        foreach (var setting in Settings.Where(s => s.HasNonDefaultValue))
         {
             setting.ResetToDefault();
         }

--- a/BrickController2/BrickController2/UI/ViewModels/DeviceSettingsPageViewModel.cs
+++ b/BrickController2/BrickController2/UI/ViewModels/DeviceSettingsPageViewModel.cs
@@ -1,10 +1,13 @@
 ﻿using BrickController2.DeviceManagement;
+using BrickController2.UI.Commands;
 using BrickController2.UI.Services.Dialog;
 using BrickController2.UI.Services.Navigation;
 using BrickController2.UI.Services.Translation;
 using System;
 using System.Collections.ObjectModel;
 using System.Linq;
+using System.Threading.Tasks;
+using System.Windows.Input;
 
 namespace BrickController2.UI.ViewModels;
 
@@ -19,25 +22,23 @@ public class DeviceSettingsPageViewModel : PageViewModelBase
         Device = parameters.Get<Device>("device");
         Settings = new ObservableCollection<DeviceSettingViewModelBase>(Device.CurrentSettings.Select(ToViewModel));
         DialogService = dialogService;
+
+        SaveSettingsCommand = new SafeCommand(ApplyChanges, () => Settings.Any(x => x.HasChanged));
+        ResetToDefaultsCommand = new SafeCommand(ResetToDefaults, () => Settings.Any(x => !x.IsDefaultValue));
     }
+
+    public ICommand SaveSettingsCommand { get; }
+    public ICommand ResetToDefaultsCommand { get; }
 
     public Device Device { get; }
     public IDialogService DialogService { get; }
 
     public ObservableCollection<DeviceSettingViewModelBase> Settings { get; }
 
-    public override async void OnDisappearing()
+    internal void OnSettingChanged()
     {
-        base.OnDisappearing();
-
-        // update changed settings on exit
-        var changedSettings = Settings
-            .Where(s => s.HasChanged)
-            .Select(s => s.Setting)
-            .ToArray();
-
-        if (changedSettings.Any())
-            await Device.UpdateDeviceSettingsAsync(changedSettings);
+        SaveSettingsCommand.RaiseCanExecuteChanged();
+        ResetToDefaultsCommand.RaiseCanExecuteChanged();
     }
 
     private DeviceSettingViewModelBase ToViewModel(DeviceSetting setting)
@@ -51,5 +52,27 @@ public class DeviceSettingsPageViewModel : PageViewModelBase
             return new DeviceEnumSettingViewModel(this, setting, TranslationService);
         }
         throw new InvalidOperationException($"The specified type {setting.Type} is not supported.");
+    }
+
+    private async Task ApplyChanges()
+    {
+        // update changed settings on exit
+        var changedSettings = Settings
+            .Where(s => s.HasChanged)
+            .Select(s => s.Setting)
+            .ToArray();
+
+        if (changedSettings.Any())
+            await Device.UpdateDeviceSettingsAsync(changedSettings);
+
+        await NavigationService.NavigateBackAsync();
+    }
+
+    private void ResetToDefaults()
+    {
+        foreach (var setting in Settings.Where(s => !s.IsDefaultValue))
+        {
+            setting.ResetToDefault();
+        }
     }
 }


### PR DESCRIPTION
Device setting used to be updated during disapearing of the view model, but it was triggered for e.g. locked device as well. Therefore I've added `Apply changes` icon and revorked the logic for change detection.
Additionally it's possible to reset all settings to the default values and did minor style tuning.

![image](https://github.com/user-attachments/assets/c3c422b8-bd1f-4a96-917a-62af3fee71fb)
