### PR TITLE
Discover BuWizz2 / BuWizz3 based on service UUID (if supported by platform)

### DIFF
--- a/BrickController2/BrickController2.Tests/DeviceManagement/BuWizz/BuWizzDeviceManagerTests.cs
+++ b/BrickController2/BrickController2.Tests/DeviceManagement/BuWizz/BuWizzDeviceManagerTests.cs
@@ -93,4 +93,24 @@ public class BuWizzDeviceManagerTests : DeviceManagerTestBase<BuWizzDeviceManage
             ManufacturerData = BitConverter.GetBytes(0x054e)
         });
     }
+
+    [Fact]
+    public void TryGetDevice_BuWizz3ServiceUuidWithOtherOne_ReturnsProperBuWizz3Device()
+    {
+        var scanResult = CreateScanResult("BuWizz3-ByUuid", new Dictionary<byte, byte[]>
+        {
+            { 0x06, [0x03, 0x0E, 0x07, 0x01, 0x09, 0x09, 0x03, 0x08, 0x01, 0x04, 0x0B, 0x04, 0x01, 0x02, 0x05, 0x00,
+                     0x93, 0x6E, 0x67, 0xB1, 0x19, 0x99, 0xB3, 0x88, 0x81, 0x44, 0xFB, 0x74, 0xD1, 0x92, 0x05, 0x50] }
+        });
+
+        var result = _manager.TryGetDevice(scanResult, out var device);
+
+        result.Should().BeTrue();
+        device.Should().BeEquivalentTo(new FoundDevice()
+        {
+            DeviceAddress = scanResult.DeviceAddress,
+            DeviceName = scanResult.DeviceName,
+            DeviceType = DeviceType.BuWizz3
+        });
+    }
 }

--- a/BrickController2/BrickController2.Tests/DeviceManagement/BuWizz/BuWizzDeviceManagerTests.cs
+++ b/BrickController2/BrickController2.Tests/DeviceManagement/BuWizz/BuWizzDeviceManagerTests.cs
@@ -32,11 +32,11 @@ public class BuWizzDeviceManagerTests : DeviceManagerTestBase<BuWizzDeviceManage
     [InlineData(new byte[] { 0x4e, 0x05, 0x42, 0x57, 0x02, 0x01 }, DeviceType.BuWizz2)] // legacy BW2
     [InlineData(new byte[] { 0x05, 0x45, 0x42, 0x57, 0x02, 0x03 }, DeviceType.BuWizz2)] // new BW2
     [InlineData(new byte[] { 0x4e, 0x05, 0x42, 0x57, 0x03, 0x22 }, DeviceType.BuWizz3)] // BW3
-    public void TryGetDevice_BuWizzManufacturerIdWithLocalName_ReturnsProperBuWizzDevice(byte[] manufacturerId, DeviceType deviceType)
+    public void TryGetDevice_BuWizzManufacturerData_ReturnsProperBuWizzDevice(byte[] manufacturerData, DeviceType deviceType)
     {
         var scanResult = CreateScanResult("BuWizz", new Dictionary<byte, byte[]>
         {
-            { 0xff, manufacturerId }
+            { 0xff, manufacturerData }
         });
 
         var result = _manager.TryGetDevice(scanResult, out var device);
@@ -47,7 +47,7 @@ public class BuWizzDeviceManagerTests : DeviceManagerTestBase<BuWizzDeviceManage
             DeviceAddress = scanResult.DeviceAddress,
             DeviceName = scanResult.DeviceName,
             DeviceType = deviceType,
-            ManufacturerData = manufacturerId
+            ManufacturerData = manufacturerData
         });
     }
 

--- a/BrickController2/BrickController2.Tests/DeviceManagement/BuWizz/BuWizzDeviceManagerTests.cs
+++ b/BrickController2/BrickController2.Tests/DeviceManagement/BuWizz/BuWizzDeviceManagerTests.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Text;
 using BrickController2.DeviceManagement;
 using BrickController2.DeviceManagement.BuWizz;
