### PR TITLE
If BLE device is not found in Windows cache, try to look for it via watcher

### DIFF
--- a/BrickController2/BrickController2.WinUI/PlatformServices/BluetoothLE/BleDevice.cs
+++ b/BrickController2/BrickController2.WinUI/PlatformServices/BluetoothLE/BleDevice.cs
@@ -14,6 +14,9 @@ namespace BrickController2.Windows.PlatformServices.BluetoothLE;
 
 public class BleDevice : IBluetoothLEDevice
 {
+    private const string AqsFilter = "(System.Devices.Aep.ProtocolId:=\"{bb7bb05e-5972-42b5-94fc-76eaa7084d49}\")";
+    private const string DeviceAddressPropertyKey = "System.Devices.Aep.DeviceAddress";
+    // Default timeout for finding a Bluetooth LE device if not present in Windows cache
     private static readonly TimeSpan DefaultDeviceFindTimeout = TimeSpan.FromSeconds(8);
 
     private readonly AsyncLock _lock = new();
@@ -324,19 +327,19 @@ public class BleDevice : IBluetoothLEDevice
         }
         // otherwise look via watcher using AQS filter for BLE devices
         var watcher = DeviceInformation.CreateWatcher(
-            "(System.Devices.Aep.ProtocolId:=\"{bb7bb05e-5972-42b5-94fc-76eaa7084d49}\")",
-            ["System.Devices.Aep.DeviceAddress"],
+            AqsFilter,
+            [DeviceAddressPropertyKey],
             DeviceInformationKind.AssociationEndpoint);
 
         var findDeviceIdSource = new TaskCompletionSource<string>();
         watcher.Added += (DeviceWatcher sender, DeviceInformation info) =>
         {
             // Check if the device matches the address
-            if (info.Properties.TryGetValue("System.Devices.Aep.DeviceAddress", out var value))
+            if (info.Properties.TryGetValue(DeviceAddressPropertyKey, out var value))
             {
                 if (value is string deviceAddress && deviceAddress.Equals(address, StringComparison.OrdinalIgnoreCase))
                 {
-                    findDeviceIdSource.SetResult(info.Id); // Found the device
+                    findDeviceIdSource.TrySetResult(info.Id); // Found the device
                 }
             }
         };

--- a/BrickController2/BrickController2.WinUI/PlatformServices/BluetoothLE/BleDevice.cs
+++ b/BrickController2/BrickController2.WinUI/PlatformServices/BluetoothLE/BleDevice.cs
@@ -8,11 +8,14 @@ using System.Threading;
 using System.Threading.Tasks;
 using Windows.Devices.Bluetooth;
 using Windows.Devices.Bluetooth.GenericAttributeProfile;
