### PR TITLE
Fix detection of BuWizz2 having firmware 1.2.30

### DIFF
--- a/BrickController2/BrickController2/DeviceManagement/BluetoothDeviceManager.cs
+++ b/BrickController2/BrickController2/DeviceManagement/BluetoothDeviceManager.cs
@@ -89,6 +89,16 @@ namespace BrickController2.DeviceManagement
                         }
                     }
                     break;
+                case "05-45": // BuWizz2 has new ID since firmware 1.2.30
+                    if (advertismentData.TryGetValue(ADTYPE_LOCAL_NAME_COMPLETE, out byte[]? buwizzName))
+                    {
+                        var completeLocalNameString = BitConverter.ToString(buwizzName).ToLower();
+                        if (completeLocalNameString == "42-75-57-69-7a-7a-32") // BuWizz2
+                        {
+                            return (DeviceType.BuWizz2, manufacturerData);
+                        }
+                    }
+                    break;
                 case "97-03":
                     if (manufacturerDataString.Length >= 11)
                     {


### PR DESCRIPTION
Seems the latest firmware 1.2.30 has changed advertisment packet and manufacturer id:

BuWizz2 advertisment packet (firmware 1.2.30)
```
0x0201060809427557697A7A3209FF05454257020361A91106936E67B11999B3888144FB740000054E
```
- 0x09 : `0x427557697A7A32`
- 0xFF:  `0x05454257020361A9`

BuWizz2 advertisment packet (firmware 1.0.30)
```
0x0201060709427557697A7A07FF4E054257001E1106936E67B11999B3888144FB740000054E
```
- 0x09 : `0x427557697A7A`
- 0xFF:  `0x4E054257001E`

I've primary reported this issue to the original repo: https://github.com/imurvai/brickcontroller2/issues/142