### PR TITLE
Allow to test servo/steppper from device page

### DIFF
--- a/BrickController2/BrickController2/App.xaml
+++ b/BrickController2/BrickController2/App.xaml
@@ -216,6 +216,20 @@
             <Setter Property="Padding" Value="0"/>
             <Setter Property="HeightRequest" Value="46"/>
             <Setter Property="WidthRequest" Value="46"/>
+            <Setter Property="VisualStateManager.VisualStateGroups">
+                <VisualStateGroupList>
+                    <VisualStateGroup x:Name="CommonStates">
+                        <VisualState x:Name="Normal" />
+                        <VisualState x:Name="Disabled">
+                            <VisualState.Setters>
+                                <Setter Property="ImageColor" Value="{DynamicResource SecondaryColor}" />
+                                <Setter Property="BackgroundColor" Value="{DynamicResource TertiaryTextColor}" />
+                            </VisualState.Setters>
+                        </VisualState>
+                        <VisualState x:Name="PointerOver" />
+                    </VisualStateGroup>
+                </VisualStateGroupList>
+            </Setter>
         </Style>
 
         <!-- Misc -->

--- a/BrickController2/BrickController2/CreationManagement/ControllerDefaults.cs
+++ b/BrickController2/BrickController2/CreationManagement/ControllerDefaults.cs
@@ -1,0 +1,8 @@
+﻿namespace BrickController2.CreationManagement;
+
+public static class ControllerDefaults
+{
+    public const int DEFAULT_MAX_SERVO_ANGLE = 90;
+    public const int DEFAULT_SERVO_BASE_ANGLE = 0;
+    public const int DEFAULT_STEPPER_ANGLE = 90;
+}

--- a/BrickController2/BrickController2/DeviceManagement/BuWizz3Device.cs
+++ b/BrickController2/BrickController2/DeviceManagement/BuWizz3Device.cs
@@ -89,7 +89,11 @@ namespace BrickController2.DeviceManagement
 
         public override string BatteryVoltageSign => "V";
 
-        public override bool CanChangeOutputType(int channel) => channel < NUMBER_OF_PU_PORTS;
+        public override bool IsOutputTypeSupported(int channel, ChannelOutputType outputType) =>
+            // allow motor output type for all channels 
+            outputType == ChannelOutputType.NormalMotor ||
+            // servo / stepper for PoweredUp channels only
+            channel < NUMBER_OF_PU_PORTS;
 
         public override bool CanChangeMaxServoAngle(int channel) => true;
 

--- a/BrickController2/BrickController2/DeviceManagement/BuWizz3Device.cs
+++ b/BrickController2/BrickController2/DeviceManagement/BuWizz3Device.cs
@@ -252,6 +252,8 @@ namespace BrickController2.DeviceManagement
 
                 result = result && await ApplyCurrentLimitsAsync(token).ConfigureAwait(false);
                 result = result && await ResetMotorRampUpDownAsync(token).ConfigureAwait(false);
+                result = result && await StopAllChannelsAsync(token).ConfigureAwait(false);
+
                 result = result && await SetPuPortModesAsync(token).ConfigureAwait(false);
 
                 result = result && await WaitForNextCharacteristicNotificationAsync(token).ConfigureAwait(false);
@@ -564,6 +566,15 @@ namespace BrickController2.DeviceManagement
             }
             var result = await _bleDevice!.WriteAsync(_characteristic!, buffer, token).ConfigureAwait(false);
             await Task.Delay(50, token).ConfigureAwait(false);
+            return result;
+        }
+
+        private async Task<bool> StopAllChannelsAsync(CancellationToken token)
+        {
+            // send command 0x30 with all channels set to 0 and motor breaks
+            var reset = new byte[] { 0x30, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x3F, 0x3F };
+            var result = await _bleDevice!.WriteAsync(_characteristic!, reset, token);
+            await Task.Delay(20, token);
             return result;
         }
 

--- a/BrickController2/BrickController2/DeviceManagement/ControlPlusDevice.cs
+++ b/BrickController2/BrickController2/DeviceManagement/ControlPlusDevice.cs
@@ -65,7 +65,9 @@ namespace BrickController2.DeviceManagement
 
         public override string BatteryVoltageSign => "%";
 
-        public override bool CanChangeOutputType(int channel) => true;
+        public override bool IsOutputTypeSupported(int channel, ChannelOutputType outputType)
+            // support all output types on all channels
+            => true;
 
         protected override bool AutoConnectOnFirstConnect => true;
 

--- a/BrickController2/BrickController2/DeviceManagement/Device.cs
+++ b/BrickController2/BrickController2/DeviceManagement/Device.cs
@@ -1,4 +1,5 @@
-﻿using BrickController2.Helpers;
+﻿using BrickController2.CreationManagement;
+using BrickController2.Helpers;
 using BrickController2.Settings;
 using System;
 using System.Collections.Generic;
@@ -74,7 +75,13 @@ namespace BrickController2.DeviceManagement
         public virtual int NumberOfOutputLevels => 1;
         public virtual int DefaultOutputLevel => 1;
 
