### PR TITLE
Fix characteristic writes as iOS seems to be sensitive if mistyped

### DIFF
--- a/BrickController2/BrickController2/DeviceManagement/BuWizz3Device.cs
+++ b/BrickController2/BrickController2/DeviceManagement/BuWizz3Device.cs
@@ -151,7 +151,7 @@ namespace BrickController2.DeviceManagement
         public override async Task ActiveShelfModeAsync(CancellationToken token = default)
         {
             var activateShelfModeCmd = ActivteShelfMode();
-            await _bleDevice!.WriteNoResponseAsync(_characteristic!, activateShelfModeCmd, token);
+            await _bleDevice!.WriteAsync(_characteristic!, activateShelfModeCmd, token);
         }
 
         public override bool CanResetOutput(int channel) => channel < NUMBER_OF_PU_PORTS;
@@ -377,7 +377,7 @@ namespace BrickController2.DeviceManagement
                 _sendOutputBuffer[17] = (byte)v4;
                 _sendOutputBuffer[18] = (byte)v5;
 
-                var result = await _bleDevice!.WriteNoResponseAsync(_characteristic!, _sendOutputBuffer, token).ConfigureAwait(false);
+                var result = await _bleDevice!.WriteAsync(_characteristic!, _sendOutputBuffer, token).ConfigureAwait(false);
                 await Task.Delay(100, token).ConfigureAwait(false); // this delay is needed not to flood the BW3 internal command queue
                 return result;
             }

--- a/BrickController2/BrickController2/DeviceManagement/CircuitCubeDevice.cs
+++ b/BrickController2/BrickController2/DeviceManagement/CircuitCubeDevice.cs
@@ -187,7 +187,7 @@ namespace BrickController2.DeviceManagement
                     commendBytes.CopyTo(_driveMotorsBuffer, idx);
                     idx += 5;
                 }
-                return await _bleDevice!.WriteAsync(_writeCharacteristic!, _driveMotorsBuffer, token);
+                return await _bleDevice!.WriteNoResponseAsync(_writeCharacteristic!, _driveMotorsBuffer, token);
             }
             catch (Exception)
             {
@@ -199,7 +199,7 @@ namespace BrickController2.DeviceManagement
         {
             try
             {
-                return await _bleDevice!.WriteAsync(_writeCharacteristic!, TURN_OFF_ALL_COMMAND, token);
+                return await _bleDevice!.WriteNoResponseAsync(_writeCharacteristic!, TURN_OFF_ALL_COMMAND, token);
             }
             catch (Exception)
             {
@@ -223,7 +223,7 @@ namespace BrickController2.DeviceManagement
                 HardwareVersion = hardwareRevision;
             }
 
-            await _bleDevice!.WriteAsync(_writeCharacteristic!, BATTERY_STATUS_COMMAND, token);
+            await _bleDevice!.WriteNoResponseAsync(_writeCharacteristic!, BATTERY_STATUS_COMMAND, token);
         }
     }
 }


### PR DESCRIPTION
Obviously iOS is sensitive if write type does not match the one defined by a characteristic being written. So changed to WriteNoResponseAsync and it seems to be working on iOS, Android and Windows.

Fixed devices:
- Circuit Cube
![image](https://github.com/user-attachments/assets/7ca6ed4c-f484-4876-bcc8-942c72157425)

- Buwizz3