+using Windows.Devices.Enumeration;
 
 namespace BrickController2.Windows.PlatformServices.BluetoothLE;
 
 public class BleDevice : IBluetoothLEDevice
 {
+    private static readonly TimeSpan DefaultDeviceFindTimeout = TimeSpan.FromSeconds(8);
+
     private readonly AsyncLock _lock = new();
 
     private BluetoothLEDevice? _bluetoothDevice;
@@ -46,16 +49,17 @@ public class BleDevice : IBluetoothLEDevice
             }
         }))
         {
-            _services = await ConnectAsync(onCharacteristicChanged, onDeviceDisconnected);
+            _services = await ConnectAsync(onCharacteristicChanged, onDeviceDisconnected, token);
             return _services;
         }
     }
 
     private async Task<ICollection<BleGattService>?> ConnectAsync(
         Action<Guid, byte[]> onCharacteristicChanged,
-        Action<IBluetoothLEDevice> onDeviceDisconnected)
+        Action<IBluetoothLEDevice> onDeviceDisconnected,
+        CancellationToken token)
     {
-        using (await _lock.LockAsync())
+        using (await _lock.LockAsync(token))
         {
             if (State != BluetoothLEDeviceState.Disconnected)
             {
@@ -66,11 +70,8 @@ public class BleDevice : IBluetoothLEDevice
 
             State = BluetoothLEDeviceState.Connecting;
 
-            if (Address.TryParseBluetoothAddressString(out var bluetoothAddress))
-            {
-                _bluetoothDevice?.Dispose();
-                _bluetoothDevice = await BluetoothLEDevice.FromBluetoothAddressAsync(bluetoothAddress);
-            }
+            _bluetoothDevice?.Dispose();
+            _bluetoothDevice = await FindDeviceAsync(Address, DefaultDeviceFindTimeout, token);
 
             if (_bluetoothDevice == null)
             {
@@ -308,5 +309,47 @@ public class BleDevice : IBluetoothLEDevice
         InternalDisconnect();
         _connectCompletionSource?.SetResult(null);
         return false;
+    }
+
+    private static async Task<BluetoothLEDevice?> FindDeviceAsync(string address, TimeSpan timeout, CancellationToken token)
+    {
+        if (address.TryParseBluetoothAddressString(out var bluetoothAddress))
+        {
+            // try Windows device cache first
+            var device = await BluetoothLEDevice.FromBluetoothAddressAsync(bluetoothAddress);
+            if (device != null)
+            {
+                return device;
+            }
+            // otherwise look via watcher using AQS filter for BLE devices
+            var watcher = DeviceInformation.CreateWatcher(
+                "(System.Devices.Aep.ProtocolId:=\"{bb7bb05e-5972-42b5-94fc-76eaa7084d49}\")",
+                ["System.Devices.Aep.DeviceAddress"],
+                DeviceInformationKind.AssociationEndpoint);
+
+            var findDeviceSource = new TaskCompletionSource<string>();
+            watcher.Added += (DeviceWatcher sender, DeviceInformation info) =>
+            {
+                // Check if the device matches the address
+                if (info.Properties.TryGetValue("System.Devices.Aep.DeviceAddress", out var value))
+                {
+                    if (value is string deviceAddress && deviceAddress.Equals(address, StringComparison.OrdinalIgnoreCase))
+                    {
+                        findDeviceSource.SetResult(info.Id); // Found the device
+                    }
+                }
+            };
+
+            watcher.Start();
+            // Wait for the watcher to find the device or timeout
+            await Task.WhenAny(findDeviceSource.Task, Task.Delay(timeout, token));
+            watcher.Stop();
+
+            if (findDeviceSource.Task.IsCompletedSuccessfully)
+            {
+                return await BluetoothLEDevice.FromIdAsync(findDeviceSource.Task.Result);
+            }
+        }
+        return null;
     }
 }

--- a/BrickController2/BrickController2.WinUI/PlatformServices/BluetoothLE/BleDevice.cs
+++ b/BrickController2/BrickController2.WinUI/PlatformServices/BluetoothLE/BleDevice.cs
@@ -321,34 +321,34 @@ public class BleDevice : IBluetoothLEDevice
             {
                 return device;
             }
-            // otherwise look via watcher using AQS filter for BLE devices
-            var watcher = DeviceInformation.CreateWatcher(
-                "(System.Devices.Aep.ProtocolId:=\"{bb7bb05e-5972-42b5-94fc-76eaa7084d49}\")",
-                ["System.Devices.Aep.DeviceAddress"],
-                DeviceInformationKind.AssociationEndpoint);
+        }
+        // otherwise look via watcher using AQS filter for BLE devices
+        var watcher = DeviceInformation.CreateWatcher(
+            "(System.Devices.Aep.ProtocolId:=\"{bb7bb05e-5972-42b5-94fc-76eaa7084d49}\")",
+            ["System.Devices.Aep.DeviceAddress"],
+            DeviceInformationKind.AssociationEndpoint);
 
-            var findDeviceSource = new TaskCompletionSource<string>();
-            watcher.Added += (DeviceWatcher sender, DeviceInformation info) =>
+        var findDeviceIdSource = new TaskCompletionSource<string>();
+        watcher.Added += (DeviceWatcher sender, DeviceInformation info) =>
+        {
+            // Check if the device matches the address
+            if (info.Properties.TryGetValue("System.Devices.Aep.DeviceAddress", out var value))
             {
-                // Check if the device matches the address
-                if (info.Properties.TryGetValue("System.Devices.Aep.DeviceAddress", out var value))
+                if (value is string deviceAddress && deviceAddress.Equals(address, StringComparison.OrdinalIgnoreCase))
                 {
-                    if (value is string deviceAddress && deviceAddress.Equals(address, StringComparison.OrdinalIgnoreCase))
-                    {
-                        findDeviceSource.SetResult(info.Id); // Found the device
-                    }
+                    findDeviceIdSource.SetResult(info.Id); // Found the device
                 }
-            };
-
-            watcher.Start();
-            // Wait for the watcher to find the device or timeout
-            await Task.WhenAny(findDeviceSource.Task, Task.Delay(timeout, token));
-            watcher.Stop();
-
-            if (findDeviceSource.Task.IsCompletedSuccessfully)
-            {
-                return await BluetoothLEDevice.FromIdAsync(findDeviceSource.Task.Result);
             }
+        };
+
+        watcher.Start();
+        // Wait for the watcher to find the device or timeout
+        await Task.WhenAny(findDeviceIdSource.Task, Task.Delay(timeout, token));
+        watcher.Stop();
+
+        if (findDeviceIdSource.Task.IsCompletedSuccessfully)
+        {
+            return await BluetoothLEDevice.FromIdAsync(findDeviceIdSource.Task.Result);
         }
         return null;
     }