-        public virtual bool CanChangeOutputType(int channel) => false;
+        /// <summary>
+        /// Check whether the output type specified in <paramref name="outputType"/> is supported
+        /// for given channel <paramref name="channel"/> 
+        /// </summary>
+        public virtual bool IsOutputTypeSupported(int channel, ChannelOutputType outputType)
+            // by default support motor output type only
+            => outputType == ChannelOutputType.NormalMotor;
 
         public abstract Task<DeviceConnectionResult> ConnectAsync(
             bool reconnect,

--- a/BrickController2/BrickController2/DeviceManagement/TechnicMoveDevice.cs
+++ b/BrickController2/BrickController2/DeviceManagement/TechnicMoveDevice.cs
@@ -43,7 +43,7 @@ namespace BrickController2.DeviceManagement
         public override bool IsOutputTypeSupported(int channel, ChannelOutputType outputType)
             => outputType switch
             {
-                // motor if not PLAYVM for all channles, if PLAYVM only others than C channel
+                // motor if not PLAYVM for all channels, if PLAYVM only others than C channel
                 ChannelOutputType.NormalMotor => !EnablePlayVmMode || channel != CHANNEL_C,
                 // servo only for PLAYVM and C channel
                 ChannelOutputType.ServoMotor => EnablePlayVmMode && channel == CHANNEL_C,
@@ -55,7 +55,7 @@ namespace BrickController2.DeviceManagement
         {
             // autodetect PLAYVM mode for A / B channels (as testing page should not be affected)
             _applyPlayVmMode = startOutputProcessing &&
-                channelConfigurations.Any(c => c.Channel == CHANNEL_VM);
+                channelConfigurations.Any(c => c.Channel == CHANNEL_VM || (c.Channel == CHANNEL_C && c.ChannelOutputType == ChannelOutputType.ServoMotor));
 
             // filter out non standard channels
             var filteredConfigurtions = channelConfigurations

--- a/BrickController2/BrickController2/DeviceManagement/TechnicMoveDevice.cs
+++ b/BrickController2/BrickController2/DeviceManagement/TechnicMoveDevice.cs
@@ -1,4 +1,5 @@
-﻿using BrickController2.PlatformServices.BluetoothLE;
+﻿using BrickController2.CreationManagement;
+using BrickController2.PlatformServices.BluetoothLE;
 using BrickController2.Settings;
 using System;
 using System.Collections.Generic;
@@ -38,8 +39,17 @@ namespace BrickController2.DeviceManagement
 
         public override bool CanAutoCalibrateOutput(int channel) => false;
         public override bool CanResetOutput(int channel) => EnablePlayVmMode && channel == CHANNEL_C;
-        public override bool CanChangeOutputType(int channel) => EnablePlayVmMode && channel == CHANNEL_C;
 
+        public override bool IsOutputTypeSupported(int channel, ChannelOutputType outputType)
+            => outputType switch
+            {
+                // motor if not PLAYVM for all channles, if PLAYVM only others than C channel
+                ChannelOutputType.NormalMotor => !EnablePlayVmMode || channel != CHANNEL_C,
+                // servo only for PLAYVM and C channel
+                ChannelOutputType.ServoMotor => EnablePlayVmMode && channel == CHANNEL_C,
+                // other types (such as stepper) are not supported at all
+                _ => false,
+            };
 
         public override Task<DeviceConnectionResult> ConnectAsync(bool reconnect, Action<Device> onDeviceDisconnected, IEnumerable<ChannelConfiguration> channelConfigurations, bool startOutputProcessing, bool requestDeviceInformation, CancellationToken token)
         {

--- a/BrickController2/BrickController2/DeviceManagement/TechnicMoveDevice.cs
+++ b/BrickController2/BrickController2/DeviceManagement/TechnicMoveDevice.cs
@@ -43,7 +43,7 @@ namespace BrickController2.DeviceManagement
         public override bool IsOutputTypeSupported(int channel, ChannelOutputType outputType)
             => outputType switch
             {
-                // motor if not PLAYVM for all channels, if PLAYVM only others than C channel
+                // motor if not PLAYVM for all channels, if PLAYVM only for other channels than C channel
                 ChannelOutputType.NormalMotor => !EnablePlayVmMode || channel != CHANNEL_C,
                 // servo only for PLAYVM and C channel
                 ChannelOutputType.ServoMotor => EnablePlayVmMode && channel == CHANNEL_C,

--- a/BrickController2/BrickController2/Resources/TranslationResources.de.resx
+++ b/BrickController2/BrickController2/Resources/TranslationResources.de.resx
@@ -711,4 +711,7 @@
   <data name="StepForward" xml:space="preserve">
     <value>Schritt nach vorn</value>
   </data>
+  <data name="TestDeviceChannel" xml:space="preserve">
+    <value>Testen des Kanals</value>
+  </data>
 </root>

--- a/BrickController2/BrickController2/Resources/TranslationResources.resx
+++ b/BrickController2/BrickController2/Resources/TranslationResources.resx
@@ -711,4 +711,7 @@
   <data name="StepForward" xml:space="preserve">
     <value>Next step</value>
   </data>
+  <data name="TestDeviceChannel" xml:space="preserve">
+    <value>Test the channel</value>
+  </data>
 </root>

--- a/BrickController2/BrickController2/UI/Converters/DeviceAndChannelToChannelOutputTypeVisibleConverter.cs
+++ b/BrickController2/BrickController2/UI/Converters/DeviceAndChannelToChannelOutputTypeVisibleConverter.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Globalization;
+using BrickController2.CreationManagement;
 using Microsoft.Maui.Controls;
 using Device = BrickController2.DeviceManagement.Device;
 
@@ -9,9 +10,10 @@ namespace BrickController2.UI.Converters
     {
         public object Convert(object[] values, Type targetType, object parameter, CultureInfo culture)
         {
-            if (values[0] is Device device)
+            if (values[0] is Device device && values[1] is int channel)
             {
-                return values[1] is int channel && device.CanChangeOutputType(channel);
+                return device.IsOutputTypeSupported(channel, ChannelOutputType.ServoMotor) ||
+                     device.IsOutputTypeSupported(channel, ChannelOutputType.StepperMotor);
             }
 
             return false;

--- a/BrickController2/BrickController2/UI/Converters/IntValueToDegreeStringConverter.cs
+++ b/BrickController2/BrickController2/UI/Converters/IntValueToDegreeStringConverter.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Globalization;
+using Microsoft.Maui.Controls;
+
+namespace BrickController2.UI.Converters;
+
+public class IntValueToDegreeStringConverter : IValueConverter
+{
+    public object Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
+    {
+        if (value is int intValue)
+        {
+            // Convert integer value to a degree string representation
+            return $"{intValue}°";
+        }
+        return value!;
+    }
+
+    public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
+        => throw new InvalidOperationException("ConvertBack is not supported for IntValueToDegreeStringConverter.");
+}

--- a/BrickController2/BrickController2/UI/Converters/ServoOutputTypeToVisibleConverter.cs
+++ b/BrickController2/BrickController2/UI/Converters/ServoOutputTypeToVisibleConverter.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Globalization;
+using BrickController2.CreationManagement;
+using Microsoft.Maui.Controls;
+
+namespace BrickController2.UI.Converters;
+
+internal class ServoOutputTypeToVisibleConverter : IValueConverter
+{
+    public object? Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
+         => value is ChannelOutputType outputType && outputType == ChannelOutputType.ServoMotor;
+
+    public object? ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
+         => throw new NotImplementedException();
+}

--- a/BrickController2/BrickController2/UI/Converters/StepperOutputTypeToVisibleConverter.cs
+++ b/BrickController2/BrickController2/UI/Converters/StepperOutputTypeToVisibleConverter.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Globalization;
+using BrickController2.CreationManagement;
+using Microsoft.Maui.Controls;
+
+namespace BrickController2.UI.Converters;
+
+internal class StepperOutputTypeToVisibleConverter : IValueConverter
+{
+    public object? Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
+         => value is ChannelOutputType outputType && outputType == ChannelOutputType.StepperMotor;
+
+    public object? ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
+         => throw new NotImplementedException();
+}

--- a/BrickController2/BrickController2/UI/Pages/ChannelSetupPage.xaml
+++ b/BrickController2/BrickController2/UI/Pages/ChannelSetupPage.xaml
@@ -69,7 +69,8 @@
 
                                 <Label Grid.Column="0" Grid.Row="3" Text="{extensions:Translate ChannelType}" FontSize="Small"/>
                                 <Label Grid.Column="1" Grid.Row="3" Text="{Binding Action.ChannelOutputType}" FontSize="Medium" FontAttributes="Bold" IsVisible="{Binding IsChannelTest, Converter={StaticResource InverseBool}, Mode=OneTime}"/>
-                                <Button Grid.Column="1" Grid.Row="3" Text="{Binding Action.ChannelOutputType}" Command="{Binding SelectChannelOutputTypeCommand}" Style="{StaticResource PickerButtonStyle}" IsVisible="{Binding IsChannelTest, Mode=OneTime}"/>
+                                <Button Grid.Column="1" Grid.Row="3" Text="{Binding Action.ChannelOutputType}" Command="{Binding SelectChannelOutputTypeCommand}"
+                                        Style="{StaticResource PickerButtonStyle}" HorizontalOptions="Start" MaximumWidthRequest="360" IsVisible="{Binding IsChannelTest, Mode=OneTime}"/>
                             </Grid>
                         </Grid>
 

--- a/BrickController2/BrickController2/UI/Pages/ChannelSetupPage.xaml
+++ b/BrickController2/BrickController2/UI/Pages/ChannelSetupPage.xaml
@@ -19,6 +19,7 @@
             <converters:DeviceConnectedToBoolConverter x:Key="DeviceConnectedToBool"/>
             <converters:DeviceDisconnectedToBoolConverter x:Key="DeviceDisconnectedToBool"/>
             <converters:ChannelToDisplayChannelConverter x:Key="ChannelToDisplayChannel"/>
+            <converters:InverseBoolConverter x:Key="InverseBool"/>
         </ResourceDictionary>
     </local:PageBase.Resources>
 
@@ -65,14 +66,15 @@
                                 <controls:DeviceChannelLabel Grid.Column="1" Grid.Row="2" DeviceType="{Binding Device.DeviceType}" Channel="{Binding Action.Channel}" FontSize="Medium" FontAttributes="Bold"/>
 
                                 <Label Grid.Column="0" Grid.Row="3" Text="{extensions:Translate ChannelType}" FontSize="Small"/>
-                                <Label Grid.Column="1" Grid.Row="3" Text="{Binding Action.ChannelOutputType}" FontSize="Medium" FontAttributes="Bold"/>
+                                <Label Grid.Column="1" Grid.Row="3" Text="{Binding Action.ChannelOutputType}" FontSize="Medium" FontAttributes="Bold" IsVisible="{Binding IsChannelTest, Converter={StaticResource InverseBool}, Mode=OneTime}"/>
+                                <Button Grid.Column="1" Grid.Row="3" Text="{Binding Action.ChannelOutputType}" Command="{Binding SelectChannelOutputTypeCommand}" Style="{StaticResource PickerButtonStyle}" IsVisible="{Binding IsChannelTest, Mode=OneTime}"/>
                             </Grid>
                         </Grid>
 
                         <BoxView Style="{StaticResource DividerBoxViewStyle}" Margin="0,4,0,4"/>
 
                         <!-- Stepper test controls -->
-                        <VerticalStackLayout Padding="10" IsVisible="{Binding IsStepperChannelOutputType, Mode=OneTime}">
+                        <VerticalStackLayout Padding="10" IsVisible="{Binding IsStepperChannelOutputType, Mode=OneWay}">
                             <Label Text="{extensions:Translate StepperAngle}" Margin="0, 10, 0, 10"/>
                             <StackLayout Orientation="Horizontal">
                                 <controls:ExtendedSlider Value="{Binding StepperAngle}" Minimum="0" Maximum="180" Step="5"
@@ -87,7 +89,7 @@
                         </VerticalStackLayout>
 
                         <!-- Auto servo calibration -->
-                        <StackLayout Orientation="Vertical" Padding="10" IsVisible="{Binding IsServoChannelOutputType, Mode=OneTime}">
+                        <StackLayout Orientation="Vertical" Padding="10" IsVisible="{Binding IsServoChannelOutputType, Mode=OneWay}">
 
                             <Button Text="{extensions:Translate AutoCalibrate}" Style="{StaticResource TextButtonStyle}" Command="{Binding AutoCalibrateServoCommand}" Margin="0, 30, 0, 30"/>
 
@@ -95,7 +97,7 @@
                         </StackLayout>
 
                         <!-- Manual servo calibration -->
-                        <VerticalStackLayout Padding="10" IsVisible="{Binding IsServoChannelOutputType, Mode=OneTime}">
+                        <VerticalStackLayout Padding="10" IsVisible="{Binding IsServoChannelOutputType, Mode=OneWay}">
                             <Label Text="{extensions:Translate BaseAngle}" Margin="0, 10, 0, 10"/>
                             <StackLayout Orientation="Horizontal">
                                 <controls:ExtendedSlider Value="{Binding ServoBaseAngle}" Minimum="-180" Maximum="179" Step="5"

--- a/BrickController2/BrickController2/UI/Pages/ChannelSetupPage.xaml
+++ b/BrickController2/BrickController2/UI/Pages/ChannelSetupPage.xaml
@@ -19,6 +19,7 @@
             <converters:DeviceConnectedToBoolConverter x:Key="DeviceConnectedToBool"/>
             <converters:DeviceDisconnectedToBoolConverter x:Key="DeviceDisconnectedToBool"/>
             <converters:ChannelToDisplayChannelConverter x:Key="ChannelToDisplayChannel"/>
+            <converters:IntValueToDegreeStringConverter x:Key="IntValueToDegreeString"/>
             <converters:InverseBoolConverter x:Key="InverseBool"/>
             <converters:StepperOutputTypeToVisibleConverter x:Key="StepperVisibility"/>
             <converters:ServoOutputTypeToVisibleConverter x:Key="ServoVisibility"/>
@@ -74,16 +75,17 @@
                             </Grid>
                         </Grid>
 
-                        <BoxView Style="{StaticResource DividerBoxViewStyle}"/>
+                        <BoxView Style="{StaticResource DividerBoxViewStyle}" Margin="0,8,0,4"/>
 
                         <!-- Stepper test controls -->
                         <VerticalStackLayout Padding="10" IsVisible="{Binding Action.ChannelOutputType, Converter={StaticResource StepperVisibility}}">
                             <Label Text="{extensions:Translate StepperAngle}" Margin="0, 0, 0, 5"/>
                             <StackLayout Orientation="Horizontal">
                                 <controls:ExtendedSlider Value="{Binding StepperAngle}" Minimum="0" Maximum="180" Step="5"
-                                                         HorizontalOptions="FillAndExpand" MinimumTrackColor="LightGray"/>
-                                <Label Text="{Binding StepperAngle}" WidthRequest="35" HorizontalOptions="End" HorizontalTextAlignment="End"/>
-                                <Label Text="°"/>
+                                                         HorizontalOptions="FillAndExpand" MinimumTrackColor="LightGray" VerticalOptions="Center"/>
+                                <Label Text="{Binding StepperAngle, Converter={StaticResource IntValueToDegreeString}}" WidthRequest="35" HorizontalOptions="End" HorizontalTextAlignment="End" VerticalOptions="Center"/>
+                                <controls:FloatingActionButton Style="{StaticResource InlineActionButtonStyle}" Icon="settings_backup_restore" ToolTipProperties.Text="{extensions:Translate Reset}"
+                                                               Command="{Binding ResetStepperAngleCommand}" Margin="10,0,0,0" VerticalOptions="Center"/>
                             </StackLayout>
                             <Grid ColumnDefinitions="*,*" ColumnSpacing="20">
                                 <Button Grid.Column="0" Text="{extensions:Translate StepBack}" Style="{StaticResource TextButtonStyle}" Command="{Binding StepperTestCommand}" CommandParameter="-1.0"/>
@@ -96,11 +98,12 @@
                             <Label Text="{extensions:Translate ServoAngle}" Margin="0, 0, 0, 5"/>
                             <StackLayout Orientation="Horizontal">
                                 <controls:ExtendedSlider Value="{Binding MaxServoAngle}" Minimum="0" Maximum="180" Step="5"
-                                                         HorizontalOptions="FillAndExpand" MinimumTrackColor="LightGray"/>
-                                <Label Text="{Binding MaxServoAngle}" WidthRequest="35" HorizontalOptions="End" HorizontalTextAlignment="End"/>
-                                <Label Text="°"/>
+                                                         HorizontalOptions="FillAndExpand" MinimumTrackColor="LightGray" VerticalOptions="Center"/>
+                                <Label Text="{Binding MaxServoAngle, Converter={StaticResource IntValueToDegreeString}}" WidthRequest="35" HorizontalOptions="End" HorizontalTextAlignment="End" VerticalOptions="Center"/>
+                                <controls:FloatingActionButton Style="{StaticResource InlineActionButtonStyle}" Icon="settings_backup_restore" ToolTipProperties.Text="{extensions:Translate Reset}"
+                                                               Command="{Binding ResetMaxServoAngleCommand}" Margin="10,0,0,0" VerticalOptions="Center"/>
                             </StackLayout>
-                            <Grid ColumnDefinitions="*,*,*,*,*" ColumnSpacing="20" >
+                            <Grid ColumnDefinitions="*,*,*,*,*" ColumnSpacing="{OnIdiom 10, Desktop=25}" >
                                 <Button Grid.Column="0" Text="-100%" Style="{StaticResource TextButtonStyle}" Command="{Binding ServoTestCommand}" CommandParameter="-1.0"/>
                                 <Button Grid.Column="1" Text="-50%" Style="{StaticResource TextButtonStyle}" Command="{Binding ServoTestCommand}" CommandParameter="-0.5"/>
                                 <Button Grid.Column="2" Text="0%" Style="{StaticResource TextButtonStyle}" Command="{Binding ServoTestCommand}" CommandParameter="0.0"/>
@@ -125,9 +128,10 @@
                             <StackLayout Orientation="Horizontal">
                                 <controls:ExtendedSlider Value="{Binding ServoBaseAngle}" Minimum="-180" Maximum="179" Step="5"
                                                          IsEnabled="{Binding CanResetChannelOutput, Mode=OneTime}"
-                                                         HorizontalOptions="FillAndExpand" MinimumTrackColor="LightGray"/>
-                                <Label Text="{Binding ServoBaseAngle}" WidthRequest="35" HorizontalOptions="End" HorizontalTextAlignment="End"/>
-                                <Label Text="°"/>
+                                                         HorizontalOptions="FillAndExpand" MinimumTrackColor="LightGray" VerticalOptions="Center"/>
+                                <Label Text="{Binding ServoBaseAngle, Converter={StaticResource IntValueToDegreeString}}" WidthRequest="35" HorizontalOptions="End" HorizontalTextAlignment="End" VerticalOptions="Center"/>
+                                <controls:FloatingActionButton Style="{StaticResource InlineActionButtonStyle}" Icon="settings_backup_restore" ToolTipProperties.Text="{extensions:Translate Reset}"
+                                                               Command="{Binding ResetServoBaseAngleCommand}" Margin="10,0,0,0" VerticalOptions="Center"/>
                             </StackLayout>
                             <Button Text="{extensions:Translate Reset}" Style="{StaticResource TextButtonStyle}" Command="{Binding ResetServoBaseCommand}"/>
                         </VerticalStackLayout>

--- a/BrickController2/BrickController2/UI/Pages/ChannelSetupPage.xaml
+++ b/BrickController2/BrickController2/UI/Pages/ChannelSetupPage.xaml
@@ -59,16 +59,16 @@
                                     <RowDefinition Height="Auto"/>
                                 </Grid.RowDefinitions>
 
-                                <Label Grid.Column="0" Grid.Row="0" Text="{extensions:Translate DeviceName}" FontSize="Small"/>
+                                <Label Grid.Column="0" Grid.Row="0" Text="{extensions:Translate DeviceName}" FontSize="Small" VerticalOptions="Center"/>
                                 <Label Grid.Column="1" Grid.Row="0" Text="{Binding Device.Name}" FontSize="Medium" FontAttributes="Bold"/>
 
-                                <Label Grid.Column="0" Grid.Row="1" Text="{extensions:Translate DeviceType}" FontSize="Small"/>
+                                <Label Grid.Column="0" Grid.Row="1" Text="{extensions:Translate DeviceType}" FontSize="Small" VerticalOptions="Center"/>
                                 <Label Grid.Column="1" Grid.Row="1" Text="{Binding Device.DeviceType}" FontSize="Medium" FontAttributes="Bold"/>
 
-                                <Label Grid.Column="0" Grid.Row="2" Text="{extensions:Translate Channel}" FontSize="Small"/>
+                                <Label Grid.Column="0" Grid.Row="2" Text="{extensions:Translate Channel}" FontSize="Small" VerticalOptions="Center"/>
                                 <controls:DeviceChannelLabel Grid.Column="1" Grid.Row="2" DeviceType="{Binding Device.DeviceType}" Channel="{Binding Action.Channel}" FontSize="Medium" FontAttributes="Bold"/>
 
-                                <Label Grid.Column="0" Grid.Row="3" Text="{extensions:Translate ChannelType}" FontSize="Small"/>
+                                <Label Grid.Column="0" Grid.Row="3" Text="{extensions:Translate ChannelType}" FontSize="Small" VerticalOptions="Center"/>
                                 <Label Grid.Column="1" Grid.Row="3" Text="{Binding Action.ChannelOutputType}" FontSize="Medium" FontAttributes="Bold" IsVisible="{Binding IsChannelTest, Converter={StaticResource InverseBool}, Mode=OneTime}"/>
                                 <Button Grid.Column="1" Grid.Row="3" Text="{Binding Action.ChannelOutputType}" Command="{Binding SelectChannelOutputTypeCommand}"
                                         Style="{StaticResource PickerButtonStyle}" HorizontalOptions="Start" MaximumWidthRequest="360" IsVisible="{Binding IsChannelTest, Mode=OneTime}"/>
@@ -103,12 +103,12 @@
                                 <controls:FloatingActionButton Style="{StaticResource InlineActionButtonStyle}" Icon="settings_backup_restore" ToolTipProperties.Text="{extensions:Translate Reset}"
                                                                Command="{Binding ResetMaxServoAngleCommand}" Margin="10,0,0,0" VerticalOptions="Center"/>
                             </StackLayout>
-                            <Grid ColumnDefinitions="*,*,*,*,*" ColumnSpacing="{OnIdiom 10, Desktop=25}" >
-                                <Button Grid.Column="0" Text="-100%" Style="{StaticResource TextButtonStyle}" Command="{Binding ServoTestCommand}" CommandParameter="-1.0"/>
+                            <Grid ColumnDefinitions="3*,3*,2*,3*,3*" ColumnSpacing="{OnIdiom 8, Desktop=25}" >
+                                <Button Grid.Column="0" Text="-100%" Style="{StaticResource TextButtonStyle}" Command="{Binding ServoTestCommand}" CommandParameter="-1.0" Padding="0"/>
                                 <Button Grid.Column="1" Text="-50%" Style="{StaticResource TextButtonStyle}" Command="{Binding ServoTestCommand}" CommandParameter="-0.5"/>
-                                <Button Grid.Column="2" Text="0%" Style="{StaticResource TextButtonStyle}" Command="{Binding ServoTestCommand}" CommandParameter="0.0"/>
+                                <Button Grid.Column="2" Text="0%" Style="{StaticResource TextButtonStyle}" Command="{Binding ServoTestCommand}" CommandParameter="0.0" Padding="0"/>
                                 <Button Grid.Column="3" Text="50%" Style="{StaticResource TextButtonStyle}" Command="{Binding ServoTestCommand}" CommandParameter="0.5"/>
-                                <Button Grid.Column="4" Text="100%" Style="{StaticResource TextButtonStyle}" Command="{Binding ServoTestCommand}" CommandParameter="1.0"/>
+                                <Button Grid.Column="4" Text="100%" Style="{StaticResource TextButtonStyle}" Command="{Binding ServoTestCommand}" CommandParameter="1.0" Padding="0"/>
                             </Grid>
                         </VerticalStackLayout>
 

--- a/BrickController2/BrickController2/UI/Pages/ChannelSetupPage.xaml
+++ b/BrickController2/BrickController2/UI/Pages/ChannelSetupPage.xaml
@@ -74,11 +74,11 @@
                             </Grid>
                         </Grid>
 
-                        <BoxView Style="{StaticResource DividerBoxViewStyle}" Margin="0,4,0,4"/>
+                        <BoxView Style="{StaticResource DividerBoxViewStyle}"/>
 
                         <!-- Stepper test controls -->
                         <VerticalStackLayout Padding="10" IsVisible="{Binding Action.ChannelOutputType, Converter={StaticResource StepperVisibility}}">
-                            <Label Text="{extensions:Translate StepperAngle}" Margin="0, 10, 0, 10"/>
+                            <Label Text="{extensions:Translate StepperAngle}" Margin="0, 0, 0, 5"/>
                             <StackLayout Orientation="Horizontal">
                                 <controls:ExtendedSlider Value="{Binding StepperAngle}" Minimum="0" Maximum="180" Step="5"
                                                          HorizontalOptions="FillAndExpand" MinimumTrackColor="LightGray"/>
@@ -91,17 +91,37 @@
                             </Grid>
                         </VerticalStackLayout>
 
+                        <!-- Servo test controls -->
+                        <VerticalStackLayout Padding="10" IsVisible="{Binding Action.ChannelOutputType, Converter={StaticResource ServoVisibility}}">
+                            <Label Text="{extensions:Translate ServoAngle}" Margin="0, 0, 0, 5"/>
+                            <StackLayout Orientation="Horizontal">
+                                <controls:ExtendedSlider Value="{Binding MaxServoAngle}" Minimum="0" Maximum="180" Step="5"
+                                                         HorizontalOptions="FillAndExpand" MinimumTrackColor="LightGray"/>
+                                <Label Text="{Binding MaxServoAngle}" WidthRequest="35" HorizontalOptions="End" HorizontalTextAlignment="End"/>
+                                <Label Text="°"/>
+                            </StackLayout>
+                            <Grid ColumnDefinitions="*,*,*,*,*" ColumnSpacing="20" >
+                                <Button Grid.Column="0" Text="-100%" Style="{StaticResource TextButtonStyle}" Command="{Binding ServoTestCommand}" CommandParameter="-1.0"/>
+                                <Button Grid.Column="1" Text="-50%" Style="{StaticResource TextButtonStyle}" Command="{Binding ServoTestCommand}" CommandParameter="-0.5"/>
+                                <Button Grid.Column="2" Text="0%" Style="{StaticResource TextButtonStyle}" Command="{Binding ServoTestCommand}" CommandParameter="0.0"/>
+                                <Button Grid.Column="3" Text="50%" Style="{StaticResource TextButtonStyle}" Command="{Binding ServoTestCommand}" CommandParameter="0.5"/>
+                                <Button Grid.Column="4" Text="100%" Style="{StaticResource TextButtonStyle}" Command="{Binding ServoTestCommand}" CommandParameter="1.0"/>
+                            </Grid>
+                        </VerticalStackLayout>
+
+                        <BoxView Style="{StaticResource DividerBoxViewStyle}"/>
+
                         <!-- Auto servo calibration -->
                         <StackLayout Orientation="Vertical" Padding="10" IsVisible="{Binding Action.ChannelOutputType, Converter={StaticResource ServoVisibility}}">
 
                             <Button Text="{extensions:Translate AutoCalibrate}" Style="{StaticResource TextButtonStyle}" Command="{Binding AutoCalibrateServoCommand}" Margin="0, 30, 0, 30"/>
 
-                            <BoxView Style="{StaticResource DividerBoxViewStyle}" Margin="0,4,0,4"/>
+                            <BoxView Style="{StaticResource DividerBoxViewStyle}"/>
                         </StackLayout>
 
-                        <!-- Manual servo calibration -->
-                        <VerticalStackLayout Padding="10" IsVisible="{Binding Action.ChannelOutputType, Converter={StaticResource ServoVisibility}}">
-                            <Label Text="{extensions:Translate BaseAngle}" Margin="0, 10, 0, 10"/>
+                        <!-- Manual servo/stepper calibration -->
+                        <VerticalStackLayout Padding="10">
+                            <Label Text="{extensions:Translate BaseAngle}" Margin="0, 0, 0, 5"/>
                             <StackLayout Orientation="Horizontal">
                                 <controls:ExtendedSlider Value="{Binding ServoBaseAngle}" Minimum="-180" Maximum="179" Step="5"
                                                          IsEnabled="{Binding CanResetChannelOutput, Mode=OneTime}"

--- a/BrickController2/BrickController2/UI/Pages/ChannelSetupPage.xaml
+++ b/BrickController2/BrickController2/UI/Pages/ChannelSetupPage.xaml
@@ -20,6 +20,8 @@
             <converters:DeviceDisconnectedToBoolConverter x:Key="DeviceDisconnectedToBool"/>
             <converters:ChannelToDisplayChannelConverter x:Key="ChannelToDisplayChannel"/>
             <converters:InverseBoolConverter x:Key="InverseBool"/>
+            <converters:StepperOutputTypeToVisibleConverter x:Key="StepperVisibility"/>
+            <converters:ServoOutputTypeToVisibleConverter x:Key="ServoVisibility"/>
         </ResourceDictionary>
     </local:PageBase.Resources>
 
@@ -74,7 +76,7 @@
                         <BoxView Style="{StaticResource DividerBoxViewStyle}" Margin="0,4,0,4"/>
 
                         <!-- Stepper test controls -->
-                        <VerticalStackLayout Padding="10" IsVisible="{Binding IsStepperChannelOutputType, Mode=OneWay}">
+                        <VerticalStackLayout Padding="10" IsVisible="{Binding Action.ChannelOutputType, Converter={StaticResource StepperVisibility}}">
                             <Label Text="{extensions:Translate StepperAngle}" Margin="0, 10, 0, 10"/>
                             <StackLayout Orientation="Horizontal">
                                 <controls:ExtendedSlider Value="{Binding StepperAngle}" Minimum="0" Maximum="180" Step="5"
@@ -89,7 +91,7 @@
                         </VerticalStackLayout>
 
                         <!-- Auto servo calibration -->
-                        <StackLayout Orientation="Vertical" Padding="10" IsVisible="{Binding IsServoChannelOutputType, Mode=OneWay}">
+                        <StackLayout Orientation="Vertical" Padding="10" IsVisible="{Binding Action.ChannelOutputType, Converter={StaticResource ServoVisibility}}">
 
                             <Button Text="{extensions:Translate AutoCalibrate}" Style="{StaticResource TextButtonStyle}" Command="{Binding AutoCalibrateServoCommand}" Margin="0, 30, 0, 30"/>
 
@@ -97,7 +99,7 @@
                         </StackLayout>
 
                         <!-- Manual servo calibration -->
-                        <VerticalStackLayout Padding="10" IsVisible="{Binding IsServoChannelOutputType, Mode=OneWay}">
+                        <VerticalStackLayout Padding="10" IsVisible="{Binding Action.ChannelOutputType, Converter={StaticResource ServoVisibility}}">
                             <Label Text="{extensions:Translate BaseAngle}" Margin="0, 10, 0, 10"/>
                             <StackLayout Orientation="Horizontal">
                                 <controls:ExtendedSlider Value="{Binding ServoBaseAngle}" Minimum="-180" Maximum="179" Step="5"

--- a/BrickController2/BrickController2/UI/Pages/ChannelSetupPage.xaml
+++ b/BrickController2/BrickController2/UI/Pages/ChannelSetupPage.xaml
@@ -23,6 +23,7 @@
             <converters:InverseBoolConverter x:Key="InverseBool"/>
             <converters:StepperOutputTypeToVisibleConverter x:Key="StepperVisibility"/>
             <converters:ServoOutputTypeToVisibleConverter x:Key="ServoVisibility"/>
+            <converters:DeviceAndChannelOutputTypeToMaxServoAngleVisibleConverter x:Key="DeviceAndChannelOutputTypeToMaxServoAngleVisible"/>
         </ResourceDictionary>
     </local:PageBase.Resources>
 
@@ -97,6 +98,13 @@
                         <VerticalStackLayout Padding="10" IsVisible="{Binding Action.ChannelOutputType, Converter={StaticResource ServoVisibility}}">
                             <Label Text="{extensions:Translate ServoAngle}" Margin="0, 0, 0, 5"/>
                             <StackLayout Orientation="Horizontal">
+                                <StackLayout.IsEnabled>
+                                    <MultiBinding Converter="{StaticResource DeviceAndChannelOutputTypeToMaxServoAngleVisible}">
+                                        <Binding Path="Device" />
+                                        <Binding Path="Action.ChannelOutputType" />
+                                        <Binding Path="Action.Channel" />
+                                    </MultiBinding>
+                                </StackLayout.IsEnabled>
                                 <controls:ExtendedSlider Value="{Binding MaxServoAngle}" Minimum="0" Maximum="180" Step="5"
                                                          HorizontalOptions="FillAndExpand" MinimumTrackColor="LightGray" VerticalOptions="Center"/>
                                 <Label Text="{Binding MaxServoAngle, Converter={StaticResource IntValueToDegreeString}}" WidthRequest="35" HorizontalOptions="End" HorizontalTextAlignment="End" VerticalOptions="Center"/>

--- a/BrickController2/BrickController2/UI/Pages/DevicePage.xaml
+++ b/BrickController2/BrickController2/UI/Pages/DevicePage.xaml
@@ -114,20 +114,19 @@
                             <VerticalStackLayout BindableLayout.ItemsSource="{Binding DeviceOutputs}">
                                 <BindableLayout.ItemTemplate>
                                     <DataTemplate>
-                                        <VerticalStackLayout>
-                                            <Grid Style="{StaticResource CollectionItemGridStyle}" Margin="10,4,10,4">
-                                                <Grid.ColumnDefinitions>
-                                                    <ColumnDefinition Width="30"/>
-                                                    <ColumnDefinition Width="*"/>
-                                                    <ColumnDefinition Width="Auto"/>
-                                                </Grid.ColumnDefinitions>
-                                                <controls:DeviceChannelLabel Grid.Column="0" DeviceType="{Binding Device.DeviceType}" Channel="{Binding Channel}"/>
-                                                <controls:ExtendedSlider Grid.Column="1" Minimum="-100" Maximum="100" IsEnabled="{Binding Device.DeviceState, Converter={StaticResource DeviceConnectedToBool}}" Value="{Binding Output}" TouchUpCommand="{Binding TouchUpCommand}"/>
-                                                <controls:FloatingActionButton Grid.Column="2" Style="{StaticResource InlineActionButtonStyle}" Icon="settings" ToolTipProperties.Text="{extensions:Translate TestServeStepperCommand}"
-                                                                               Command="{Binding TestServeStepperCommand}" IsVisible="{Binding IsServoOrStepperSupported}"/>
-                                            </Grid>
-                                            <BoxView Style="{StaticResource DividerBoxViewStyle}" Margin="6,6,6,0"/>
-                                        </VerticalStackLayout>
+                                        <Grid Style="{StaticResource CollectionItemGridStyle}" Margin="10,0,10,0" RowDefinitions="*,*">
+                                            <Grid.ColumnDefinitions>
+                                                <ColumnDefinition Width="30"/>
+                                                <ColumnDefinition Width="*"/>
+                                                <ColumnDefinition Width="Auto"/>
+                                            </Grid.ColumnDefinitions>
+                                            <controls:DeviceChannelLabel Grid.Column="0" DeviceType="{Binding Device.DeviceType}" Channel="{Binding Channel}" VerticalOptions="Center" />
+                                            <controls:ExtendedSlider Grid.Column="1" Minimum="-100" Maximum="100" IsEnabled="{Binding Device.DeviceState, Converter={StaticResource DeviceConnectedToBool}}" Value="{Binding Output}" TouchUpCommand="{Binding TouchUpCommand}" VerticalOptions="Center"/>
+                                            <controls:FloatingActionButton Grid.Column="2" Style="{StaticResource InlineActionButtonStyle}" Icon="settings" ToolTipProperties.Text="{extensions:Translate TestServeStepperCommand}"
+                                                                           Command="{Binding TestServoStepperCommand}" Margin="10,0,0,0"
+                                                                           IsVisible="{Binding x:DataType='bool', Source={RelativeSource AncestorType={x:Type VerticalStackLayout}}, Path=BindingContext.IsServoOrStepperSupported}"/>
+                                            <BoxView Style="{StaticResource DividerBoxViewStyle}" Grid.Row="1" Grid.ColumnSpan="2" Margin="6,4,6,0"/>
+                                        </Grid>
                                     </DataTemplate>
                                 </BindableLayout.ItemTemplate>
                             </VerticalStackLayout>

--- a/BrickController2/BrickController2/UI/Pages/DevicePage.xaml
+++ b/BrickController2/BrickController2/UI/Pages/DevicePage.xaml
@@ -114,15 +114,15 @@
                             <VerticalStackLayout BindableLayout.ItemsSource="{Binding DeviceOutputs}">
                                 <BindableLayout.ItemTemplate>
                                     <DataTemplate>
-                                        <Grid Style="{StaticResource CollectionItemGridStyle}" Margin="10,0,10,0" RowDefinitions="*,*">
+                                        <Grid Style="{StaticResource CollectionItemGridStyle}" Margin="5,0,5,0" RowDefinitions="*,*">
                                             <Grid.ColumnDefinitions>
-                                                <ColumnDefinition Width="30"/>
+                                                <ColumnDefinition Width="25"/>
                                                 <ColumnDefinition Width="*"/>
                                                 <ColumnDefinition Width="Auto"/>
                                             </Grid.ColumnDefinitions>
                                             <controls:DeviceChannelLabel Grid.Column="0" DeviceType="{Binding Device.DeviceType}" Channel="{Binding Channel}" VerticalOptions="Center" />
                                             <controls:ExtendedSlider Grid.Column="1" Minimum="-100" Maximum="100" IsEnabled="{Binding Device.DeviceState, Converter={StaticResource DeviceConnectedToBool}}" Value="{Binding Output}" TouchUpCommand="{Binding TouchUpCommand}" VerticalOptions="Center"/>
-                                            <controls:FloatingActionButton Grid.Column="2" Style="{StaticResource InlineActionButtonStyle}" Icon="settings" ToolTipProperties.Text="{extensions:Translate TestServeStepperCommand}"
+                                            <controls:FloatingActionButton Grid.Column="2" Style="{StaticResource InlineActionButtonStyle}" Icon="settings" ToolTipProperties.Text="{extensions:Translate OpenChannelSetup}"
                                                                            Command="{Binding TestServoStepperCommand}" Margin="10,0,0,0"
                                                                            IsVisible="{Binding x:DataType='bool', Source={RelativeSource AncestorType={x:Type VerticalStackLayout}}, Path=BindingContext.IsServoOrStepperSupported}"/>
                                             <BoxView Style="{StaticResource DividerBoxViewStyle}" Grid.Row="1" Grid.ColumnSpan="2" Margin="6,4,6,0"/>

--- a/BrickController2/BrickController2/UI/Pages/DevicePage.xaml
+++ b/BrickController2/BrickController2/UI/Pages/DevicePage.xaml
@@ -122,7 +122,7 @@
                                             </Grid.ColumnDefinitions>
                                             <controls:DeviceChannelLabel Grid.Column="0" DeviceType="{Binding Device.DeviceType}" Channel="{Binding Channel}" VerticalOptions="Center" />
                                             <controls:ExtendedSlider Grid.Column="1" Minimum="-100" Maximum="100" IsEnabled="{Binding Device.DeviceState, Converter={StaticResource DeviceConnectedToBool}}" Value="{Binding Output}" TouchUpCommand="{Binding TouchUpCommand}" VerticalOptions="Center"/>
-                                            <controls:FloatingActionButton Grid.Column="2" Style="{StaticResource InlineActionButtonStyle}" Icon="settings" ToolTipProperties.Text="{extensions:Translate OpenChannelSetup}"
+                                            <controls:FloatingActionButton Grid.Column="2" Style="{StaticResource InlineActionButtonStyle}" Icon="settings" ToolTipProperties.Text="{extensions:Translate TestDeviceChannel}"
                                                                            Command="{Binding TestServoStepperCommand}" Margin="10,0,0,0"
                                                                            IsVisible="{Binding x:DataType='bool', Source={RelativeSource AncestorType={x:Type VerticalStackLayout}}, Path=BindingContext.IsServoOrStepperSupported}"/>
                                             <BoxView Style="{StaticResource DividerBoxViewStyle}" Grid.Row="1" Grid.ColumnSpan="2" Margin="6,4,6,0"/>

--- a/BrickController2/BrickController2/UI/Pages/DevicePage.xaml
+++ b/BrickController2/BrickController2/UI/Pages/DevicePage.xaml
@@ -119,9 +119,12 @@
                                                 <Grid.ColumnDefinitions>
                                                     <ColumnDefinition Width="30"/>
                                                     <ColumnDefinition Width="*"/>
+                                                    <ColumnDefinition Width="Auto"/>
                                                 </Grid.ColumnDefinitions>
                                                 <controls:DeviceChannelLabel Grid.Column="0" DeviceType="{Binding Device.DeviceType}" Channel="{Binding Channel}"/>
                                                 <controls:ExtendedSlider Grid.Column="1" Minimum="-100" Maximum="100" IsEnabled="{Binding Device.DeviceState, Converter={StaticResource DeviceConnectedToBool}}" Value="{Binding Output}" TouchUpCommand="{Binding TouchUpCommand}"/>
+                                                <controls:FloatingActionButton Grid.Column="2" Style="{StaticResource InlineActionButtonStyle}" Icon="settings" ToolTipProperties.Text="{extensions:Translate TestServeStepperCommand}"
+                                                                               Command="{Binding TestServeStepperCommand}" IsVisible="{Binding IsServoOrStepperSupported}"/>
                                             </Grid>
                                             <BoxView Style="{StaticResource DividerBoxViewStyle}" Margin="6,6,6,0"/>
                                         </VerticalStackLayout>

--- a/BrickController2/BrickController2/UI/ViewModels/ChannelSetupPageViewModel.cs
+++ b/BrickController2/BrickController2/UI/ViewModels/ChannelSetupPageViewModel.cs
@@ -260,21 +260,28 @@ namespace BrickController2.UI.ViewModels
 
         private async Task TestChannelAsync(string parameter, bool reset = true)
         {
-            var value = Convert.ToSingle(parameter, CultureInfo.InvariantCulture);
-            // ensure stepper / servo settings are up-to-date and output processing is set
-            if (MaxServoAngle != _channelConfig.MaxServoAngle ||
-                ServoBaseAngle != _channelConfig.ServoBaseAngle ||
-                StepperAngle != _channelConfig.StepperAngle ||
-                Action.ChannelOutputType != _channelConfig.ChannelOutputType ||
-                !_startOutputProcessing)
+            try
             {
-                // update prerequsities for servo/stepper testing
-                UpdateChannelConfig();
-                // force reconnection with processing enabled
-                await EnforceEnabledChannelOutputProcessing(true);
+                var value = Convert.ToSingle(parameter, CultureInfo.InvariantCulture);
+                // ensure stepper / servo settings are up-to-date and output processing is set
+                if (MaxServoAngle != _channelConfig.MaxServoAngle ||
+                    ServoBaseAngle != _channelConfig.ServoBaseAngle ||
+                    StepperAngle != _channelConfig.StepperAngle ||
+                    Action.ChannelOutputType != _channelConfig.ChannelOutputType ||
+                    !_startOutputProcessing)
+                {
+                    // update prerequsities for servo/stepper testing
+                    UpdateChannelConfig();
+                    // force reconnection with processing enabled
+                    await EnforceEnabledChannelOutputProcessing(true);
+                }
+                // simulate triggering of servo/stepper button
+                await TestButtonAsync(value, reset).ConfigureAwait(false);
             }
-            // simulate triggering of servo/stepper button
-            await TestButtonAsync(value, reset).ConfigureAwait(false);
+            catch (TaskCanceledException)
+            {
+                // ignore cancellation
+            }
         }
 
         private async Task EnforceEnabledChannelOutputProcessing(bool force = false)
@@ -322,6 +329,7 @@ namespace BrickController2.UI.ViewModels
                 Device.SetOutput(Action.Channel, GameControllers.BUTTON_RELEASED);
             }
         }
+
         private async Task SelectChannelOutputTypeAsync()
         {
             // do filtering based on device capabilities
@@ -347,12 +355,12 @@ namespace BrickController2.UI.ViewModels
 
                 if (newChannelType == ChannelOutputType.ServoMotor)
                 {
-                    // prepare servo for calibration/reset (no proutput processing)
+                    // prepare servo for calibration/reset (no output processing)
                     await EnforceDisabledChannelOutputProcessing();
                 }
                 else if (newChannelType == ChannelOutputType.StepperMotor)
                 {
-                    // prepare stepper for testing (requires processing enabled
+                    // prepare stepper for testing (requires output processing enabled
                     await EnforceEnabledChannelOutputProcessing();
                 }
             }

--- a/BrickController2/BrickController2/UI/ViewModels/ChannelSetupPageViewModel.cs
+++ b/BrickController2/BrickController2/UI/ViewModels/ChannelSetupPageViewModel.cs
@@ -57,6 +57,9 @@ namespace BrickController2.UI.ViewModels
             StepperTestCommand = new SafeCommand<string>(value => TestChannelAsync(value, reset: true));
             ServoTestCommand = new SafeCommand<string>(value => TestChannelAsync(value, reset: false));
             SelectChannelOutputTypeCommand = new SafeCommand(SelectChannelOutputTypeAsync, () => IsChannelTest);
+            ResetMaxServoAngleCommand = new SafeCommand(() => MaxServoAngle = 90);
+            ResetServoBaseAngleCommand = new SafeCommand(() => ServoBaseAngle = 0);
+            ResetStepperAngleCommand = new SafeCommand(() => StepperAngle = 90);
         }
 
         public Device Device { get; }
@@ -87,6 +90,9 @@ namespace BrickController2.UI.ViewModels
         public ICommand StepperTestCommand { get; }
         public ICommand ServoTestCommand { get; }
         public ICommand SelectChannelOutputTypeCommand { get; }
+        public ICommand ResetStepperAngleCommand { get; }
+        public ICommand ResetMaxServoAngleCommand { get; }
+        public ICommand ResetServoBaseAngleCommand { get; }
 
         public override async void OnAppearing()
         {
@@ -314,8 +320,9 @@ namespace BrickController2.UI.ViewModels
             // disconnect 
             await Device.DisconnectAsync();
 
-            // await reconnection
-            while (!DisappearingToken.IsCancellationRequested && Device.DeviceState != DeviceState.Connected)
+            // await reconnection (and closing of dialog if any)
+            while (!DisappearingToken.IsCancellationRequested &&
+                (Device.DeviceState != DeviceState.Connected || _dialogService.IsDialogOpen))
             {
                 await Task.Delay(100, DisappearingToken);
             }
@@ -355,16 +362,8 @@ namespace BrickController2.UI.ViewModels
                 // update prerequsities for servo/stepper testing
                 UpdateChannelConfig();
 
-                if (newChannelType == ChannelOutputType.ServoMotor)
-                {
-                    // prepare servo for calibration/reset (no output processing)
-                    await EnforceDisabledChannelOutputProcessing();
-                }
-                else if (newChannelType == ChannelOutputType.StepperMotor)
-                {
-                    // prepare stepper for testing (requires output processing enabled
-                    await EnforceEnabledChannelOutputProcessing();
-                }
+                // by default enable output processing for testing servo/stepper motor
+                await EnforceEnabledChannelOutputProcessing(true);
             }
         }
     }

--- a/BrickController2/BrickController2/UI/ViewModels/ChannelSetupPageViewModel.cs
+++ b/BrickController2/BrickController2/UI/ViewModels/ChannelSetupPageViewModel.cs
@@ -12,6 +12,8 @@ using System.Threading;
 using System.Threading.Tasks;
 using System.Windows.Input;
 
+using static BrickController2.CreationManagement.ControllerDefaults;
+
 namespace BrickController2.UI.ViewModels
 {
     public class ChannelSetupPageViewModel : PageViewModelBase
@@ -57,9 +59,9 @@ namespace BrickController2.UI.ViewModels
             StepperTestCommand = new SafeCommand<string>(value => TestChannelAsync(value, reset: true));
             ServoTestCommand = new SafeCommand<string>(value => TestChannelAsync(value, reset: false));
             SelectChannelOutputTypeCommand = new SafeCommand(SelectChannelOutputTypeAsync, () => IsChannelTest);
-            ResetMaxServoAngleCommand = new SafeCommand(() => MaxServoAngle = 90);
-            ResetServoBaseAngleCommand = new SafeCommand(() => ServoBaseAngle = 0);
-            ResetStepperAngleCommand = new SafeCommand(() => StepperAngle = 90);
+            ResetMaxServoAngleCommand = new SafeCommand(() => MaxServoAngle = DEFAULT_MAX_SERVO_ANGLE, () => MaxServoAngle != DEFAULT_MAX_SERVO_ANGLE);
+            ResetServoBaseAngleCommand = new SafeCommand(() => ServoBaseAngle = DEFAULT_SERVO_BASE_ANGLE, () => ServoBaseAngle != DEFAULT_SERVO_BASE_ANGLE);
+            ResetStepperAngleCommand = new SafeCommand(() => StepperAngle = DEFAULT_STEPPER_ANGLE, () => StepperAngle != DEFAULT_STEPPER_ANGLE);
         }
 
         public Device Device { get; }
@@ -71,17 +73,17 @@ namespace BrickController2.UI.ViewModels
         public int ServoBaseAngle
         {
             get { return _servoBaseAngle; }
-            set { _servoBaseAngle = value; RaisePropertyChanged(); }
+            set { _servoBaseAngle = value; RaisePropertyChanged(); ResetServoBaseAngleCommand.RaiseCanExecuteChanged(); }
         }
         public int MaxServoAngle
         {
             get { return _maxServoAngle; }
-            set { _maxServoAngle = value; RaisePropertyChanged(); }
+            set { _maxServoAngle = value; RaisePropertyChanged(); ResetMaxServoAngleCommand.RaiseCanExecuteChanged(); }
         }
         public int StepperAngle
         {
             get { return _stepperAngle; }
-            set { _stepperAngle = value; RaisePropertyChanged(); }
+            set { _stepperAngle = value; RaisePropertyChanged(); ResetStepperAngleCommand.RaiseCanExecuteChanged(); }
         }
 
         public ICommand SaveChannelSettingsCommand { get; }

--- a/BrickController2/BrickController2/UI/ViewModels/ChannelSetupPageViewModel.cs
+++ b/BrickController2/BrickController2/UI/ViewModels/ChannelSetupPageViewModel.cs
@@ -55,6 +55,7 @@ namespace BrickController2.UI.ViewModels
             AutoCalibrateServoCommand = new SafeCommand(async () => await AutoCalibrateServoAsync(), () => Device.CanAutoCalibrateOutput(Action.Channel));
             ResetServoBaseCommand = new SafeCommand(async () => await ResetServoBaseAngleAsync(), () => CanResetChannelOutput);
             StepperTestCommand = new SafeCommand<string>(value => TestChannelAsync(value, reset: true));
+            ServoTestCommand = new SafeCommand<string>(value => TestChannelAsync(value, reset: false));
             SelectChannelOutputTypeCommand = new SafeCommand(SelectChannelOutputTypeAsync, () => IsChannelTest);
         }
 
@@ -84,6 +85,7 @@ namespace BrickController2.UI.ViewModels
         public ICommand AutoCalibrateServoCommand { get; }
         public ICommand ResetServoBaseCommand { get; }
         public ICommand StepperTestCommand { get; }
+        public ICommand ServoTestCommand { get; }
         public ICommand SelectChannelOutputTypeCommand { get; }
 
         public override async void OnAppearing()

--- a/BrickController2/BrickController2/UI/ViewModels/ChannelSetupPageViewModel.cs
+++ b/BrickController2/BrickController2/UI/ViewModels/ChannelSetupPageViewModel.cs
@@ -43,9 +43,9 @@ namespace BrickController2.UI.ViewModels
             Device = parameters.Get<Device>("device");
             Action = parameters.Get<ControllerAction>("controlleraction");
             IsChannelTest = parameters.Get("ischanneltest", false);
-            MaxServoAngle = Action.ChannelOutputType == ChannelOutputType.ServoMotor ? Action.MaxServoAngle : 0;
-            ServoBaseAngle = Action.ChannelOutputType == ChannelOutputType.ServoMotor ? Action.ServoBaseAngle : 0;
-            StepperAngle = Action.ChannelOutputType == ChannelOutputType.StepperMotor ? Action.StepperAngle : 0;
+            MaxServoAngle = Action.MaxServoAngle;
+            ServoBaseAngle = Action.ServoBaseAngle;
+            StepperAngle = Action.StepperAngle;
 
             // setup channel config for testing
             UpdateChannelConfig();
@@ -60,9 +60,6 @@ namespace BrickController2.UI.ViewModels
 
         public Device Device { get; }
         public ControllerAction Action { get; }
-
-        public bool IsServoChannelOutputType => Action.ChannelOutputType == ChannelOutputType.ServoMotor;
-        public bool IsStepperChannelOutputType => Action.ChannelOutputType == ChannelOutputType.StepperMotor;
         public bool CanResetChannelOutput => Device.CanResetOutput(Action.Channel);
 
         public bool IsChannelTest { get; }
@@ -255,9 +252,9 @@ namespace BrickController2.UI.ViewModels
                 Channel = Action.Channel,
                 ChannelOutputType = Action.ChannelOutputType,
                 // current settings
-                MaxServoAngle = Action.ChannelOutputType == ChannelOutputType.ServoMotor ? MaxServoAngle : 0,
+                MaxServoAngle = MaxServoAngle,
                 ServoBaseAngle = ServoBaseAngle, // for testing applied both servo and stepper
-                StepperAngle = Action.ChannelOutputType == ChannelOutputType.StepperMotor ? StepperAngle : 0
+                StepperAngle = StepperAngle
             };
         }
 
