### PR TITLE
[iOS] Fix detection of devices via their Service UUID (CircuitCubes, WeDo2)

### DIFF
--- a/BrickController2/BrickController2.iOS/PlatformServices/BluetoothLE/BluetoothLEService.cs
+++ b/BrickController2/BrickController2.iOS/PlatformServices/BluetoothLE/BluetoothLEService.cs
@@ -121,6 +121,12 @@ namespace BrickController2.iOS.PlatformServices.BluetoothLE
                 result[0x09] = completeDeviceName;
             }
 
+            var serviceUuid = GetServiceUuidForKey(advertisementData, CBAdvertisement.DataServiceUUIDsKey);
+            if (serviceUuid is not null)
+            {
+                result[0x06] = serviceUuid;
+            }
+
             // TODO: add the rest of the advertisementdata...
 
             return result;
@@ -141,6 +147,30 @@ namespace BrickController2.iOS.PlatformServices.BluetoothLE
             else if (rawObject is NSString stringObject)
             {
                 return Encoding.ASCII.GetBytes(stringObject.ToString());
+            }
+
+            return null;
+        }
+
+        private byte[]? GetServiceUuidForKey(NSDictionary advertisementData, NSString key)
+        {
+            if (advertisementData == null ||
+                !advertisementData.TryGetValue(key, out var rawObject) ||
+                rawObject is not NSArray arrayObject)
+            {
+                return null;
+            }
+            // find first matching 128-bit UUID
+            for (nuint i = 0; i < arrayObject.Count; i++)
+            {
+                var cbuuid = arrayObject.GetItem<CBUUID>(i);
+                if (cbuuid.Data.Length == 16)
+                {
+                    // Service UUID's are read backwards (little endian) according to specs
+                    var serviceUUid = cbuuid.Data.ToArray();
+                    Array.Reverse(serviceUUid);
+                    return serviceUUid;
+                }
             }
 
             return null;

--- a/BrickController2/BrickController2.iOS/PlatformServices/BluetoothLE/BluetoothLEService.cs
+++ b/BrickController2/BrickController2.iOS/PlatformServices/BluetoothLE/BluetoothLEService.cs
@@ -9,6 +9,8 @@ using CoreFoundation;
 using Foundation;
 using BrickController2.PlatformServices.BluetoothLE;
 
+using static BrickController2.Protocols.BluetoothLowEnergy;
+
 namespace BrickController2.iOS.PlatformServices.BluetoothLE
 {
     public class BluetoothLEService : CBCentralManagerDelegate, IBluetoothLEService
@@ -112,19 +114,19 @@ namespace BrickController2.iOS.PlatformServices.BluetoothLE
             var manufacturerData = GetDataForKey(advertisementData, CBAdvertisement.DataManufacturerDataKey);
             if (manufacturerData is not null)
             {
-                result[0xFF] = manufacturerData;
+                result[ADTYPE_MANUFACTURER_SPECIFIC] = manufacturerData;
             }
 
             var completeDeviceName = GetDataForKey(advertisementData, CBAdvertisement.DataLocalNameKey);
             if (completeDeviceName is not null)
             {
-                result[0x09] = completeDeviceName;
+                result[ADTYPE_LOCAL_NAME_COMPLETE] = completeDeviceName;
             }
 
             var serviceUuid = GetServiceUuidForKey(advertisementData, CBAdvertisement.DataServiceUUIDsKey);
             if (serviceUuid is not null)
             {
-                result[0x06] = serviceUuid;
+                result[ADTYPE_SERVICE_128BIT] = serviceUuid;
             }
 
             // TODO: add the rest of the advertisementdata...
@@ -152,27 +154,25 @@ namespace BrickController2.iOS.PlatformServices.BluetoothLE
             return null;
         }
 
-        private byte[]? GetServiceUuidForKey(NSDictionary advertisementData, NSString key)
+        private static byte[]? GetServiceUuidForKey(NSDictionary advertisementData, NSString key)
         {
-            if (advertisementData == null ||
-                !advertisementData.TryGetValue(key, out var rawObject) ||
-                rawObject is not NSArray arrayObject)
+            if (advertisementData != null &&
+                advertisementData.TryGetValue(key, out var rawObject) &&
+                rawObject is NSArray arrayObject)
             {
-                return null;
-            }
-            // find first matching 128-bit UUID
-            for (nuint i = 0; i < arrayObject.Count; i++)
-            {
-                var cbuuid = arrayObject.GetItem<CBUUID>(i);
-                if (cbuuid.Data.Length == 16)
+                // find first available 128-bit UUID
+                for (nuint i = 0; i < arrayObject.Count; i++)
                 {
-                    // Service UUID's are read backwards (little endian) according to specs
-                    var serviceUUid = cbuuid.Data.ToArray();
-                    Array.Reverse(serviceUUid);
-                    return serviceUUid;
+                    var cbuuid = arrayObject.GetItem<CBUUID>(i);
+                    if (cbuuid.Data.Length == 16)
+                    {
+                        // Service UUID's are read backwards (little endian) according to specs
+                        var serviceUUid = cbuuid.Data.ToArray();
+                        Array.Reverse(serviceUUid);
+                        return serviceUUid;
+                    }
                 }
             }
-
             return null;
         }
     }

