### PR TITLE
App crashes if there is no device but an action has a missing one

### DIFF
--- a/BrickController2/BrickController2/UI/ViewModels/ControllerProfilePageViewModel.cs
+++ b/BrickController2/BrickController2/UI/ViewModels/ControllerProfilePageViewModel.cs
@@ -243,21 +243,22 @@ namespace BrickController2.UI.ViewModels
             {
             }
         }
+
         private async Task ShowActionAsync(ControllerActionViewModel controllerActionViewModel)
         {
             try
             {
-                if (_deviceManager.Devices?.Count == 0)
+                if (_deviceManager.Devices.Count == 0)
                 {
                     await _dialogService.ShowMessageBoxAsync(
                         Translate("Warning"),
                         Translate("MissingDevices"),
                         Translate("Ok"),
-                        _disappearingTokenSource.Token);
+                        DisappearingToken);
                     return;
                 }
 
-                await NavigationService.NavigateToAsync<ControllerActionPageViewModel>(new NavigationParameters(("controlleraction", controllerActionViewModel.ControllerAction)));
+                await NavigationService.NavigateToAsync<ControllerActionPageViewModel>(new (controllerActionViewModel.ControllerAction, "controlleraction"));
             }
             catch (OperationCanceledException)
             {

--- a/BrickController2/BrickController2/UI/ViewModels/ControllerProfilePageViewModel.cs
+++ b/BrickController2/BrickController2/UI/ViewModels/ControllerProfilePageViewModel.cs
@@ -60,7 +60,7 @@ namespace BrickController2.UI.ViewModels
             AddControllerEventCommand = new SafeCommand(async () => await AddControllerEventAsync(false));
             AddControllerEventForSpecificControllerIdCommand = new SafeCommand(async () => await AddControllerEventAsync(true));
             PlayCommand = new SafeCommand(async () => await PlayAsync());
-            ControllerActionTappedCommand = new SafeCommand<ControllerActionViewModel>(async controllerActionViewModel => await NavigationService.NavigateToAsync<ControllerActionPageViewModel>(new NavigationParameters(("controlleraction", controllerActionViewModel.ControllerAction))));
+            ControllerActionTappedCommand = new SafeCommand<ControllerActionViewModel>(ShowActionAsync);
             DeleteControllerEventCommand = new SafeCommand<ControllerEvent>(async controllerEvent => await DeleteControllerEventAsync(controllerEvent));
             AddAnotherActionCommand = new SafeCommand<ControllerEvent>(AddAnotherActionAsync);
             DeleteControllerActionCommand = new SafeCommand<ControllerAction>(async controllerAction => await DeleteControllerActionAsync(controllerAction));
@@ -238,6 +238,26 @@ namespace BrickController2.UI.ViewModels
 
                     await NavigationService.NavigateToAsync<ControllerActionPageViewModel>(new NavigationParameters(("controllerevent", controllerEvent!)));
                 }
+            }
+            catch (OperationCanceledException)
+            {
+            }
+        }
+        private async Task ShowActionAsync(ControllerActionViewModel controllerActionViewModel)
+        {
+            try
+            {
+                if (_deviceManager.Devices?.Count == 0)
+                {
+                    await _dialogService.ShowMessageBoxAsync(
+                        Translate("Warning"),
+                        Translate("MissingDevices"),
+                        Translate("Ok"),
+                        _disappearingTokenSource.Token);
+                    return;
+                }
+
+                await NavigationService.NavigateToAsync<ControllerActionPageViewModel>(new NavigationParameters(("controlleraction", controllerActionViewModel.ControllerAction)));
             }
             catch (OperationCanceledException)
             {


### PR DESCRIPTION
This is edge case, but real. For example if you develop an Android app and import a creation, it crashes when trying to edit some action.