@@ -273,17 +270,27 @@ namespace BrickController2.UI.ViewModels
             {
                 // update prerequsities for servo/stepper testing
                 UpdateChannelConfig();
-                _startOutputProcessing = true;
-                // force reconnection
-                await ReconnectDeviceAsync();
+                // force reconnection with processing enabled
+                await EnforceEnabledChannelOutputProcessing(true);
             }
             // simulate triggering of servo/stepper button
             await TestButtonAsync(value, reset).ConfigureAwait(false);
         }
 
+        private async Task EnforceEnabledChannelOutputProcessing(bool force = false)
+        {
+            if (!_startOutputProcessing|| force)
+            {
+                // update prerequisites for servo/stepper calibration/reset
+                _startOutputProcessing = true;
+                // force reconnection
+                await ReconnectDeviceAsync();
+            }
+        }
+
         private async Task EnforceDisabledChannelOutputProcessing()
         {
-            // if stepper angle has changed, we need to reconnect to apply it
+            // if output processing was required, reset it now
             if (_startOutputProcessing)
             {
                 // update prerequisites for servo/stepper calibration/reset
@@ -333,10 +340,21 @@ namespace BrickController2.UI.ViewModels
                 Enum.TryParse<ChannelOutputType>(result.SelectedItem, out var newChannelType) &&
                 newChannelType != Action.ChannelOutputType)
             {
+                // update channel output type and trigger UI update
                 Action.ChannelOutputType = newChannelType;
-                // trigger update
-                RaisePropertyChanged(nameof(IsServoChannelOutputType));
-                RaisePropertyChanged(nameof(IsStepperChannelOutputType));
+                // update prerequsities for servo/stepper testing
+                UpdateChannelConfig();
+
+                if (newChannelType == ChannelOutputType.ServoMotor)
+                {
+                    // prepare servo for calibration/reset (no proutput processing)
+                    await EnforceDisabledChannelOutputProcessing();
+                }
+                else if (newChannelType == ChannelOutputType.StepperMotor)
+                {
+                    // prepare stepper for testing (requires processing enabled
+                    await EnforceEnabledChannelOutputProcessing();
+                }
             }
         }
     }