+using BrickController2.Protocols;
 using FluentAssertions;
 using Xunit;
 
@@ -48,6 +49,49 @@ public class BuWizzDeviceManagerTests : DeviceManagerTestBase<BuWizzDeviceManage
             DeviceName = scanResult.DeviceName,
             DeviceType = deviceType,
             ManufacturerData = BitConverter.GetBytes(manufacturerId)
+        });
+    }
+
+    [Fact]
+    public void TryGetDevice_BuWizz2ServiceUuidWithoutLocalName_ReturnsProperBuWizz2Device()
+    {
+        var scanResult = CreateScanResult("BuWizz3-ByUuid", new Dictionary<byte, byte[]>
+        {
+            { 0xff, BitConverter.GetBytes(0x054e) },
+            { 0x07, new Guid("4e050000-74fb-4481-88b3-9919b1676e93").To128BitByteArray() }
+        });
+
+        var result = _manager.TryGetDevice(scanResult, out var device);
+
+        result.Should().BeTrue();
+        device.Should().BeEquivalentTo(new FoundDevice()
+        {
+            DeviceAddress = scanResult.DeviceAddress,
+            DeviceName = scanResult.DeviceName,
+            DeviceType = DeviceType.BuWizz2,
+            ManufacturerData = BitConverter.GetBytes(0x054e)
+        });
+    }
+
+    [Fact]
+    public void TryGetDevice_BuWizz3ServiceUuidWithWrongLocalName_ReturnsProperBuWizz3Device()
+    {
+        var scanResult = CreateScanResult("BuWizz3-ByUuid", new Dictionary<byte, byte[]>
+        {
+            { 0xff, BitConverter.GetBytes(0x054e) },
+            { 0x09, Encoding.ASCII.GetBytes("BuWizz") },
+            { 0x06, new Guid("500592d1-74fb-4481-88b3-9919b1676e93").To128BitByteArray() }
+        });
+
+        var result = _manager.TryGetDevice(scanResult, out var device);
+
+        result.Should().BeTrue();
+        device.Should().BeEquivalentTo(new FoundDevice()
+        {
+            DeviceAddress = scanResult.DeviceAddress,
+            DeviceName = scanResult.DeviceName,
+            DeviceType = DeviceType.BuWizz3,
+            ManufacturerData = BitConverter.GetBytes(0x054e)
         });
     }
 }

--- a/BrickController2/BrickController2.Tests/DeviceManagement/BuWizz/BuWizzDeviceManagerTests.cs
+++ b/BrickController2/BrickController2.Tests/DeviceManagement/BuWizz/BuWizzDeviceManagerTests.cs
@@ -29,15 +29,14 @@ public class BuWizzDeviceManagerTests : DeviceManagerTestBase<BuWizzDeviceManage
     }
 
     [Theory]
-    [InlineData(0x054e, "BuWizz", DeviceType.BuWizz2)]
-    [InlineData(0x4505, "BuWizz2", DeviceType.BuWizz2)]
-    [InlineData(0x054e, "BuWizz3", DeviceType.BuWizz3)]
-    public void TryGetDevice_BuWizzManufacturerIdWithLocalName_ReturnsProperBuWizzDevice(ushort manufacturerId, string localName, DeviceType deviceType)
+    [InlineData(new byte[] { 0x4e, 0x05, 0x42, 0x57, 0x02, 0x01 }, DeviceType.BuWizz2)] // legacy BW2
+    [InlineData(new byte[] { 0x05, 0x45, 0x42, 0x57, 0x02, 0x03 }, DeviceType.BuWizz2)] // new BW2
+    [InlineData(new byte[] { 0x4e, 0x05, 0x42, 0x57, 0x03, 0x22 }, DeviceType.BuWizz3)] // BW3
+    public void TryGetDevice_BuWizzManufacturerIdWithLocalName_ReturnsProperBuWizzDevice(byte[] manufacturerId, DeviceType deviceType)
     {
         var scanResult = CreateScanResult("BuWizz", new Dictionary<byte, byte[]>
         {
-            { 0xff, BitConverter.GetBytes(manufacturerId) },
-            { 0x09, Encoding.ASCII.GetBytes(localName) }
+            { 0xff, manufacturerId }
         });
 
         var result = _manager.TryGetDevice(scanResult, out var device);
@@ -48,16 +47,16 @@ public class BuWizzDeviceManagerTests : DeviceManagerTestBase<BuWizzDeviceManage
             DeviceAddress = scanResult.DeviceAddress,
             DeviceName = scanResult.DeviceName,
             DeviceType = deviceType,
-            ManufacturerData = BitConverter.GetBytes(manufacturerId)
+            ManufacturerData = manufacturerId
         });
     }
 
     [Fact]
