### PR TITLE
JK: fixed DuploTrainHubDevice

### DIFF
--- a/BrickController2/BrickController2/DeviceManagement/BluetoothDeviceManager.cs
+++ b/BrickController2/BrickController2/DeviceManagement/BluetoothDeviceManager.cs
@@ -109,7 +109,7 @@ namespace BrickController2.DeviceManagement
                             case "41": return (DeviceType.PoweredUp, manufacturerData);
                             case "80": return (DeviceType.TechnicHub, manufacturerData);
                             case "84": return (DeviceType.TechnicMove, manufacturerData);
-                            //case "20": return (DeviceType.DuploTrainHub, manufacturerData);
+                            case "20": return (DeviceType.DuploTrainHub, manufacturerData);
                         }
                     }
                     break;

--- a/BrickController2/BrickController2/DeviceManagement/ControlPlusDevice.cs
+++ b/BrickController2/BrickController2/DeviceManagement/ControlPlusDevice.cs
@@ -41,7 +41,7 @@ namespace BrickController2.DeviceManagement
         private readonly bool[] _positionsUpdated;
         private readonly DateTime[] _positionUpdateTimes;
         private readonly object _positionLock = new object();
-        private readonly Stopwatch _lastSent_NormalMotor = new Stopwatch();
+        private readonly Stopwatch[] _lastSent_NormalMotor;
 
         private IGattCharacteristic? _characteristic;
 
@@ -51,6 +51,7 @@ namespace BrickController2.DeviceManagement
             _outputValues = new int[NumberOfChannels];
             _lastOutputValues = new int[NumberOfChannels];
             _sendAttemptsLeft = new int[NumberOfChannels];
+            _lastSent_NormalMotor = new Stopwatch[NumberOfChannels];
 
             _channelOutputTypes = new ChannelOutputType[NumberOfChannels];
             _maxServoAngles = new int[NumberOfChannels];
@@ -388,7 +389,6 @@ namespace BrickController2.DeviceManagement
                         InitializeChannelInfo(channel);
                     }
                 }
-                _lastSent_NormalMotor.Reset();
 
                 while (!token.IsCancellationRequested)
                 {
@@ -411,6 +411,7 @@ namespace BrickController2.DeviceManagement
             _outputValues[channel] = 0;
             _lastOutputValues[channel] = lastOutputValue;
             _sendAttemptsLeft[channel] = sendAttempsLeft;
+            _lastSent_NormalMotor[channel] = new Stopwatch();
             _positionsUpdated[channel] = false;
             _positionUpdateTimes[channel] = DateTime.MinValue;
         }
@@ -493,12 +494,12 @@ namespace BrickController2.DeviceManagement
 
                 if (v != _lastOutputValues[channel] || 
                     sendAttemptsLeft > 0 ||
-                    _lastSent_NormalMotor.Elapsed > ResendDelay_NormalMotor)
+                    _lastSent_NormalMotor[channel].Elapsed > ResendDelay_NormalMotor)
                 {
                     var outputCmd = GetOutputCommand(channel, v);
                     if (await _bleDevice!.WriteNoResponseAsync(_characteristic!, outputCmd, token))
                     {
-                        _lastSent_NormalMotor.Restart();
+                        _lastSent_NormalMotor[channel].Restart();
 
                         _lastOutputValues[channel] = v;
                         ResetSendAttemps(channel, 0);

--- a/BrickController2/BrickController2/DeviceManagement/ControlPlusDevice.cs
+++ b/BrickController2/BrickController2/DeviceManagement/ControlPlusDevice.cs
@@ -41,7 +41,7 @@ namespace BrickController2.DeviceManagement
         private readonly bool[] _positionsUpdated;
         private readonly DateTime[] _positionUpdateTimes;
         private readonly object _positionLock = new object();
-        private readonly Stopwatch[] _lastSent_NormalMotor;
+        private readonly Stopwatch _lastSent_NormalMotor = new Stopwatch();
 
         private IGattCharacteristic? _characteristic;
 
@@ -51,7 +51,6 @@ namespace BrickController2.DeviceManagement
             _outputValues = new int[NumberOfChannels];
             _lastOutputValues = new int[NumberOfChannels];
             _sendAttemptsLeft = new int[NumberOfChannels];
-            _lastSent_NormalMotor = new Stopwatch[NumberOfChannels];
 
             _channelOutputTypes = new ChannelOutputType[NumberOfChannels];
             _maxServoAngles = new int[NumberOfChannels];
@@ -389,6 +388,7 @@ namespace BrickController2.DeviceManagement
                         InitializeChannelInfo(channel);
                     }
                 }
+                _lastSent_NormalMotor.Reset();
 
                 while (!token.IsCancellationRequested)
                 {
@@ -411,7 +411,6 @@ namespace BrickController2.DeviceManagement
             _outputValues[channel] = 0;
             _lastOutputValues[channel] = lastOutputValue;
             _sendAttemptsLeft[channel] = sendAttempsLeft;
-            _lastSent_NormalMotor[channel] = new Stopwatch();
             _positionsUpdated[channel] = false;
             _positionUpdateTimes[channel] = DateTime.MinValue;
         }
@@ -494,12 +493,12 @@ namespace BrickController2.DeviceManagement
 
                 if (v != _lastOutputValues[channel] || 
                     sendAttemptsLeft > 0 ||
-                    _lastSent_NormalMotor[channel].Elapsed > ResendDelay_NormalMotor)
+                    _lastSent_NormalMotor.Elapsed > ResendDelay_NormalMotor)
                 {
                     var outputCmd = GetOutputCommand(channel, v);
                     if (await _bleDevice!.WriteNoResponseAsync(_characteristic!, outputCmd, token))
                     {
-                        _lastSent_NormalMotor[channel].Restart();
+                        _lastSent_NormalMotor.Restart();
 
                         _lastOutputValues[channel] = v;
                         ResetSendAttemps(channel, 0);

--- a/BrickController2/BrickController2/DeviceManagement/DuploTrainHubDevice.cs
+++ b/BrickController2/BrickController2/DeviceManagement/DuploTrainHubDevice.cs
@@ -1,4 +1,5 @@
-﻿using BrickController2.PlatformServices.BluetoothLE;
+﻿using System;
+using BrickController2.PlatformServices.BluetoothLE;
 
 namespace BrickController2.DeviceManagement
 {
@@ -11,5 +12,6 @@ namespace BrickController2.DeviceManagement
 
         public override DeviceType DeviceType => DeviceType.DuploTrainHub;
         public override int NumberOfChannels => 1;
+        protected override TimeSpan ResendDelay_NormalMotor => TimeSpan.FromMilliseconds(500);
     }
 }

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Cross platform mobile application for controlling your creations using a bluetoo
 - Lego Technic Hub
 - Lego WeDo 2.0 Smart Hub
 - Lego Technic Move Hub (PLAYVM mode)
+- Lego Duplo Train Hub
 - Circuit Cubes
 - Mould King 4.0 Powered Module
 - Mould King 6.0 Powered Module


### PR DESCRIPTION
The Problem:
After setting a new value to the one channel of the `DuploTainHubDevice` it was doing it's job.
But after a short peridod of time the motor was stopping!
The problem is/was that the data has to be resend....

I added a mechanism to resend data after a certain period of time has elapsed.

It's done in the baseclass `ControlPlusDevice` by adding a stopwatch and a virtual property `ResendDelay_NormalMotor` to set the ResendDelay wich is overridden and set in `DuploTrainHubDevice`.

Please have a look at my changes.