--- a/BrickController2/BrickController2/UI/ViewModels/ChannelSetupPageViewModel.cs
+++ b/BrickController2/BrickController2/UI/ViewModels/ChannelSetupPageViewModel.cs
@@ -60,7 +60,7 @@ namespace BrickController2.UI.ViewModels
             ServoTestCommand = new SafeCommand<string>(value => TestChannelAsync(value, reset: false));
             SelectChannelOutputTypeCommand = new SafeCommand(SelectChannelOutputTypeAsync, () => IsChannelTest);
             ResetMaxServoAngleCommand = new SafeCommand(() => MaxServoAngle = DEFAULT_MAX_SERVO_ANGLE, () => MaxServoAngle != DEFAULT_MAX_SERVO_ANGLE);
-            ResetServoBaseAngleCommand = new SafeCommand(() => ServoBaseAngle = DEFAULT_SERVO_BASE_ANGLE, () => ServoBaseAngle != DEFAULT_SERVO_BASE_ANGLE);
+            ResetServoBaseAngleCommand = new SafeCommand(() => ServoBaseAngle = DEFAULT_SERVO_BASE_ANGLE, () => ServoBaseAngle != DEFAULT_SERVO_BASE_ANGLE && CanResetChannelOutput);
             ResetStepperAngleCommand = new SafeCommand(() => StepperAngle = DEFAULT_STEPPER_ANGLE, () => StepperAngle != DEFAULT_STEPPER_ANGLE);
         }
 

