### PR TITLE
Workaround for slow BLE characteristic writes for BuWizz3 [Android]

### DIFF
--- a/BrickController2/BrickController2/DeviceManagement/BuWizz3Device.cs
+++ b/BrickController2/BrickController2/DeviceManagement/BuWizz3Device.cs
@@ -38,6 +38,7 @@ namespace BrickController2.DeviceManagement
         private static readonly Guid CHARACTERISTIC_UUID_FIRMWARE_REVISION = new Guid("00002a26-0000-1000-8000-00805f9b34fb");
 
         private static readonly TimeSpan VoltageMeasurementTimeout = TimeSpan.FromSeconds(5);
+        private static readonly bool ApplyWriteWorkaround = DeviceInfo.Platform == DevicePlatform.Android;
 
         private readonly byte[] _sendOutputBuffer = new byte[] { 0x31, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, MOTOR_BREAKS_NONE, MOTOR_LUT_DISABLE_ALL };
 
@@ -380,7 +381,7 @@ namespace BrickController2.DeviceManagement
 
                 // workaround for BuWizz3 long writes with response on Android
                 // https://github.com/vicocz/brickcontroller2/issues/104
-                var result = DeviceInfo.Platform == DevicePlatform.Android
+                var result = ApplyWriteWorkaround
                     ? await _bleDevice!.WriteNoResponseAsync(_characteristic!, _sendOutputBuffer, token).ConfigureAwait(false)
                     : await _bleDevice!.WriteAsync(_characteristic!, _sendOutputBuffer, token).ConfigureAwait(false);
 

--- a/BrickController2/BrickController2/DeviceManagement/BuWizz3Device.cs
+++ b/BrickController2/BrickController2/DeviceManagement/BuWizz3Device.cs
@@ -2,6 +2,7 @@
 using BrickController2.Helpers;
 using BrickController2.PlatformServices.BluetoothLE;
 using BrickController2.Settings;
+using Microsoft.Maui.Devices;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -377,7 +378,12 @@ namespace BrickController2.DeviceManagement
                 _sendOutputBuffer[17] = (byte)v4;
                 _sendOutputBuffer[18] = (byte)v5;
 
-                var result = await _bleDevice!.WriteAsync(_characteristic!, _sendOutputBuffer, token).ConfigureAwait(false);
+                // workaround for BuWizz3 long writes with response on Android
+                // https://github.com/vicocz/brickcontroller2/issues/104
+                var result = DeviceInfo.Platform == DevicePlatform.Android
+                    ? await _bleDevice!.WriteNoResponseAsync(_characteristic!, _sendOutputBuffer, token).ConfigureAwait(false)
+                    : await _bleDevice!.WriteAsync(_characteristic!, _sendOutputBuffer, token).ConfigureAwait(false);
+
                 await Task.Delay(100, token).ConfigureAwait(false); // this delay is needed not to flood the BW3 internal command queue
                 return result;
             }


### PR DESCRIPTION
This change enables writing of BLE charactericts without response for BuWizz3 in order to address issue when writes with response takes circa 600 ms when there is a bluetooth gamepad connected to Android phone.
Proper solution, if ever, will be addressed in scope of https://github.com/vicocz/brickcontroller2/issues/104.