### PR TITLE
Add GH Action to build the app for Android

### DIFF
--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -4,15 +4,21 @@ on:
   push:
     branches:
       - master
-      - '*'      
-    paths-ignore:
-      - '**/*.md'
-      - '**/*.gitignore'
-      - '**/*.gitattributes'
+      - 'releases/**'
+    paths:
+      - 'BrickController2/*.props'
+      - 'BrickController2/*.sln'
+      - 'BrickController2/BrickController2/**'
+      - 'BrickController2/BrickController2.Android/**'
   pull_request:
     branches:    
       - main
-      - '*'
+      - 'releases/**'
+    paths:
+      - 'BrickController2/*.props'
+      - 'BrickController2/*.sln'
+      - 'BrickController2/BrickController2/**'
+      - 'BrickController2/BrickController2.Android/**'
   workflow_dispatch:
 
 permissions:
@@ -39,5 +45,5 @@ jobs:
     - name: Upload Android Artifact
       uses: actions/upload-artifact@v4
       with:
-        name: mauibeach-android-ci-build
+        name: brickcontroller-android-ci-build
         path: BrickController2/BrickController2.Android/bin/Release/net8.0-android/*Signed.a*

--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -1,0 +1,43 @@
+name: Build 
+
+on:
+  push:
+    branches:
+      - master
+      - '*'      
+    paths-ignore:
+      - '**/*.md'
+      - '**/*.gitignore'
+      - '**/*.gitattributes'
+  pull_request:
+    branches:    
+      - main
+      - '*'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  build-android:
+    runs-on: windows-2022
+    name: BrickController Android Build
+    steps:
+    - uses: actions/checkout@v4
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: 8.0.x
+    - name: Install MAUI Workload
+      run: dotnet workload install maui --ignore-failed-sources
+            
+    - name: Restore Dependencies
+      run: dotnet restore BrickController2/BrickController2.Android/BrickController2.Android.csproj
+    - name: Build MAUI Android
+      run: dotnet publish BrickController2/BrickController2.Android/BrickController2.Android.csproj -c Release -f net8.0-android --no-restore
+
+    - name: Upload Android Artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: mauibeach-android-ci-build
+        path: BrickController2/BrickController2.Android/bin/Release/net8.0-android/*Signed.a*

--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -3,7 +3,7 @@ name: Build BrickController Android
 on:
   push:
     branches:
-      - master
+      - default
       - 'releases/**'
     paths:
       - '.github/**/*.yml'
@@ -13,7 +13,7 @@ on:
       - 'BrickController2/BrickController2.Android/**'
   pull_request:
     branches:    
-      - main
+      - default
       - 'releases/**'
     paths:
       - '.github/**/*.yml'

--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -1,4 +1,4 @@
-name: Build 
+name: Build BrickController Android 
 
 on:
   push:
@@ -6,6 +6,7 @@ on:
       - master
       - 'releases/**'
     paths:
+      - '.github/**/*.yml'
       - 'BrickController2/*.props'
       - 'BrickController2/*.sln'
       - 'BrickController2/BrickController2/**'
@@ -15,6 +16,7 @@ on:
       - main
       - 'releases/**'
     paths:
+      - '.github/**/*.yml'
       - 'BrickController2/*.props'
       - 'BrickController2/*.sln'
       - 'BrickController2/BrickController2/**'


### PR DESCRIPTION
There should be now CI build of BC2 app for Android available as zip archive:
![image](https://github.com/user-attachments/assets/69d0e88e-9e4a-4869-aaa6-b09329cdcdaf)

It contains:
- com.scn.BrickController2-Signed.apk
- com.scn.BrickController2-Signed.aab