--- a/BrickController2/BrickController2/UI/ViewModels/ChannelSetupPageViewModel.cs
+++ b/BrickController2/BrickController2/UI/ViewModels/ChannelSetupPageViewModel.cs
@@ -1,15 +1,16 @@
-﻿using System;
-using System.Globalization;
-using System.Threading;
-using System.Threading.Tasks;
-using System.Windows.Input;
-using BrickController2.CreationManagement;
+﻿using BrickController2.CreationManagement;
 using BrickController2.DeviceManagement;
 using BrickController2.PlatformServices.GameController;
 using BrickController2.UI.Commands;
 using BrickController2.UI.Services.Dialog;
 using BrickController2.UI.Services.Navigation;
 using BrickController2.UI.Services.Translation;
+using System;
+using System.Globalization;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Windows.Input;
 
 namespace BrickController2.UI.ViewModels
 {
@@ -41,6 +42,7 @@ namespace BrickController2.UI.ViewModels
 
             Device = parameters.Get<Device>("device");
             Action = parameters.Get<ControllerAction>("controlleraction");
+            IsChannelTest = parameters.Get("ischanneltest", false);
             MaxServoAngle = Action.ChannelOutputType == ChannelOutputType.ServoMotor ? Action.MaxServoAngle : 0;
             ServoBaseAngle = Action.ChannelOutputType == ChannelOutputType.ServoMotor ? Action.ServoBaseAngle : 0;
             StepperAngle = Action.ChannelOutputType == ChannelOutputType.StepperMotor ? Action.StepperAngle : 0;
@@ -49,10 +51,11 @@ namespace BrickController2.UI.ViewModels
             UpdateChannelConfig();
             _startOutputProcessing = Action.ChannelOutputType == ChannelOutputType.StepperMotor;
 
-            SaveChannelSettingsCommand = new SafeCommand(async () => await SaveChannelSettingsAsync(), () => !_dialogService.IsDialogOpen);
+            SaveChannelSettingsCommand = new SafeCommand(async () => await SaveChannelSettingsAsync(), () => !IsChannelTest && !_dialogService.IsDialogOpen);
             AutoCalibrateServoCommand = new SafeCommand(async () => await AutoCalibrateServoAsync(), () => Device.CanAutoCalibrateOutput(Action.Channel));
             ResetServoBaseCommand = new SafeCommand(async () => await ResetServoBaseAngleAsync(), () => CanResetChannelOutput);
             StepperTestCommand = new SafeCommand<string>(value => TestChannelAsync(value, reset: true));
+            SelectChannelOutputTypeCommand = new SafeCommand(SelectChannelOutputTypeAsync, () => IsChannelTest);
         }
 
         public Device Device { get; }