--- a/BrickController2/BrickController2/DeviceManagement/BluetoothDeviceManager.cs
+++ b/BrickController2/BrickController2/DeviceManagement/BluetoothDeviceManager.cs
@@ -6,6 +6,8 @@ using System.Threading.Tasks;
 using BrickController2.Helpers;
 using BrickController2.PlatformServices.BluetoothLE;
 
+using static BrickController2.Protocols.BluetoothLowEnergy;
+
 namespace BrickController2.DeviceManagement
 {
     internal class BluetoothDeviceManager : IBluetoothDeviceManager
@@ -61,7 +63,7 @@ namespace BrickController2.DeviceManagement
                 return (DeviceType.Unknown, null);
             }
 
-            if (!advertismentData.TryGetValue(0xFF, out var manufacturerData) || manufacturerData.Length < 2)
+            if (!advertismentData.TryGetValue(ADTYPE_MANUFACTURER_SPECIFIC, out var manufacturerData) || manufacturerData.Length < 2)
             {
                 return GetDeviceInfoByService(advertismentData);
             }
@@ -74,7 +76,7 @@ namespace BrickController2.DeviceManagement
                 case "98-01": return (DeviceType.SBrick, manufacturerData);
                 case "48-4d": return (DeviceType.BuWizz, manufacturerData);
                 case "4e-05":
-                    if (advertismentData.TryGetValue(0x09, out byte[]? completeLocalName))
+                    if (advertismentData.TryGetValue(ADTYPE_LOCAL_NAME_COMPLETE, out byte[]? completeLocalName))
                     {
                         var completeLocalNameString = BitConverter.ToString(completeLocalName).ToLower();
                         if (completeLocalNameString == "42-75-57-69-7a-7a") // BuWizz
@@ -108,7 +110,7 @@ namespace BrickController2.DeviceManagement
         private (DeviceType DeviceType, byte[]? ManufacturerData) GetDeviceInfoByService(IDictionary<byte, byte[]> advertismentData)
         {
             // 0x06: 128 bits Service UUID type
-            if (!advertismentData.TryGetValue(0x06, out byte[]? serviceData) || serviceData.Length < 16)
+            if (!advertismentData.TryGetValue(ADTYPE_SERVICE_128BIT, out byte[]? serviceData) || serviceData.Length < 16)
             {
                 return (DeviceType.Unknown, null);
             }

--- a/BrickController2/BrickController2/Protocols/BluetoothLowEnergy.cs
+++ b/BrickController2/BrickController2/Protocols/BluetoothLowEnergy.cs
@@ -1,0 +1,9 @@
+﻿namespace BrickController2.Protocols;
+
+public static class BluetoothLowEnergy
+{
+    // advertisment data types
+    public const byte ADTYPE_SERVICE_128BIT = 0x06;        // Service: Additional 128-bit UUIDs
+    public const byte ADTYPE_LOCAL_NAME_COMPLETE = 0x09;   // Complete local name
+    public const byte ADTYPE_MANUFACTURER_SPECIFIC = 0xFF; // Manufacturer specific data
+}


### PR DESCRIPTION
Fix for bluetooth discovery do as devices discovered by their Service UUID are properly found:
Resolves #4 
Resolves #86 