-    public void TryGetDevice_BuWizz2ServiceUuidWithoutLocalName_ReturnsProperBuWizz2Device()
+    public void TryGetDevice_BuWizz2ServiceUuid_ReturnsProperBuWizz2Device()
     {
-        var scanResult = CreateScanResult("BuWizz3-ByUuid", new Dictionary<byte, byte[]>
+        var scanResult = CreateScanResult("BuWizz2-ByUuid", new Dictionary<byte, byte[]>
         {
-            { 0xff, BitConverter.GetBytes(0x054e) },
+            { 0xff, [0x01, 0x02, 0x03] },
             { 0x07, new Guid("4e050000-74fb-4481-88b3-9919b1676e93").To128BitByteArray() }
         });
 
@@ -69,18 +68,18 @@ public class BuWizzDeviceManagerTests : DeviceManagerTestBase<BuWizzDeviceManage
             DeviceAddress = scanResult.DeviceAddress,
             DeviceName = scanResult.DeviceName,
             DeviceType = DeviceType.BuWizz2,
-            ManufacturerData = BitConverter.GetBytes(0x054e)
+            ManufacturerData = [0x01, 0x02, 0x03]
         });
     }
 
     [Fact]
-    public void TryGetDevice_BuWizz3ServiceUuidWithWrongLocalName_ReturnsProperBuWizz3Device()
+    public void TryGetDevice_BuWizz3ServiceUuid_ReturnsProperBuWizz3Device()
     {
         var scanResult = CreateScanResult("BuWizz3-ByUuid", new Dictionary<byte, byte[]>
         {
             { 0xff, BitConverter.GetBytes(0x054e) },
             { 0x09, Encoding.ASCII.GetBytes("BuWizz") },
-            { 0x06, new Guid("500592d1-74fb-4481-88b3-9919b1676e93").To128BitByteArray() }
+            { 0x06, [0x93, 0x6E, 0x67, 0xB1, 0x19, 0x99, 0xB3, 0x88, 0x81, 0x44, 0xFB, 0x74, 0xD1, 0x92, 0x05, 0x50] }
         });
 
         var result = _manager.TryGetDevice(scanResult, out var device);

--- a/BrickController2/BrickController2.WinUI/PlatformServices/BluetoothLE/BleScanner.cs
+++ b/BrickController2/BrickController2.WinUI/PlatformServices/BluetoothLE/BleScanner.cs
@@ -20,6 +20,7 @@ public class BleScanner
     private static readonly IReadOnlySet<byte> AdvertismentDataTypes = new HashSet<byte>(
     [
         BluetoothLEAdvertisementDataTypes.ManufacturerSpecificData,
+        BluetoothLEAdvertisementDataTypes.CompleteService128BitUuids,
         BluetoothLEAdvertisementDataTypes.IncompleteService128BitUuids,
         BluetoothLEAdvertisementDataTypes.CompleteLocalName
     ]);

--- a/BrickController2/BrickController2.iOS/PlatformServices/BluetoothLE/BluetoothLEService.cs
+++ b/BrickController2/BrickController2.iOS/PlatformServices/BluetoothLE/BluetoothLEService.cs
@@ -126,6 +126,7 @@ namespace BrickController2.iOS.PlatformServices.BluetoothLE
             var serviceUuid = GetServiceUuidForKey(advertisementData, CBAdvertisement.DataServiceUUIDsKey);
             if (serviceUuid is not null)
             {
+                // set it as incomplete service UUID (even though it might be the complete lest)
                 result[ADTYPE_INCOMPLETE_SERVICE_128BIT] = serviceUuid;
             }
 

--- a/BrickController2/BrickController2.iOS/PlatformServices/BluetoothLE/BluetoothLEService.cs
+++ b/BrickController2/BrickController2.iOS/PlatformServices/BluetoothLE/BluetoothLEService.cs
@@ -126,7 +126,7 @@ namespace BrickController2.iOS.PlatformServices.BluetoothLE
             var serviceUuid = GetServiceUuidForKey(advertisementData, CBAdvertisement.DataServiceUUIDsKey);
             if (serviceUuid is not null)
             {
-                // set it as incomplete service UUID (even though it might be the complete lest)
+                // set it as incomplete service UUID (even though it might be the complete list)
                 result[ADTYPE_INCOMPLETE_SERVICE_128BIT] = serviceUuid;
             }
 

--- a/BrickController2/BrickController2.iOS/PlatformServices/BluetoothLE/BluetoothLEService.cs
+++ b/BrickController2/BrickController2.iOS/PlatformServices/BluetoothLE/BluetoothLEService.cs
@@ -126,7 +126,7 @@ namespace BrickController2.iOS.PlatformServices.BluetoothLE
             var serviceUuid = GetServiceUuidForKey(advertisementData, CBAdvertisement.DataServiceUUIDsKey);
             if (serviceUuid is not null)
             {
-                result[ADTYPE_SERVICE_128BIT] = serviceUuid;
+                result[ADTYPE_INCOMPLETE_SERVICE_128BIT] = serviceUuid;
             }
 
             // TODO: add the rest of the advertisementdata...

--- a/BrickController2/BrickController2/DeviceManagement/BluetoothDeviceManagerBase.cs
+++ b/BrickController2/BrickController2/DeviceManagement/BluetoothDeviceManagerBase.cs
@@ -22,7 +22,7 @@ public abstract class BluetoothDeviceManagerBase : IBluetoothLEDeviceManager
         // build device template using available data from scan
         var template = new FoundDevice(DeviceType.Unknown, scanResult.DeviceName, scanResult.DeviceAddress);
 
-        // adjust device template
+        // adjust device template if there is manufacturer data present
         if (scanResult.TryGetManufacturerData(out var manufacturerData) && manufacturerData.Length > 0)
         {
             template = template with
@@ -37,7 +37,7 @@ public abstract class BluetoothDeviceManagerBase : IBluetoothLEDeviceManager
             return true;
         }
 
-        // if there is manufacturer data, prefer it
+        // if there is manufacturer data, try to apply it
         if (manufacturerData.Length >= 2)
         {
             var manufacturerId = manufacturerData.GetUInt16();

--- a/BrickController2/BrickController2/DeviceManagement/BluetoothDeviceManagerBase.cs
+++ b/BrickController2/BrickController2/DeviceManagement/BluetoothDeviceManagerBase.cs
@@ -141,3 +141,4 @@ public abstract class BluetoothDeviceManagerBase : IBluetoothLEDeviceManager
         return false;
     }
 }