@@ -61,6 +64,8 @@ namespace BrickController2.UI.ViewModels
         public bool IsServoChannelOutputType => Action.ChannelOutputType == ChannelOutputType.ServoMotor;
         public bool IsStepperChannelOutputType => Action.ChannelOutputType == ChannelOutputType.StepperMotor;
         public bool CanResetChannelOutput => Device.CanResetOutput(Action.Channel);
+
+        public bool IsChannelTest { get; }
 
         public int ServoBaseAngle
         {
@@ -82,6 +87,7 @@ namespace BrickController2.UI.ViewModels
         public ICommand AutoCalibrateServoCommand { get; }
         public ICommand ResetServoBaseCommand { get; }
         public ICommand StepperTestCommand { get; }
+        public ICommand SelectChannelOutputTypeCommand { get; }
 
         public override async void OnAppearing()
         {
@@ -262,6 +268,7 @@ namespace BrickController2.UI.ViewModels
             if (MaxServoAngle != _channelConfig.MaxServoAngle ||
                 ServoBaseAngle != _channelConfig.ServoBaseAngle ||
                 StepperAngle != _channelConfig.StepperAngle ||
+                Action.ChannelOutputType != _channelConfig.ChannelOutputType ||
                 !_startOutputProcessing)
             {
                 // update prerequsities for servo/stepper testing
@@ -279,7 +286,7 @@ namespace BrickController2.UI.ViewModels
             // if stepper angle has changed, we need to reconnect to apply it
             if (_startOutputProcessing)
             {
-                // update prerequsities for servo/stepper calibration/reset
+                // update prerequisites for servo/stepper calibration/reset
                 _startOutputProcessing = false;
                 // force reconnection
                 await ReconnectDeviceAsync();
@@ -306,6 +313,30 @@ namespace BrickController2.UI.ViewModels
             if (reset)
             {
                 Device.SetOutput(Action.Channel, GameControllers.BUTTON_RELEASED);
+            }
+        }
+        private async Task SelectChannelOutputTypeAsync()
+        {
+            // do filtering based on device capabilities
+            var channelOutputTypes = new[] { ChannelOutputType.ServoMotor, ChannelOutputType.StepperMotor }
+                .Where(x => Device.IsOutputTypeSupported(Action.Channel, x))
+                .Select(x => Enum.GetName(x)!)
+                .ToArray();
+
+            var result = await _dialogService.ShowSelectionDialogAsync(
+                channelOutputTypes,
+                Translate("ChannelType"),
+                Translate("Cancel"),
+                DisappearingToken);
+
+            if (result.IsOk &&
+                Enum.TryParse<ChannelOutputType>(result.SelectedItem, out var newChannelType) &&
+                newChannelType != Action.ChannelOutputType)
+            {
+                Action.ChannelOutputType = newChannelType;
+                // trigger update
+                RaisePropertyChanged(nameof(IsServoChannelOutputType));
+                RaisePropertyChanged(nameof(IsStepperChannelOutputType));
             }
         }
     }

--- a/BrickController2/BrickController2/UI/ViewModels/ChannelSetupPageViewModel.cs
+++ b/BrickController2/BrickController2/UI/ViewModels/ChannelSetupPageViewModel.cs
@@ -223,36 +223,50 @@ namespace BrickController2.UI.ViewModels
 
         private async Task AutoCalibrateServoAsync()
         {
-            await EnforceDisabledChannelOutputProcessing();
-            await _dialogService.ShowProgressDialogAsync(
-                false,
-                async (progressDialog, token) =>
-                {
-                    var result = await Device.AutoCalibrateOutputAsync(Action.Channel, token);
-                    if (result.Success)
+            try
+            {
+                await EnforceDisabledChannelOutputProcessing();
+                await _dialogService.ShowProgressDialogAsync(
+                    false,
+                    async (progressDialog, token) =>
                     {
-                        ServoBaseAngle = (int)(result.BaseServoAngle * 180);
-                    }
-                },
-                Translate("Calibrating"),
-                null,
-                Translate("Cancel"),
-                DisappearingToken);
+                        var result = await Device.AutoCalibrateOutputAsync(Action.Channel, token);
+                        if (result.Success)
+                        {
+                            ServoBaseAngle = (int)(result.BaseServoAngle * 180);
+                        }
+                    },
+                    Translate("Calibrating"),
+                    null,
+                    Translate("Cancel"),
+                    DisappearingToken);
+            }
+            catch (OperationCanceledException)
+            {
+                // ignore cancellation
+            }
         }
 
         private async Task ResetServoBaseAngleAsync()
         {
-            await EnforceDisabledChannelOutputProcessing();
-            await _dialogService.ShowProgressDialogAsync(
-                false,
-                async (progressDialog, token) =>
-                {
-                    await Device.ResetOutputAsync(Action.Channel, ServoBaseAngle / 180F, token);
-                },
-                Translate("Reseting"),
-                null,
-                Translate("Cancel"),
-                DisappearingToken);
+            try
+            {
+                await EnforceDisabledChannelOutputProcessing();
+                await _dialogService.ShowProgressDialogAsync(
+                    false,
+                    async (progressDialog, token) =>
+                    {
+                        await Device.ResetOutputAsync(Action.Channel, ServoBaseAngle / 180F, token);
+                    },
+                    Translate("Reseting"),
+                    null,
+                    Translate("Cancel"),
+                    DisappearingToken);
+            }
+            catch (OperationCanceledException)
+            {
+                // ignore cancellation
+            }
         }
 
         private void UpdateChannelConfig()
@@ -288,7 +302,7 @@ namespace BrickController2.UI.ViewModels
                 // simulate triggering of servo/stepper button
                 await TestButtonAsync(value, reset).ConfigureAwait(false);
             }
