### PR TITLE
Show proper channel name if device is missing

### DIFF
--- a/BrickController2/BrickController2/DeviceManagement/Device.cs
+++ b/BrickController2/BrickController2/DeviceManagement/Device.cs
@@ -34,7 +34,7 @@ namespace BrickController2.DeviceManagement
 
         public abstract DeviceType DeviceType { get; }
         public string Address { get; }
-        public string Id => $"{DeviceType}#{Address}";
+        public string Id => DeviceId.Get(DeviceType, Address);
 
         public string Name
         {

--- a/BrickController2/BrickController2/DeviceManagement/DeviceId.cs
+++ b/BrickController2/BrickController2/DeviceManagement/DeviceId.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Diagnostics.CodeAnalysis;
+
+namespace BrickController2.DeviceManagement;
+
+internal static class DeviceId
+{
+    public static string Get(DeviceType deviceType, string address) => $"{deviceType}#{address}";
+
+    public static bool TryParse(string id, out DeviceType deviceType, [MaybeNullWhen(false)] out string address)
+    {
+        var deviceTypeAndAddress = id.Split('#');
+        if (deviceTypeAndAddress.Length != 2 ||
+            !Enum.TryParse<DeviceType>(deviceTypeAndAddress[0], out deviceType))
+        {
+            deviceType = DeviceType.Unknown;
+            address =default;
+            return false;
+        }
+
+        address = deviceTypeAndAddress[1];
+        return true;
+    }
+}

--- a/BrickController2/BrickController2/DeviceManagement/DeviceManager.cs
+++ b/BrickController2/BrickController2/DeviceManagement/DeviceManager.cs
@@ -125,15 +125,12 @@ namespace BrickController2.DeviceManagement
                 return null;
             }
 
-            var deviceTypeAndAddress = id.Split('#');
-            if (!Enum.TryParse<DeviceType>(deviceTypeAndAddress[0], out var deviceType))
+            if (!DeviceId.TryParse(id, out var deviceType, out var deviceAddress))
             {
-                _logger.LogWarning("Device ID [{id}] contains unsupported DeviceType:{deviceType}.",
-                    id, deviceTypeAndAddress[0]);
+                _logger.LogWarning("Device ID [{id}] contains unsupported DeviceType or has bad format.", id);
                 return null;
             }
 
-            var deviceAddress = deviceTypeAndAddress[1];
             return Devices.FirstOrDefault(d => d.DeviceType == deviceType && d.Address == deviceAddress);
         }
 

--- a/BrickController2/BrickController2/UI/ViewModels/ControllerProfilePageViewModel.cs
+++ b/BrickController2/BrickController2/UI/ViewModels/ControllerProfilePageViewModel.cs
@@ -380,7 +380,9 @@ namespace BrickController2.UI.ViewModels
 
                 ControllerActionValid = playLogic.ValidateControllerAction(controllerAction);
                 DeviceName = device != null ? device.Name : translationService.Translate("Missing");
-                DeviceType = device != null ? device.DeviceType : DeviceType.Unknown;
+                // primary take type from existing device or try to parse DeviceId
+                DeviceType = device != null ? device.DeviceType :
+                    (DeviceId.TryParse(controllerAction.DeviceId, out var deviceType, out var _) ? deviceType : DeviceType.Unknown);
                 Channel = controllerAction.Channel;
                 InvertName = controllerAction.IsInvert ? translationService.Translate("Inv") : string.Empty;
             }


### PR DESCRIPTION
If some device used in the controller profile is missing, there is wrong channel shown (e.g. `0` instead of `1`, etc):

Resolves #96.

Current version of the app:
![image](https://github.com/user-attachments/assets/122ec8e4-0bcb-479f-9fa6-f73155f3f987)

With this fix:
![image](https://github.com/user-attachments/assets/54ac3cb4-1a84-457c-8479-e76be62b556c)