+

--- a/BrickController2/BrickController2/DeviceManagement/BluetoothDeviceManagerBase.cs
+++ b/BrickController2/BrickController2/DeviceManagement/BluetoothDeviceManagerBase.cs
@@ -22,31 +22,39 @@ public abstract class BluetoothDeviceManagerBase : IBluetoothLEDeviceManager
         // build device template using available data from scan
         var template = new FoundDevice(DeviceType.Unknown, scanResult.DeviceName, scanResult.DeviceAddress);
 
-        // if there is no manufacturer data, try other methods
-        if (!scanResult.TryGetManufacturerData(out var manufacturerData) || manufacturerData.Length < 2)
+        // adjust device template
+        if (scanResult.TryGetManufacturerData(out var manufacturerData) && manufacturerData.Length > 0)
         {
-            // by exact service UUID present in advertisment data
-            if (TryGetDeviceInfoByService(template, scanResult, out device))
+            template = template with
+            {
+                ManufacturerData = manufacturerData.ToArray()
+            };
+        }
+
+        // by exact service UUID present in advertisment data
+        if (TryGetDeviceInfoByService(template, scanResult, out device))
+        {
+            return true;
+        }
+
+        // if there is manufacturer data, prefer it
+        if (manufacturerData.Length >= 2)
+        {
+            var manufacturerId = manufacturerData.GetUInt16();
+            if (TryGetDeviceByManufacturerData(scanResult, template, manufacturerId, manufacturerData, out device))
             {
                 return true;
             }
-
-            // by well known local name
-            if (scanResult.TryGetCompleteLocalName(out var localName))
-            {
-                return TryGetDeviceByCompleteLocalName(template, localName, out device);
-            }
-
-            device = default;
-            return false;
         }