-            catch (TaskCanceledException)
+            catch (OperationCanceledException)
             {
                 // ignore cancellation
             }
@@ -326,7 +340,7 @@ namespace BrickController2.UI.ViewModels
             while (!DisappearingToken.IsCancellationRequested &&
                 (Device.DeviceState != DeviceState.Connected || _dialogService.IsDialogOpen))
             {
-                await Task.Delay(100, DisappearingToken);
+                await Task.Delay(50, DisappearingToken);
             }
         }
 
@@ -343,29 +357,36 @@ namespace BrickController2.UI.ViewModels
 
         private async Task SelectChannelOutputTypeAsync()
         {
-            // do filtering based on device capabilities
-            var channelOutputTypes = new[] { ChannelOutputType.ServoMotor, ChannelOutputType.StepperMotor }
-                .Where(x => Device.IsOutputTypeSupported(Action.Channel, x))
-                .Select(x => Enum.GetName(x)!)
-                .ToArray();
-
-            var result = await _dialogService.ShowSelectionDialogAsync(
-                channelOutputTypes,
-                Translate("ChannelType"),
-                Translate("Cancel"),
-                DisappearingToken);
-
-            if (result.IsOk &&
-                Enum.TryParse<ChannelOutputType>(result.SelectedItem, out var newChannelType) &&
-                newChannelType != Action.ChannelOutputType)
+            try
             {
-                // update channel output type and trigger UI update
-                Action.ChannelOutputType = newChannelType;
-                // update prerequsities for servo/stepper testing
-                UpdateChannelConfig();
+                // do filtering based on device capabilities
+                var channelOutputTypes = new[] { ChannelOutputType.ServoMotor, ChannelOutputType.StepperMotor }
+                    .Where(x => Device.IsOutputTypeSupported(Action.Channel, x))
+                    .Select(x => Enum.GetName(x)!)
+                    .ToArray();
 
-                // by default enable output processing for testing servo/stepper motor
-                await EnforceEnabledChannelOutputProcessing(true);
+                var result = await _dialogService.ShowSelectionDialogAsync(
+                    channelOutputTypes,
+                    Translate("ChannelType"),
+                    Translate("Cancel"),
+                    DisappearingToken);
+
+                if (result.IsOk &&
+                    Enum.TryParse<ChannelOutputType>(result.SelectedItem, out var newChannelType) &&
+                    newChannelType != Action.ChannelOutputType)
+                {
+                    // update channel output type and trigger UI update
+                    Action.ChannelOutputType = newChannelType;
+                    // update prerequsities for servo/stepper testing
+                    UpdateChannelConfig();
+
+                    // by default enable output processing for testing servo/stepper motor
+                    await EnforceEnabledChannelOutputProcessing(true);
+                }
+            }
+            catch (OperationCanceledException)
+            {
+                // ignore cancellation
             }
         }
     }