--- a/BrickController2/BrickController2.WinUI/PlatformServices/BluetoothLE/BleDevice.cs
+++ b/BrickController2/BrickController2.WinUI/PlatformServices/BluetoothLE/BleDevice.cs
@@ -331,7 +331,7 @@ public class BleDevice : IBluetoothLEDevice
             [DeviceAddressPropertyKey],
             DeviceInformationKind.AssociationEndpoint);
 
-        var findDeviceIdSource = new TaskCompletionSource<string>();
+        var findDeviceIdSource = new TaskCompletionSource<string>(TaskCreationOptions.RunContinuationsAsynchronously);
         watcher.Added += (DeviceWatcher sender, DeviceInformation info) =>
         {
             // Check if the device matches the address
@@ -344,10 +344,16 @@ public class BleDevice : IBluetoothLEDevice
             }
         };
 
-        watcher.Start();
-        // Wait for the watcher to find the device or timeout
-        await Task.WhenAny(findDeviceIdSource.Task, Task.Delay(timeout, token));
-        watcher.Stop();
+        try
+        {
+            watcher.Start();
+            // Wait for the watcher to find the device or timeout
+            await Task.WhenAny(findDeviceIdSource.Task, Task.Delay(timeout, token));
+        }
+        finally
+        {
+            watcher.Stop();
+        }
 
         if (findDeviceIdSource.Task.IsCompletedSuccessfully)
         {

--- a/BrickController2/BrickController2.WinUI/PlatformServices/BluetoothLE/BleService.cs
+++ b/BrickController2/BrickController2.WinUI/PlatformServices/BluetoothLE/BleService.cs
@@ -18,7 +18,7 @@ public class BleService : IBluetoothLEService
     public async Task<bool> IsBluetoothLESupportedAsync()
     {
         var adapter = await BluetoothAdapter.GetDefaultAsync();
-        return adapter.IsLowEnergySupported;
+        return adapter != null && adapter.IsLowEnergySupported;
     }
 
     public Task<bool> IsBluetoothLEAdvertisingSupportedAsync()
@@ -32,8 +32,12 @@ public class BleService : IBluetoothLEService
     public async Task<bool> IsBluetoothOnAsync()
     {
         var adapter = await BluetoothAdapter.GetDefaultAsync();
+        if (adapter == null)
+        {
+            return false; // No Bluetooth adapter found
+        }
         var radio = await adapter.GetRadioAsync();
-        return radio.State == RadioState.On;
+        return radio != null && radio.State == RadioState.On;
     }
 
     public async Task<bool> ScanDevicesAsync(Action<ScanResult> scanCallback, CancellationToken token)


### PR DESCRIPTION
This should resolve issue when a device has not been connected for long time and is not present in Windows bt cache:
* https://github.com/MicrosoftDocs/winrt-api/issues/2092
* https://learn.microsoft.com/en-us/uwp/api/windows.devices.bluetooth.bluetoothledevice.frombluetoothaddressasync?view=winrt-22000