### PR TITLE
Enable BLE advertising on IOS

### DIFF
--- a/BrickController2/BrickController2.iOS/PlatformServices/BluetoothLE/BluetoothLEService.cs
+++ b/BrickController2/BrickController2.iOS/PlatformServices/BluetoothLE/BluetoothLEService.cs
@@ -29,7 +29,7 @@ namespace BrickController2.iOS.PlatformServices.BluetoothLE
         }
 
         public Task<bool> IsBluetoothLESupportedAsync() => Task.FromResult(true);
-        public Task<bool> IsBluetoothLEAdvertisingSupportedAsync() => Task.FromResult(false); // Not supported yet - has to be implemented
+        public Task<bool> IsBluetoothLEAdvertisingSupportedAsync() => Task.FromResult(true);
         public Task<bool> IsBluetoothOnAsync() => Task.FromResult(_centralManager.State == CBManagerState.PoweredOn);
         public async Task<bool> ScanDevicesAsync(Action<ScanResult> scanCallback, CancellationToken token)
         {


### PR DESCRIPTION
Seems this was omitted in #133.

Resolves #114.