--- a/BrickController2/BrickController2/UI/ViewModels/ControllerActionPageViewModel.cs
+++ b/BrickController2/BrickController2/UI/ViewModels/ControllerActionPageViewModel.cs
@@ -219,10 +219,11 @@ namespace BrickController2.UI.ViewModels
 
         private async Task SelectChannelOutputTypeAsync()
         {
-            // do simple filtering of Normal and Stepper for TechnicMove
-            var channelOutputTypes = SelectedDevice?.DeviceType != DeviceType.TechnicMove ?
-                Enum.GetNames<ChannelOutputType>() :
-                [Enum.GetName(ChannelOutputType.ServoMotor)!];
+            // do filtering based on device capabilities
+            var channelOutputTypes = Enum.GetValues<ChannelOutputType>()
+                .Where(x => SelectedDevice?.IsOutputTypeSupported(Action.Channel, x) ?? true)
+                .Select(x => Enum.GetName(x)!)
+                .ToArray();
 
             var result = await _dialogService.ShowSelectionDialogAsync(
                 channelOutputTypes,

--- a/BrickController2/BrickController2/UI/ViewModels/DevicePageViewModel.cs
+++ b/BrickController2/BrickController2/UI/ViewModels/DevicePageViewModel.cs
@@ -12,6 +12,7 @@ using BrickController2.UI.Services.Navigation;
 using BrickController2.UI.Services.Dialog;
 using BrickController2.UI.Services.Translation;
 using Device = BrickController2.DeviceManagement.Device;
+using BrickController2.CreationManagement;
 
 namespace BrickController2.UI.ViewModels
 {
@@ -41,7 +42,7 @@ namespace BrickController2.UI.ViewModels
             BuWizz2OutputLevel = Device.DefaultOutputLevel;
             DeviceOutputs =  Enumerable
                 .Range(0, Device.NumberOfChannels)
-                .Select(channel => new DeviceOutputViewModel(Device, channel))
+                .Select(channel => new DeviceOutputViewModel(navigationService, Device, channel))
                 .ToArray();
 
             RenameCommand = new SafeCommand(async () => await RenameDeviceAsync());
@@ -347,15 +348,18 @@ namespace BrickController2.UI.ViewModels
 
         public class DeviceOutputViewModel : NotifyPropertyChangedSource
         {
+            private readonly INavigationService _navigationService;
             private int _output;
 
-            public DeviceOutputViewModel(Device device, int channel)
+            public DeviceOutputViewModel(INavigationService navigationService, Device device, int channel)
             {
+                _navigationService= navigationService;
                 Device = device;
                 Channel = channel;
                 Output = 0;
 
                 TouchUpCommand = new Command(() => Output = 0);
+                TestServeStepperCommand = new SafeCommand(OpenChannelSetupAsync);
             }
 
             public Device Device { get; }
@@ -374,8 +378,24 @@ namespace BrickController2.UI.ViewModels
                     RaisePropertyChanged();
                 }
             }
+            public bool IsServoOrStepperSupported => true;//todo
 
             public ICommand TouchUpCommand { get; }
+            public ICommand TestServeStepperCommand { get; }
+
+            private async Task OpenChannelSetupAsync()
+            {
+                var action = new ControllerAction
+                {
+                    DeviceId = Device.Id,
+                    Channel = Channel,
+
+                    ChannelOutputType= ChannelOutputType.ServoMotor,//todo
+
+
+                };
+                await _navigationService.NavigateToAsync<ChannelSetupPageViewModel>(new NavigationParameters(("device", Device), ("controlleraction", action)));
+            }
         }
     }
 }

--- a/BrickController2/BrickController2/UI/ViewModels/DevicePageViewModel.cs
+++ b/BrickController2/BrickController2/UI/ViewModels/DevicePageViewModel.cs
@@ -342,6 +342,8 @@ namespace BrickController2.UI.ViewModels
             ScanCommand.RaiseCanExecuteChanged();
             ActivateShelfModeCommand.RaiseCanExecuteChanged();
             OpenDeviceSettingsPageCommand.RaiseCanExecuteChanged();
+            // to ensure that servo/stepper commands are enabled / disabled properly
+            RaisePropertyChanged(nameof(IsServoOrStepperSupported));
         }
 
         private void SetBuWizzOutputLevel(int level)

--- a/BrickController2/BrickController2/UI/ViewModels/DevicePageViewModel.cs
+++ b/BrickController2/BrickController2/UI/ViewModels/DevicePageViewModel.cs
@@ -5,6 +5,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using System.Windows.Input;
 using Microsoft.Maui.Controls;
+using BrickController2.CreationManagement;
 using BrickController2.DeviceManagement;
 using BrickController2.Helpers;
 using BrickController2.UI.Commands;
@@ -12,7 +13,7 @@ using BrickController2.UI.Services.Navigation;
 using BrickController2.UI.Services.Dialog;
 using BrickController2.UI.Services.Translation;
 using Device = BrickController2.DeviceManagement.Device;
-using BrickController2.CreationManagement;
+using static BrickController2.CreationManagement.ControllerDefaults;
 
 namespace BrickController2.UI.ViewModels
 {
@@ -394,9 +395,9 @@ namespace BrickController2.UI.ViewModels
                 {
                     DeviceId = Device.Id,
                     Channel = Channel,
-                    MaxServoAngle = 90,
-                    ServoBaseAngle = 0,
-                    StepperAngle = 90,
+                    MaxServoAngle = DEFAULT_MAX_SERVO_ANGLE,
+                    ServoBaseAngle = DEFAULT_SERVO_BASE_ANGLE,
+                    StepperAngle = DEFAULT_STEPPER_ANGLE,
                     // choose first supported output type
                     ChannelOutputType = Device.IsOutputTypeSupported(Channel, ChannelOutputType.ServoMotor) 
                         ? ChannelOutputType.ServoMotor

--- a/BrickController2/BrickController2/UI/ViewModels/DevicePageViewModel.cs
+++ b/BrickController2/BrickController2/UI/ViewModels/DevicePageViewModel.cs
@@ -67,6 +67,8 @@ namespace BrickController2.UI.ViewModels
             Device.DeviceState == DeviceState.Connected &&
             !_deviceManager.IsScanning;
 
+        public bool IsServoOrStepperSupported => DeviceOutputs.Any(x => x.IsServoOrStepperSupported);
+
         public ICommand RenameCommand { get; }
         public ICommand BuWizzOutputLevelChangedCommand { get; }
         public ICommand BuWizz2OutputLevelChangedCommand { get; }
@@ -359,7 +361,7 @@ namespace BrickController2.UI.ViewModels
                 Output = 0;
 
                 TouchUpCommand = new Command(() => Output = 0);
-                TestServeStepperCommand = new SafeCommand(OpenChannelSetupAsync);
+                TestServoStepperCommand = new SafeCommand(OpenChannelSetupAsync, () => IsServoOrStepperSupported);
             }
 
             public Device Device { get; }
@@ -378,10 +380,13 @@ namespace BrickController2.UI.ViewModels
                     RaisePropertyChanged();
                 }
             }
-            public bool IsServoOrStepperSupported => true;//todo
+
+            public bool IsServoOrStepperSupported =>
+                Device.IsOutputTypeSupported(Channel, ChannelOutputType.ServoMotor) ||
+                Device.IsOutputTypeSupported(Channel, ChannelOutputType.StepperMotor);
 
             public ICommand TouchUpCommand { get; }
-            public ICommand TestServeStepperCommand { get; }
+            public ICommand TestServoStepperCommand { get; }
 
             private async Task OpenChannelSetupAsync()
             {
@@ -389,12 +394,17 @@ namespace BrickController2.UI.ViewModels
                 {
                     DeviceId = Device.Id,
                     Channel = Channel,
-
-                    ChannelOutputType= ChannelOutputType.ServoMotor,//todo
-
-
+                    MaxServoAngle = 90,
+                    ServoBaseAngle = 0,
+                    StepperAngle = 90,
+                    // choose first supported output type
+                    ChannelOutputType = Device.IsOutputTypeSupported(Channel, ChannelOutputType.ServoMotor) 
+                        ? ChannelOutputType.ServoMotor
+                        : ChannelOutputType.StepperMotor,
                 };
-                await _navigationService.NavigateToAsync<ChannelSetupPageViewModel>(new NavigationParameters(("device", Device), ("controlleraction", action)));
+                await _navigationService.NavigateToAsync<ChannelSetupPageViewModel>(new NavigationParameters(("device", Device),
+                    ("controlleraction", action),
+                    ("ischanneltest", true)));
             }
         }
     }


### PR DESCRIPTION
* added new API `IsOutputTypeSupported` for `Deice` to replace `CanChangeOutputType`
* enabled Channel setup page (for stepper / servo if supported) to be openned for particular channel
* stepper channel setup allows to reset current angle based on current base angle value
* servo testing involves setting of range as well:
![image](https://github.com/user-attachments/assets/7d4bb0a9-9a9a-4163-bd46-cca29a84bb18)
* fixed handling of test button and availability of PLAYVM mode for Technic Move when such settings has changed
