### PR TITLE
Open context menu on right click if Windows does not support swipe items

### DIFF
--- a/BrickController2/BrickController2.WinUI/UI/CustomHandlers/CustomSwipeViewHandler.cs
+++ b/BrickController2/BrickController2.WinUI/UI/CustomHandlers/CustomSwipeViewHandler.cs
@@ -1,5 +1,6 @@
 ﻿using BrickController2.UI.Controls;
 using Microsoft.Maui.Handlers;
+using Microsoft.Maui.Platform;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Input;
 using System.Linq;
@@ -18,29 +19,26 @@ public class CustomSwipeViewHandler : SwipeViewHandler
     private void SwipeControl_RightTapped(object sender, RightTappedRoutedEventArgs e)
     {
         // open context menu instead of swipte items
-        if (VirtualView.LeftItems.Count > 0 ||
-            VirtualView.RightItems.Count > 0)
+        if (VirtualView.LeftItems.Count == 0 && VirtualView.RightItems.Count == 0)
         {
-
-            var contextMenu = new MenuFlyout();
-            foreach (var item in VirtualView.LeftItems
-                .Concat(VirtualView.RightItems)
-                .Cast<SwipeIcon>())
-            {
-                contextMenu.Items.Add(new MenuFlyoutItem
-                {
-                    Icon = new FontIcon
-                    {
-                        Glyph = item.Icon,
-                        FontFamily = item.IconImageSource is Microsoft.Maui.Controls.FontImageSource fontImage ? new(fontImage.FontFamily) : default
-                    },
-                    Text = item.Text,
-                    Command = item.Command,
-                    CommandParameter = item.CommandParameter,
-                });
-            }
-            contextMenu.ShowAt(PlatformView, e.GetPosition(PlatformView));
+            return;
         }
+
+        var contextMenu = new MenuFlyout();
+        foreach (var item in VirtualView.LeftItems
+            .Concat(VirtualView.RightItems)
+            .Cast<SwipeIcon>()
+            .Where(x => x.IsEnabled && x.IsVisible))
+        {
+            contextMenu.Items.Add(new MenuFlyoutItem
+            {
+                Icon = item.IconImageSource.ToIconSource(MauiContext!)?.CreateIconElement(),
+                Text = item.Text,
+                Command = item.Command,
+                CommandParameter = item.CommandParameter,
+            });
+        }
+        contextMenu.ShowAt(PlatformView, e.GetPosition(PlatformView));
     }
 
     protected override void DisconnectHandler(SwipeControl platformView)

--- a/BrickController2/BrickController2.WinUI/UI/CustomHandlers/CustomSwipeViewHandler.cs
+++ b/BrickController2/BrickController2.WinUI/UI/CustomHandlers/CustomSwipeViewHandler.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.Maui.Handlers;
+﻿using BrickController2.UI.Controls;
+using Microsoft.Maui.Handlers;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Input;
 using System.Linq;
@@ -16,11 +17,29 @@ public class CustomSwipeViewHandler : SwipeViewHandler
 
     private void SwipeControl_RightTapped(object sender, RightTappedRoutedEventArgs e)
     {
-        // invoke command of the first left item to suppport deletion (workaround for Windouws without touch controls)
-        if (VirtualView.LeftItems.Count == 1)
+        // open context menu instead of swipte items
+        if (VirtualView.LeftItems.Count > 0 ||
+            VirtualView.RightItems.Count > 0)
         {
-            var item = VirtualView.LeftItems.First();
-            item.OnInvoked();
+
+            var contextMenu = new MenuFlyout();
+            foreach (var item in VirtualView.LeftItems
+                .Concat(VirtualView.RightItems)
+                .Cast<SwipeIcon>())
+            {
+                contextMenu.Items.Add(new MenuFlyoutItem
+                {
+                    Icon = new FontIcon
+                    {
+                        Glyph = item.Icon,
+                        FontFamily = item.IconImageSource is Microsoft.Maui.Controls.FontImageSource fontImage ? new(fontImage.FontFamily) : default
+                    },
+                    Text = item.Text,
+                    Command = item.Command,
+                    CommandParameter = item.CommandParameter,
+                });
+            }
+            contextMenu.ShowAt(PlatformView, e.GetPosition(PlatformView));
         }
     }
 

--- a/BrickController2/BrickController2.WinUI/UI/CustomHandlers/CustomSwipeViewHandler.cs
+++ b/BrickController2/BrickController2.WinUI/UI/CustomHandlers/CustomSwipeViewHandler.cs
@@ -1,4 +1,5 @@
 ﻿using BrickController2.UI.Controls;
+using Microsoft.Maui.Graphics;
 using Microsoft.Maui.Handlers;
 using Microsoft.Maui.Platform;
 using Microsoft.UI.Xaml.Controls;
@@ -16,6 +17,13 @@ public class CustomSwipeViewHandler : SwipeViewHandler
         platformView.RightTapped += SwipeControl_RightTapped;
     }
 
+    protected override void DisconnectHandler(SwipeControl platformView)
+    {
+        platformView.RightTapped -= SwipeControl_RightTapped;
+
+        base.DisconnectHandler(platformView);
+    }
+
     private void SwipeControl_RightTapped(object sender, RightTappedRoutedEventArgs e)
     {
         // open context menu instead of swipte items
@@ -25,6 +33,7 @@ public class CustomSwipeViewHandler : SwipeViewHandler
         }
 
         var contextMenu = new MenuFlyout();
+
         foreach (var item in VirtualView.LeftItems
             .Concat(VirtualView.RightItems)
             .Cast<SwipeIcon>()
@@ -32,7 +41,7 @@ public class CustomSwipeViewHandler : SwipeViewHandler
         {
             contextMenu.Items.Add(new MenuFlyoutItem
             {
-                Icon = item.IconImageSource.ToIconSource(MauiContext!)?.CreateIconElement(),
+                Icon = GetIconElement(item),
                 Text = item.Text,
                 Command = item.Command,
                 CommandParameter = item.CommandParameter,
@@ -41,10 +50,14 @@ public class CustomSwipeViewHandler : SwipeViewHandler
         contextMenu.ShowAt(PlatformView, e.GetPosition(PlatformView));
     }
 
-    protected override void DisconnectHandler(SwipeControl platformView)
+    private IconElement? GetIconElement(SwipeIcon item)
     {
-        platformView.RightTapped -= SwipeControl_RightTapped;
-
-        base.DisconnectHandler(platformView);
+        var iconSource = item.IconImageSource.ToIconSource(MauiContext!);
+        if (iconSource is FontIconSource fontIconSource)
+        {
+            // hardcode now to override SwipeItem's Icon color which is typically white
+            fontIconSource.Foreground = Colors.Black.ToPlatform();
+        }
+        return iconSource?.CreateIconElement();
     }
 }


### PR DESCRIPTION
All enabled and visible swipe items are now shown as context menu: 
![image](https://github.com/user-attachments/assets/b78745db-8a10-406c-845b-c547f7f94258)

Will require some styling, probably after additional .NET 9 changes.