-        // adjust device template
-        template = template with
+
+        // by well known local name
+        if (scanResult.TryGetCompleteLocalName(out var localName))
         {
-            ManufacturerData = manufacturerData.ToArray()
-        };
-        var manufacturerId = manufacturerData.GetUInt16();
-        return TryGetDeviceByManufacturerData(scanResult, template, manufacturerId, manufacturerData, out device);
+            return TryGetDeviceByCompleteLocalName(template, localName, out device);
+        }
+
+        device = default;
+        return false;
     }
 
     /// <summary>
@@ -93,15 +101,41 @@ public abstract class BluetoothDeviceManagerBase : IBluetoothLEDeviceManager
     private bool TryGetDeviceInfoByService(FoundDevice template, ScanResult scanResult, out FoundDevice device)
     {
         // 0x06: 128 bits Service UUID type
-        if (scanResult.TryGetData(ADTYPE_SERVICE_128BIT, out var serviceData))
+        if (scanResult.TryGetData(ADTYPE_INCOMPLETE_SERVICE_128BIT, out var incompleteServiceData))
         {
-            if (serviceData.Length == 16)
+            if (TryGetDeviceByServiceUiid(template, scanResult, incompleteServiceData, out device))
             {
-                var serviceGuid = BluetoothLowEnergy.GetGuid(serviceData);
-                return TryGetDeviceByServiceUiid(template, serviceGuid, out device);
+                return true;
+            }
+        }
+        
+        // 0x07: 128 bits Service UUID type
+        if (scanResult.TryGetData(ADTYPE_COMPLETE_SERVICE_128BIT, out var completeServiceData))
+        {
+            if (TryGetDeviceByServiceUiid(template, scanResult, completeServiceData, out device))
+            {
+                return true;
             }
         }
         // detect other types of UUID if needed
+
+        device = default;
+        return false;
+    }
+
+    private bool TryGetDeviceByServiceUiid(FoundDevice template, ScanResult scanResult, ReadOnlySpan<byte> serviceData, out FoundDevice device)
+    {
+        // go through all service UUIDs if needed
+        while (serviceData.Length >= 16)
+        {
+            var serviceGuid = BluetoothLowEnergy.GetGuid(serviceData[..16]);
+            if (TryGetDeviceByServiceUiid(template, serviceGuid, out device))
+            {
+                return true;
+            }
+
+            serviceData = serviceData[16..];
+        }
 
         device = default;
         return false;

--- a/BrickController2/BrickController2/DeviceManagement/BuWizz/BuWizzDeviceManager.cs
+++ b/BrickController2/BrickController2/DeviceManagement/BuWizz/BuWizzDeviceManager.cs
@@ -50,4 +50,17 @@ public class BuWizzDeviceManager : BluetoothDeviceManagerBase
         device = default;
         return false;
     }
+    
+    protected override bool TryGetDeviceByServiceUiid(FoundDevice template, Guid serviceGuid, out FoundDevice device)
+    {
+        // detect BuWizz2 (firmware 1.2.30+) and BuWizz3 by service UUID
+        device = serviceGuid switch
+        {
+            {} when serviceGuid == BuWizz2Device.SERVICE_UUID => template with { DeviceType = DeviceType.BuWizz2 },
+            {} when serviceGuid == BuWizz3Device.SERVICE_UUID => template with { DeviceType = DeviceType.BuWizz3 },
+            _ => default
+        };
+
+        return device.DeviceType != DeviceType.Unknown;
+    }
 }

--- a/BrickController2/BrickController2/DeviceManagement/BuWizz/BuWizzDeviceManager.cs
+++ b/BrickController2/BrickController2/DeviceManagement/BuWizz/BuWizzDeviceManager.cs
@@ -8,12 +8,15 @@ namespace BrickController2.DeviceManagement.BuWizz;
 /// </summary>
 public class BuWizzDeviceManager : BluetoothDeviceManagerBase
 {
+    //  05:4E:’B’:’W’:’x’:’y’ where x and y are firmware version
+    private static readonly byte[] BuWizz3Prefix = [0x4e, 0x05, 0x42, 0x57, 0x03];
+    private static readonly byte[] BuWizz2Prefix = [0x05, 0x45, 0x42, 0x57, 0x02];
+
     protected override bool TryGetDeviceByManufacturerData(ScanResult scanResult,
         FoundDevice template, ushort manufacturerId,
         ReadOnlySpan<byte> manufacturerData,
         out FoundDevice device)
     {
-        ReadOnlySpan<byte> completeLocalName;
         switch (manufacturerId)
         {
             case 0x4d48:
@@ -21,28 +24,21 @@ public class BuWizzDeviceManager : BluetoothDeviceManagerBase
                 return true;
 
             case 0x054e:
-                if (scanResult.TryGetCompleteLocalName(out completeLocalName))
+                if (manufacturerData.StartsWith(BuWizz3Prefix))
                 {
-                    if (completeLocalName.SequenceEqual("BuWizz"u8)) // BuWizz
-                    {
-                        device = template with { DeviceType = DeviceType.BuWizz2 };
-                    }
-                    else
-                    {
-                        device = template with { DeviceType = DeviceType.BuWizz3 };
-                    }
-                    return true;
+                    device = template with { DeviceType = DeviceType.BuWizz3 };
                 }
-                break;
+                else
+                {
+                    device = template with { DeviceType = DeviceType.BuWizz2 };
+                }
+                return true;
 
             case 0x4505: // BuWizz2 has new ID since firmware 1.2.30
-                if (scanResult.TryGetCompleteLocalName(out completeLocalName))
+                if (manufacturerData.StartsWith(BuWizz2Prefix))
                 {
-                    if (completeLocalName.SequenceEqual("BuWizz2"u8)) // BuWizz2
-                    {
-                        device = template with { DeviceType = DeviceType.BuWizz2 };
-                        return true;
-                    }
+                    device = template with { DeviceType = DeviceType.BuWizz2 };
+                    return true;
                 }
                 break;
         }

--- a/BrickController2/BrickController2/DeviceManagement/BuWizz/BuWizzDeviceManager.cs
+++ b/BrickController2/BrickController2/DeviceManagement/BuWizz/BuWizzDeviceManager.cs
@@ -8,7 +8,8 @@ namespace BrickController2.DeviceManagement.BuWizz;
 /// </summary>
 public class BuWizzDeviceManager : BluetoothDeviceManagerBase
 {
-    //  05:4E:’B’:’W’:’x’:’y’ where x and y are firmware version
+    // Discovering BuWizz device is based on the following information:
+    // 4E:05:’B’:’W’:’x’:’y’ where x and y are firmware version
     private static readonly byte[] BuWizz3Prefix = [0x4e, 0x05, 0x42, 0x57, 0x03];
     private static readonly byte[] BuWizz2Prefix = [0x05, 0x45, 0x42, 0x57, 0x02];
 
@@ -24,6 +25,7 @@ public class BuWizzDeviceManager : BluetoothDeviceManagerBase
                 return true;
 
             case 0x054e:
+                // check if there is well known BuWizz3 manufacturer data prefix
                 if (manufacturerData.StartsWith(BuWizz3Prefix))
                 {
                     device = template with { DeviceType = DeviceType.BuWizz3 };

--- a/BrickController2/BrickController2/DeviceManagement/BuWizz/BuWizzDeviceManager.cs
+++ b/BrickController2/BrickController2/DeviceManagement/BuWizz/BuWizzDeviceManager.cs
@@ -8,54 +8,42 @@ namespace BrickController2.DeviceManagement.BuWizz;
 /// </summary>
 public class BuWizzDeviceManager : BluetoothDeviceManagerBase
 {
-    // Discovering BuWizz device is based on the following information:
-    // 4E:05:’B’:’W’:’x’:’y’ where x and y are firmware version
-    private static readonly byte[] BuWizz3Prefix = [0x4e, 0x05, 0x42, 0x57, 0x03];
-    private static readonly byte[] BuWizz2Prefix = [0x05, 0x45, 0x42, 0x57, 0x02];
-
     protected override bool TryGetDeviceByManufacturerData(ScanResult scanResult,
         FoundDevice template, ushort manufacturerId,
         ReadOnlySpan<byte> manufacturerData,
         out FoundDevice device)
     {
-        switch (manufacturerId)
+        // Discovering BuWizz device is based on the following information:
+        // 4E:05:’B’:’W’:’x’:’y’ where x and y are firmware version
+        // 05:45:’B’:’W’:’x’:’y’ where x and y are firmware version
+
+        device = manufacturerData switch
         {
-            case 0x4d48:
-                device = template with { DeviceType = DeviceType.BuWizz };
-                return true;
+            // legacy BuWizz 1 - manufacturer ID only
+            [0x48, 0x4d, ..] => template with { DeviceType = DeviceType.BuWizz },
+            // BuWizz 3 prefix - 
+            [0x4e, 0x05, 0x42, 0x57, 0x03, ..] => template with { DeviceType = DeviceType.BuWizz3 },
+            // BuWizz 2 with older firmware -
+            [0x4e, 0x05, ..] or
+            // BuWizz2 with new ID since firmware 1.2.30
+            [0x05, 0x45, 0x42, 0x57, 0x02, ..] => template with { DeviceType = DeviceType.BuWizz2 },
 
-            case 0x054e:
-                // check if there is well known BuWizz3 manufacturer data prefix
-                if (manufacturerData.StartsWith(BuWizz3Prefix))
-                {
-                    device = template with { DeviceType = DeviceType.BuWizz3 };
-                }
-                else
-                {
-                    device = template with { DeviceType = DeviceType.BuWizz2 };
-                }
-                return true;
+            _ => default,
+        };
 
-            case 0x4505: // BuWizz2 has new ID since firmware 1.2.30
-                if (manufacturerData.StartsWith(BuWizz2Prefix))
-                {
-                    device = template with { DeviceType = DeviceType.BuWizz2 };
-                    return true;
-                }
-                break;
-        }
-        // no match
-        device = default;
-        return false;
+        return device.DeviceType != DeviceType.Unknown;
     }
     
     protected override bool TryGetDeviceByServiceUiid(FoundDevice template, Guid serviceGuid, out FoundDevice device)
     {
-        // detect BuWizz2 (firmware 1.2.30+) and BuWizz3 by service UUID
+        // this is prefered way however UUID might not be available on some platforms
         device = serviceGuid switch
         {
-            {} when serviceGuid == BuWizz2Device.SERVICE_UUID => template with { DeviceType = DeviceType.BuWizz2 },
-            {} when serviceGuid == BuWizz3Device.SERVICE_UUID => template with { DeviceType = DeviceType.BuWizz3 },
+            // BuWizz2 (firmware 1.2.30 +)
+            { } when serviceGuid == BuWizz2Device.SERVICE_UUID => template with { DeviceType = DeviceType.BuWizz2 },
+            // BuWizz3
+            { } when serviceGuid == BuWizz3Device.SERVICE_UUID => template with { DeviceType = DeviceType.BuWizz3 },
+
             _ => default
         };
 

--- a/BrickController2/BrickController2/DeviceManagement/BuWizz2Device.cs
+++ b/BrickController2/BrickController2/DeviceManagement/BuWizz2Device.cs
@@ -14,7 +14,7 @@ namespace BrickController2.DeviceManagement
     {
         private const int MAX_SEND_ATTEMPTS = 10;
 
-        private static readonly Guid SERVICE_UUID = new Guid("4e050000-74fb-4481-88b3-9919b1676e93");
+        internal static readonly Guid SERVICE_UUID = new Guid("4e050000-74fb-4481-88b3-9919b1676e93");
         private static readonly Guid CHARACTERISTIC_UUID = new Guid("000092d1-0000-1000-8000-00805f9b34fb");
                 
         private static readonly Guid SERVICE_UUID_DEVICE_INFORMATION = new Guid("0000180a-0000-1000-8000-00805f9b34fb");

--- a/BrickController2/BrickController2/DeviceManagement/BuWizz3Device.cs
+++ b/BrickController2/BrickController2/DeviceManagement/BuWizz3Device.cs
@@ -30,7 +30,7 @@ namespace BrickController2.DeviceManagement
         private const double DefaultPoweredUpCurrentLimit = 1050;
         private const double DefaultPowerFunctionsCurrentLimit = 2100;
 
-        private static readonly Guid SERVICE_UUID = new Guid("500592d1-74fb-4481-88b3-9919b1676e93");
+        internal static readonly Guid SERVICE_UUID = new Guid("500592d1-74fb-4481-88b3-9919b1676e93");
         private static readonly Guid CHARACTERISTIC_UUID = new Guid("50052901-74fb-4481-88b3-9919b1676e93");
 
         private static readonly Guid SERVICE_UUID_DEVICE_INFORMATION = new Guid("0000180a-0000-1000-8000-00805f9b34fb");

--- a/BrickController2/BrickController2/Protocols/BluetoothLowEnergy.cs
+++ b/BrickController2/BrickController2/Protocols/BluetoothLowEnergy.cs
@@ -6,7 +6,8 @@ namespace BrickController2.Protocols;
 public static class BluetoothLowEnergy
 {
     // advertisment data types
-    public const byte ADTYPE_SERVICE_128BIT = 0x06;        // Service: Additional 128-bit UUIDs
+    public const byte ADTYPE_INCOMPLETE_SERVICE_128BIT = 0x06; // Service: Additional 128-bit UUIDs
+    public const byte ADTYPE_COMPLETE_SERVICE_128BIT = 0x07;   // Service: Additional 128-bit UUIDs
     public const byte ADTYPE_LOCAL_NAME_COMPLETE = 0x09;   // Complete local name
     public const byte ADTYPE_MANUFACTURER_SPECIFIC = 0xFF; // Manufacturer specific data
 


### PR DESCRIPTION
This PR makes BuWizz device detection more precise (e.g. to avoid wrong detection of BuWizz3 (by local complete name) if renamed to `BuWizz` - https://github.com/imurvai/brickcontroller2/issues/147)

Discovery by UUID is prefered over manufacturer data.

Example of BLE AD data when BW3 is renamed to `BuWizz`:
![image](https://github.com/user-attachments/assets/054f04ae-2bd6-4d83-b809-6b8d35593d86)
