### PR TITLE
revised - type specific handling of channels

### DIFF
--- a/BrickController2/BrickController2/DeviceManagement/BluetoothAdvertisingDevice.cs
+++ b/BrickController2/BrickController2/DeviceManagement/BluetoothAdvertisingDevice.cs
@@ -124,6 +124,11 @@ namespace BrickController2.DeviceManagement
         protected abstract void InitDevice();
 
         /// <summary>
+        /// set device to discennected state
+        /// </summary>
+        protected abstract void DisconnectDevice();
+
+        /// <summary>
         /// Get or create BluetoothAdvertisingDeviceHandler
         /// </summary>
         /// <returns>Instance of BluetoothAdvertisingDeviceHandler</returns>

--- a/BrickController2/BrickController2/DeviceManagement/BluetoothAdvertisingDeviceHandler.cs
+++ b/BrickController2/BrickController2/DeviceManagement/BluetoothAdvertisingDeviceHandler.cs
@@ -96,7 +96,7 @@ namespace BrickController2.DeviceManagement
         /// <summary>
         /// bitfield representing the set-state of all channels of all instances of the DeviceType handled by this instance.
         /// </summary>
-        private long _allChannelsSetState = 0;
+        private int _allChannelsSetState = 0;
 
         public BluetoothAdvertisingDeviceHandler(IBluetoothLEService bleService, ushort manufacturerId, TryGetTelegramHandler tryGetTelegram, TimeSpan reconnectTimespan)
         {
@@ -109,34 +109,62 @@ namespace BrickController2.DeviceManagement
         public AdvertisingInterval AdvertisingInterval => AdvertisingInterval.Min;
         public TxPowerLevel TxPowerLevel => TxPowerLevel.Max;
 
-        public void NotifyDataChanged(int specificChannelNo, bool zeroSet)
+        /// <summary>
+        /// Updates the state of a specific channel by either setting or resetting its state.
+        /// </summary>
+        /// <remarks>This method modifies the internal state of the specified channel by either setting or
+        /// resetting its corresponding bit. If <paramref name="zeroSet"/> is <see langword="true"/>, the method sets
+        /// the bit for the specified channel and checks whether the state of all channels is zero and whether a change
+        /// occurred. If <paramref name="zeroSet"/> is <see langword="false"/>, the method resets the bit for the
+        /// specified channel and always returns <see langword="false"/>.</remarks>
+        /// <param name="specificChannelNo">The zero-based index of the channel to update. Must be a valid channel number.</param>
+        /// <param name="zeroSet">A value indicating whether to set (<see langword="true"/>) or reset (<see langword="false"/>) the state of
+        /// the specified channel.</param>
+        /// <returns><see langword="true"/> if the state of all channels is zero and the state of the specified channel was
+        /// successfully changed; otherwise, <see langword="false"/>.</returns>
+        public bool SetChannelState(int specificChannelNo, bool zeroSet)
         {
             if (zeroSet)
             {
-                long allChannelsSetState = _allChannelsSetState;
+                int allChannelsSetState = _allChannelsSetState;
 
-                // reset the bit for the specificChannelNo
-                _allChannelsSetState &= ~(1L << specificChannelNo);
+                // reset the bit for the specificChannelNo in the bitfield
+                _allChannelsSetState &= ~(1 << specificChannelNo);
 
-                if (_allChannelsSetState == 0 &&                    // set state of all channels is zero
-                    allChannelsSetState != _allChannelsSetState)    // there was a change
+                if(_allChannelsSetState == 0 &&                     // new set state of all channels is zero
+                    allChannelsSetState != _allChannelsSetState)    // and there was a change
                 {
+                    // if all channels are set to zero, reset the stopwatch
                     _allZeroStopwatch.Restart();
 
-                    // signal _waitForNewData to immediately run next loop in ProcessOutputs
-                    _waitForNewData?.Set();
+                    return true;
                 }
-                //else {} // no change, no signalling
+                else
+                {
+                    return false; // no change in state
+                }
             }
             else
             {
                 // set the bit for the specificChannelNo
-                _allChannelsSetState |= (1L << specificChannelNo);
+                _allChannelsSetState |= (1 << specificChannelNo);
 
-                // signal _waitForNewData to immediately run next loop in ProcessOutputs
-                _waitForNewData?.Set();
+                return false;
             }
         }
+
+        /// <summary>
+        /// Notifies the system that data has changed and triggers any associated processes.
+        /// </summary>
+        /// <remarks>This method signals the system to immediately proceed with processing outputs that
+        /// depend on new data. It resets internal timing mechanisms and ensures that waiting processes are
+        /// notified.</remarks>
+        public void NotifyDataChanged()
+        {
+            // signal _waitForNewData to immediately run next loop in ProcessOutputs
+            _waitForNewData?.Set();
+        }
+
 
         public async Task<bool> TryConnectAsync(BluetoothAdvertisingDevice requestingDevice)
         {

--- a/BrickController2/BrickController2/DeviceManagement/BluetoothAdvertisingDeviceHandler.cs
+++ b/BrickController2/BrickController2/DeviceManagement/BluetoothAdvertisingDeviceHandler.cs
@@ -94,9 +94,9 @@ namespace BrickController2.DeviceManagement
         private AutoResetEvent? _waitForNewData;
 
         /// <summary>
-        /// True if all channels are zero
+        /// bitfield representing the set-state of all channels of all instances of the DeviceType handled by this instance.
         /// </summary>
-        private bool _allChannelsZero = true;
+        private long _allChannelsSetState = 0;
 
         public BluetoothAdvertisingDeviceHandler(IBluetoothLEService bleService, ushort manufacturerId, TryGetTelegramHandler tryGetTelegram, TimeSpan reconnectTimespan)
         {
@@ -109,14 +109,18 @@ namespace BrickController2.DeviceManagement
         public AdvertisingInterval AdvertisingInterval => AdvertisingInterval.Min;
         public TxPowerLevel TxPowerLevel => TxPowerLevel.Max;
 
-        public void NotifyDataChanged(bool allChannelsZero)
+        public void NotifyDataChanged(int specificChannelNo, bool zeroSet)
         {
-            if (allChannelsZero)
+            if (zeroSet)
             {
-                // _allChannelsZero will change to true
-                if (!_allChannelsZero)
+                long allChannelsSetState = _allChannelsSetState;
+
+                // reset the bit for the specificChannelNo
+                _allChannelsSetState &= ~(1L << specificChannelNo);
+
+                if (_allChannelsSetState == 0 &&                    // set state of all channels is zero
+                    allChannelsSetState != _allChannelsSetState)    // there was a change
                 {
-                    _allChannelsZero = true;
                     _allZeroStopwatch.Restart();
 
                     // signal _waitForNewData to immediately run next loop in ProcessOutputs
@@ -126,7 +130,8 @@ namespace BrickController2.DeviceManagement
             }
             else
             {
-                _allChannelsZero = false;
+                // set the bit for the specificChannelNo
+                _allChannelsSetState |= (1L << specificChannelNo);
 
                 // signal _waitForNewData to immediately run next loop in ProcessOutputs
                 _waitForNewData?.Set();
@@ -316,7 +321,8 @@ namespace BrickController2.DeviceManagement
 
                 // if all channels are zero and _reconnectTimeSpan has elapsed
                 // then the connect telegram should be sent
-                inConnectMode = _allChannelsZero && _allZeroStopwatch.Elapsed > _reconnectTimeSpan;
+                inConnectMode = _allChannelsSetState == 0 && 
+                    _allZeroStopwatch.Elapsed > _reconnectTimeSpan;
 
                 // if connectMode is requested and if previous was not a connect telegram
                 if (inConnectMode && !inConnectModePrevious)

--- a/BrickController2/BrickController2/DeviceManagement/BluetoothAdvertisingDeviceHandler.cs
+++ b/BrickController2/BrickController2/DeviceManagement/BluetoothAdvertisingDeviceHandler.cs
@@ -74,6 +74,13 @@ namespace BrickController2.DeviceManagement
         private readonly Stopwatch _allZeroStopwatch = Stopwatch.StartNew();
 
         /// <summary>
+        /// A synchronization object used to ensure thread-safe operations when setting the state of all channels.
+        /// </summary>
+        /// <remarks>This object is intended for use in locking mechanisms to prevent race conditions
+        /// during state updates.</remarks>
+        private readonly object _lockAllChannelsSetState = new object();
+
+        /// <summary>
         /// task running the cyclic output loop
         /// </summary>
         private Task? _outputTask;
@@ -124,30 +131,29 @@ namespace BrickController2.DeviceManagement
         /// successfully changed; otherwise, <see langword="false"/>.</returns>
         public bool SetChannelState(int specificChannelNo, bool zeroSet)
         {
-            if (zeroSet)
+            lock (_lockAllChannelsSetState)
             {
-                int allChannelsSetState = _allChannelsSetState;
-
-                // reset the bit for the specificChannelNo in the bitfield
-                _allChannelsSetState &= ~(1 << specificChannelNo);
-
-                if(_allChannelsSetState == 0 &&                     // new set state of all channels is zero
-                    allChannelsSetState != _allChannelsSetState)    // and there was a change
+                if (zeroSet)
                 {
-                    // if all channels are set to zero, reset the stopwatch
-                    _allZeroStopwatch.Restart();
+                    int allChannelsSetState = _allChannelsSetState;
 
-                    return true;
+                    // reset the bit for the specificChannelNo in the bitfield
+                    _allChannelsSetState &= ~(1 << specificChannelNo);
+
+                    if (_allChannelsSetState == 0 &&                    // new set state of all channels is zero
+                        allChannelsSetState != _allChannelsSetState)    // and there was a change
+                    {
+                        // if all channels are set to zero, reset the stopwatch
+                        _allZeroStopwatch.Restart();
+
+                        return true;
+                    }
                 }
                 else
                 {
-                    return false; // no change in state
+                    // set the bit for the specificChannelNo
+                    _allChannelsSetState |= (1 << specificChannelNo);
                 }
-            }
-            else
-            {
-                // set the bit for the specificChannelNo
-                _allChannelsSetState |= (1 << specificChannelNo);
 
                 return false;
             }

--- a/BrickController2/BrickController2/DeviceManagement/CaDA/CaDARaceCar.cs
+++ b/BrickController2/BrickController2/DeviceManagement/CaDA/CaDARaceCar.cs
@@ -87,7 +87,7 @@ internal class CaDARaceCar : BluetoothAdvertisingDevice
                 _outputValues[channelNo] = intValue;
 
                 // notify data changed
-                _bluetoothAdvertisingDeviceHandler.NotifyDataChanged(false);
+                _bluetoothAdvertisingDeviceHandler.NotifyDataChanged(0, false);
             }
         }
     }

--- a/BrickController2/BrickController2/DeviceManagement/CaDA/CaDARaceCar.cs
+++ b/BrickController2/BrickController2/DeviceManagement/CaDA/CaDARaceCar.cs
@@ -82,15 +82,17 @@ internal class CaDARaceCar : BluetoothAdvertisingDevice
 
         lock (_outputLock)
         {
+            // check for change
             if (_outputValues[channelNo] != intValue)
             {
                 _outputValues[channelNo] = intValue;
 
                 // notify data changed
-                _bluetoothAdvertisingDeviceHandler.NotifyDataChanged(0, false);
+                _bluetoothAdvertisingDeviceHandler.NotifyDataChanged();
             }
         }
     }
+
     protected override void InitDevice()
     {
     }

--- a/BrickController2/BrickController2/DeviceManagement/CaDA/CaDARaceCar.cs
+++ b/BrickController2/BrickController2/DeviceManagement/CaDA/CaDARaceCar.cs
@@ -97,6 +97,10 @@ internal class CaDARaceCar : BluetoothAdvertisingDevice
     {
     }
 
+    protected override void DisconnectDevice()
+    {
+    }
+
     protected bool TryGetTelegram(bool getConnectTelegram, out byte[] currentData)
     {
         ushort random = (ushort)_rnd.Next(ushort.MinValue, ushort.MaxValue);

--- a/BrickController2/BrickController2/DeviceManagement/MouldKing/MK4.cs
+++ b/BrickController2/BrickController2/DeviceManagement/MouldKing/MK4.cs
@@ -111,42 +111,40 @@ namespace BrickController2.DeviceManagement.MouldKing
     /// the nibble value for the analog channel output. </description> </item> <item> <description> A <see cref="bool"/>
     /// indicating whether the nibble corresponds to the zero value. <see langword="true"/> if the nibble represents
     /// zero; otherwise, <see langword="false"/>. </description> </item> </list></returns>
-    private (byte, bool) SetOutput_AnalogChannel(float value)
+    private (byte setValue_Nibble, bool zeroSet) SetOutput_AnalogChannel(float value)
     {
-        // MK4: ZeroValueNibble = 0x08, Range_pos_Offset = 0x08
-        // value <  0:  7 6 5 4 3 2 1                    range_neg: 0x07
+        // MK4: ZEROVALUE_NIBBLE = 0x08, RANGE_POS_OFFSET = 0x08
+        // value <  0:  7 6 5 4 3 2 1                    RANGE_NEG: 0x07
         // value == 0:                0 8
-        // value >  0:                    9 A B C D E F  range_pos: 0x07
+        // value >  0:                    9 A B C D E F  RANGE_POS: 0x07
 
-        const byte ZeroValueNibble = 0x08;
-        const byte Range_pos_Offset = 0x08;
-        const int Range_pos = 0x07;
-        const int Range_neg = 0x07;
+        const byte RANGE_POS_OFFSET = 0x08;
+        const int RANGE_POS = 0x07;
+        const int RANGE_NEG = 0x07;
 
-        if (value < 0)
+        const float MIN_NEG_RANGE_THRESHOLD = -1f / RANGE_NEG;    // Minimum value for negative range
+        const float MIN_POS_RANGE_THRESHOLD = 1f / RANGE_POS;     // Minimum value for positive range
+
+        const byte ZEROVALUE_NIBBLE = 0x08;
+
+
+        if (value < MIN_NEG_RANGE_THRESHOLD)
         {
-            float value_abs = Math.Min(0x07, -value * Range_neg);
+            float value_abs = Math.Min(0x07, -value * RANGE_NEG);
             byte setValue_nibble = (byte)(0x0F & (byte)value_abs);
 
-            if (setValue_nibble == 0) // replace zero with ZeroValueNibble
-            {
-                return (ZeroValueNibble, true);
-            }
-            else
-            {
-                return (setValue_nibble, false);
-            }
+            return (setValue_nibble, false);
         }
-        else if (value > 0)
+        else if (value > MIN_POS_RANGE_THRESHOLD)
         {
-            float value_abs = Math.Min(0x0F, (value * Range_pos) + Range_pos_Offset);
+            float value_abs = Math.Min(0x0F, (value * RANGE_POS) + RANGE_POS_OFFSET);
             byte setValue_nibble = (byte)(0x0F & (byte)(value_abs));
 
             return (setValue_nibble, false);
         }
         else
         {
-            return (ZeroValueNibble, true);
+            return (ZEROVALUE_NIBBLE, true);
         }
     }
 

--- a/BrickController2/BrickController2/DeviceManagement/MouldKing/MK4.cs
+++ b/BrickController2/BrickController2/DeviceManagement/MouldKing/MK4.cs
@@ -13,40 +13,35 @@ namespace BrickController2.DeviceManagement.MouldKing
         public const string Device2 = "Device2";
         public const string Device3 = "Device3";
 
-        /// <summary>
-        /// offset to position of first analog channel in base telegram
-        /// </summary>
-        private const int ChannelStartOffset = 3;
+    /// <summary>
+    /// Telegram to connect to the MK4.0 device(s)
+    /// This telegram is sent on init and on reconnect conditions matching
+    /// </summary>
+    private static readonly byte[] Telegram_Connect = new byte[] { 0xAD, 0x7B, 0xA7, 0x80, 0x80, 0x80, 0x4F, 0x52 };
 
-        /// <summary>
-        /// Telegram to connect to the MK4.0 device(s)
-        /// This telegram is sent on init and on reconnect conditions matching
-        /// </summary>
-        private static readonly byte[] Telegram_Connect = new byte[] { 0xAD, 0x7B, 0xA7, 0x80, 0x80, 0x80, 0x4F, 0x52 };
+    /// <summary>
+    /// Base Telegram for MK4.0
+    /// -> this telegram handles all three MK4.0 devices
+    /// * channels 0..3 for Device1 start at offset 3 and are analog channels
+    /// * channels 0..3 for Device2 start at offset 5 and are analog channels
+    /// * channels 0..3 for Device3 start at offset 7 and are analog channels
+    /// </summary>
+    private static readonly byte[] Telegram_Base = new byte[] { 0x7D, 0x7B, 0xA7, 0x88, 0x88, 0x88, 0x88, 0x88, 0x88, 0x82 };
 
-        /// <summary>
-        /// Base Telegram for MK4.0
-        /// -> this telegram handles all three MK4.0 devices
-        /// * channels 0..3 for Device1 start at offset 3 and are analog channels
-        /// * channels 0..3 for Device2 start at offset 5 and are analog channels
-        /// * channels 0..3 for Device3 start at offset 7 and are analog channels
-        /// </summary>
-        private static readonly byte[] Telegram_Base = new byte[] { 0x7D, 0x7B, 0xA7, 0x88, 0x88, 0x88, 0x88, 0x88, 0x88, 0x82 };
+    /// <summary>
+    /// after this timespan and all channel's values equal to zero the connect telegram is sent
+    /// </summary>
+    private static readonly TimeSpan ReconnectTimeSpan = TimeSpan.FromSeconds(3);
 
-        /// <summary>
-        /// after this timespan and all channel's values equal to zero the connect telegram is sent
-        /// </summary>
-        private static readonly TimeSpan ReconnectTimeSpan = TimeSpan.FromSeconds(3);
+    /// <summary>
+    /// all MK4.0 modules share the same BluetoothAdvertisingDeviceHandler
+    /// </summary>
+    private static BluetoothAdvertisingDeviceHandler? bluetoothAdvertisingDeviceHandler;
 
-        /// <summary>
-        /// all MK4.0 modules share the same BluetoothAdvertisingDeviceHandler
-        /// </summary>
-        private static BluetoothAdvertisingDeviceHandler? bluetoothAdvertisingDeviceHandler;
-
-        public MK4(string name, string address, byte[] deviceData, IDeviceRepository deviceRepository, IBluetoothLEService bleService, IMKPlatformService mkPlatformService)
-          : base(name, address, deviceData, deviceRepository, bleService, mkPlatformService, MK4.GetChannelStartOffset(address), MK4.Telegram_Connect, MK4.Telegram_Base)
-        {
-        }
+    public MK4(string name, string address, byte[] deviceData, IDeviceRepository deviceRepository, IBluetoothLEService bleService, IMKPlatformService mkPlatformService)
+      : base(name, address, deviceData, deviceRepository, bleService, mkPlatformService, GetInstanceNo(address), Telegram_Connect, Telegram_Base)
+    {
+    }
 
         public override DeviceType DeviceType => Type;
 
@@ -54,84 +49,111 @@ namespace BrickController2.DeviceManagement.MouldKing
 
         public static string TypeName => "MK 4.0";
 
-        /// <summary>
-        /// Number of channels for one MK4.0 device
-        /// * channel 0..3 are analog 
-        /// </summary>
-        public override int NumberOfChannels => 4;
+    /// <summary>
+    /// Number of channels for one MK4.0 device
+    /// * channel 0..3 are analog 
+    /// </summary>
+    public override int NumberOfChannels => 4;
 
-        /// <summary>
-        /// manufacturerId to advertise
-        /// </summary>
-        protected override ushort ManufacturerId => MKProtocol.ManufacturerID;
+    /// <summary>
+    /// manufacturerId to advertise
+    /// </summary>
+    protected override ushort ManufacturerId => MKProtocol.ManufacturerID;
 
-        /// <summary>
-        /// number of bytes containing channel values in base telegram
-        /// -> channel 0..3 for all three devices -> 6 bytes
-        /// </summary>
-        protected override int BaseTelegram_ChannelBytesCount => 6;
+    /// <summary>
+    /// Get or create BluetoothAdvertisingDeviceHandler
+    /// </summary>
+    /// <returns>Instance of BluetoothAdvertisingDeviceHandler</returns>
+    protected override BluetoothAdvertisingDeviceHandler GetBluetoothAdvertisingDeviceHandler()
+    {
+        lock (typeof(MK4)) // lock type
+        {
+            if (bluetoothAdvertisingDeviceHandler == null)
+            {
+                // all MK4.0 modules share the same BluetoothAdvertisingDeviceHandler
+                bluetoothAdvertisingDeviceHandler = new BluetoothAdvertisingDeviceHandler(_bleService, ManufacturerId, TryGetTelegram, ReconnectTimeSpan);
+            }
+            return bluetoothAdvertisingDeviceHandler;
+        }
+    }
 
-        /// <summary>
-        /// offset to position of first channel in base telegram
-        /// </summary>
-        protected override int BaseTelegram_ChannelStartOffset => 3;
+    /// <summary>
+    /// Returns a function that processes a floating-point input value and produces a tuple containing the channel
+    /// offset and the result of the analog channel output operation.
+    /// </summary>
+    /// <remarks>The returned function is specific to the provided channel number and uses predefined
+    /// parameters  to calculate the analog channel output. The caller must ensure that the channel number is valid 
+    /// to avoid exceptions.</remarks>
+    /// <param name="channelNo">The channel number for which the processing function is requested. Valid values are 0, 1, 2, or 3.</param>
+    /// <returns>A function that takes a <see langword="float"/> input value and returns a tuple containing: - An <see
+    /// langword="int"/> representing the channel offset. - A nested tuple containing:   - A <see langword="byte"/>
+    /// representing the output value.   - A <see langword="bool"/> indicating the success or failure of the
+    /// operation.</returns>
+    /// <exception cref="ArgumentException">Thrown if <paramref name="channelNo"/> is not one of the valid channel numbers (0, 1, 2, or 3).</exception>
+    protected override Func<float, (byte, bool)> CreateSetChannel(int channelNo)
+    {
+        return channelNo switch
+        {
+            0 => (float value) => SetOutput_AnalogChannel(value),
+            1 => (float value) => SetOutput_AnalogChannel(value),
+            2 => (float value) => SetOutput_AnalogChannel(value),
+            3 => (float value) => SetOutput_AnalogChannel(value),
+            _ => throw new ArgumentException("Illegal Argument", nameof(channelNo))
+        };
+    }
 
-        // MK4: ZeroValueNibble = 0x08, ZeroValueOffset = 0x08
+    private (byte, bool) SetOutput_AnalogChannel(float value)
+    {
+        // MK4: ZeroValueNibble = 0x08, Range_pos_Offset = 0x08
         // value <  0:  7 6 5 4 3 2 1                    range_neg: 0x07
         // value == 0:                0 8
         // value >  0:                    9 A B C D E F  range_pos: 0x07
+        const byte ZeroValueNibble = 0x08;
+        const byte Range_pos_Offset = 0x08;
+        const int Range_pos = 0x07;
+        const int Range_neg = 0x07;
 
-        /// <summary>
-        /// Gets the nibble value that represents zero in the current encoding scheme.
-        /// </summary>
-        protected override byte ZeroValueNibble => 0x08;
-
-        /// <summary>
-        /// Gets the offset for positive values
-        /// </summary>
-        protected override byte Range_pos_Offset => 0x08;
-
-        /// <summary>
-        /// Gets the range for positive values
-        /// </summary>
-        protected override int Range_pos => 0x07;
-
-        /// <summary>
-        /// Gets the range for negative values
-        /// </summary>
-        protected override int Range_neg => 0x07;
-        
-        /// <summary>
-                                                         /// Get reference to Base-Telegram for the given address
-                                                         /// </summary>
-                                                         /// <param name="address">address</param>
-                                                         /// <returns>reference to Base-Telegram</returns>
-        private static int GetChannelStartOffset(string address)
+        if (value < 0)
         {
-            return address switch
-            {
-                MK4.Device1 => MK4.ChannelStartOffset,
-                MK4.Device2 => MK4.ChannelStartOffset + 2,
-                MK4.Device3 => MK4.ChannelStartOffset + 4,
-                _ => throw new ArgumentException("Illegal Argument", nameof(address))
-            };
-        }
+            float value_abs = Math.Min(0x07, -value * Range_neg);
+            byte setValue_nibble = (byte)(0x0F & (byte)value_abs);
 
-        /// <summary>
-        /// Get or create BluetoothAdvertisingDeviceHandler
-        /// </summary>
-        /// <returns>Instance of BluetoothAdvertisingDeviceHandler</returns>
-        protected override BluetoothAdvertisingDeviceHandler GetBluetoothAdvertisingDeviceHandler()
-        {
-            lock (typeof(MK4)) // lock type
+            if (setValue_nibble == 0) // replace zero with ZeroValueNibble
             {
-                if (bluetoothAdvertisingDeviceHandler == null)
-                {
-                    // all MK4.0 modules share the same BluetoothAdvertisingDeviceHandler
-                    bluetoothAdvertisingDeviceHandler = new BluetoothAdvertisingDeviceHandler(_bleService, ManufacturerId, TryGetTelegram, MK4.ReconnectTimeSpan);
-                }
-                return bluetoothAdvertisingDeviceHandler;
+                return (ZeroValueNibble, true);
+            }
+            else
+            {
+                return (setValue_nibble, false);
             }
         }
+        else if (value > 0)
+        {
+            float value_abs = Math.Min(0x0F, (value * Range_pos) + Range_pos_Offset);
+            byte setValue_nibble = (byte)(0x0F & (byte)(value_abs));
+
+            return (setValue_nibble, false);
+        }
+        else
+        {
+            return (ZeroValueNibble, true);
+        }
+    }
+
+    /// <summary>
+    /// Determines the instance number associated with the specified device address.
+    /// </summary>
+    /// <param name="address">The address of the device. Must match one of the predefined device addresses.</param>
+    /// <returns>An integer representing the zero based instance number of the device.</returns>
+    /// <exception cref="ArgumentException">Thrown if <paramref name="address"/> does not match any predefined device address.</exception>
+    private static int GetInstanceNo(string address)
+    {
+        return address switch
+        {
+            Device1 => 0,
+            Device2 => 1,
+            Device3 => 2,
+            _ => throw new ArgumentException("Illegal Argument", nameof(address))
+        };
     }
 }

--- a/BrickController2/BrickController2/DeviceManagement/MouldKing/MK4.cs
+++ b/BrickController2/BrickController2/DeviceManagement/MouldKing/MK4.cs
@@ -91,10 +91,10 @@ namespace BrickController2.DeviceManagement.MouldKing
     {
         return channelNo switch
         {
-            0 => (0, (value) => SetOutput_AnalogChannel(value)),
-            1 => (1, (value) => SetOutput_AnalogChannel(value)),
-            2 => (2, (value) => SetOutput_AnalogChannel(value)),
-            3 => (3, (value) => SetOutput_AnalogChannel(value)),
+            0 => (0, SetOutput_AnalogChannel),
+            1 => (1, SetOutput_AnalogChannel),
+            2 => (2, SetOutput_AnalogChannel),
+            3 => (3, SetOutput_AnalogChannel),
             _ => throw new ArgumentException("Illegal Argument", nameof(channelNo))
         };
     }

--- a/BrickController2/BrickController2/DeviceManagement/MouldKing/MK4.cs
+++ b/BrickController2/BrickController2/DeviceManagement/MouldKing/MK4.cs
@@ -128,14 +128,14 @@ namespace BrickController2.DeviceManagement.MouldKing
         const byte ZEROVALUE_NIBBLE = 0x08;
 
 
-        if (value < MIN_NEG_RANGE_THRESHOLD)
+        if (value <= MIN_NEG_RANGE_THRESHOLD)
         {
             float value_abs = Math.Min(0x07, -value * RANGE_NEG);
             byte setValue_nibble = (byte)(0x0F & (byte)value_abs);
 
             return (setValue_nibble, false);
         }
-        else if (value > MIN_POS_RANGE_THRESHOLD)
+        else if (value >= MIN_POS_RANGE_THRESHOLD)
         {
             float value_abs = Math.Min(0x0F, (value * RANGE_POS) + RANGE_POS_OFFSET);
             byte setValue_nibble = (byte)(0x0F & (byte)(value_abs));

--- a/BrickController2/BrickController2/DeviceManagement/MouldKing/MK4.cs
+++ b/BrickController2/BrickController2/DeviceManagement/MouldKing/MK4.cs
@@ -80,24 +80,20 @@ internal class MK4 : MKBaseNibble, IDeviceType<MK4>
     }
 
     /// <summary>
-    /// Creates a handler for the specified analog channel.
+    /// Processes the value for the specified analog channel and returns the processed result.
     /// </summary>
-    /// <param name="channelNo">The channel number for which the handler is to be created. Valid values are 0, 1, 2, or 3.</param>
-    /// <returns>A tuple containing the channel identifier and a function that processes analog output values. The function takes
-    /// a <see langword="float"/> representing the analog value and returns a tuple containing a <see langword="byte"/>
-    /// representing the processed output and a <see langword="bool"/> indicating the success of the operation.</returns>
+    /// <param name="channelNo">The channel number to process. Valid values are 0, 1, 2, or 3.</param>
+    /// <param name="value">The input value to be processed for the specified channel.</param>
+    /// <returns>A tuple containing the processed value and a flag indicating the success of the operation.</returns>
     /// <exception cref="ArgumentException">Thrown if <paramref name="channelNo"/> is not one of the valid channel numbers (0, 1, 2, or 3).</exception>
-    protected override (int, Func<float, (byte, bool)>) CreateChannelHandler(int channelNo)
+    protected override (byte value, bool flag) ProccessChannelValue(int channelNo, float value) => channelNo switch
     {
-        return channelNo switch
-        {
-            0 => (0, SetOutput_AnalogChannel),
-            1 => (1, SetOutput_AnalogChannel),
-            2 => (2, SetOutput_AnalogChannel),
-            3 => (3, SetOutput_AnalogChannel),
-            _ => throw new ArgumentException("Illegal Argument", nameof(channelNo))
-        };
-    }
+        0 => SetOutput_AnalogChannel(value),
+        1 => SetOutput_AnalogChannel(value),
+        2 => SetOutput_AnalogChannel(value),
+        3 => SetOutput_AnalogChannel(value),
+        _ => throw new ArgumentException("Illegal Argument", nameof(channelNo))
+    };
 
     /// <summary>
     /// Converts a floating-point value into a nibble representation for an analog channel output.
@@ -154,14 +150,11 @@ internal class MK4 : MKBaseNibble, IDeviceType<MK4>
     /// <param name="address">The address of the device. Must match one of the predefined device addresses.</param>
     /// <returns>An integer representing the zero based instance number of the device.</returns>
     /// <exception cref="ArgumentException">Thrown if <paramref name="address"/> does not match any predefined device address.</exception>
-    private static int GetInstanceNo(string address)
+    private static int GetInstanceNo(string address) => address switch
     {
-        return address switch
-        {
-            Device1 => 0,
-            Device2 => 1,
-            Device3 => 2,
-            _ => throw new ArgumentException($"Illegal Argument: \"{address}\"", nameof(address))
-        };
-    }
+        Device1 => 0,
+        Device2 => 1,
+        Device3 => 2,
+        _ => throw new ArgumentException($"Illegal Argument: \"{address}\"", nameof(address))
+    };
 }

--- a/BrickController2/BrickController2/DeviceManagement/MouldKing/MK4.cs
+++ b/BrickController2/BrickController2/DeviceManagement/MouldKing/MK4.cs
@@ -50,8 +50,10 @@ namespace BrickController2.DeviceManagement.MouldKing
         public static string TypeName => "MK 4.0";
 
     /// <summary>
-    /// Number of channels for one MK4.0 device
-    /// * channel 0..3 are analog 
+    /// Gets the number of audio channels supported by the current configuration.
+    /// <remarks><list type="bullet">
+    /// <item><description>Channel 0..4: real existing channel</description></item> 
+    /// </list></remarks>
     /// </summary>
     public override int NumberOfChannels => 4;
 
@@ -78,36 +80,44 @@ namespace BrickController2.DeviceManagement.MouldKing
     }
 
     /// <summary>
-    /// Returns a function that processes a floating-point input value and produces a tuple containing the channel
-    /// offset and the result of the analog channel output operation.
+    /// Creates a handler for the specified analog channel.
     /// </summary>
-    /// <remarks>The returned function is specific to the provided channel number and uses predefined
-    /// parameters  to calculate the analog channel output. The caller must ensure that the channel number is valid 
-    /// to avoid exceptions.</remarks>
-    /// <param name="channelNo">The channel number for which the processing function is requested. Valid values are 0, 1, 2, or 3.</param>
-    /// <returns>A function that takes a <see langword="float"/> input value and returns a tuple containing: - An <see
-    /// langword="int"/> representing the channel offset. - A nested tuple containing:   - A <see langword="byte"/>
-    /// representing the output value.   - A <see langword="bool"/> indicating the success or failure of the
-    /// operation.</returns>
+    /// <param name="channelNo">The channel number for which the handler is to be created. Valid values are 0, 1, 2, or 3.</param>
+    /// <returns>A tuple containing the channel identifier and a function that processes analog output values. The function takes
+    /// a <see langword="float"/> representing the analog value and returns a tuple containing a <see langword="byte"/>
+    /// representing the processed output and a <see langword="bool"/> indicating the success of the operation.</returns>
     /// <exception cref="ArgumentException">Thrown if <paramref name="channelNo"/> is not one of the valid channel numbers (0, 1, 2, or 3).</exception>
-    protected override Func<float, (byte, bool)> CreateSetChannel(int channelNo)
+    protected override (int, Func<float, (byte, bool)>) CreateChannelHandler(int channelNo)
     {
         return channelNo switch
         {
-            0 => (float value) => SetOutput_AnalogChannel(value),
-            1 => (float value) => SetOutput_AnalogChannel(value),
-            2 => (float value) => SetOutput_AnalogChannel(value),
-            3 => (float value) => SetOutput_AnalogChannel(value),
+            0 => (0, (value) => SetOutput_AnalogChannel(value)),
+            1 => (1, (value) => SetOutput_AnalogChannel(value)),
+            2 => (2, (value) => SetOutput_AnalogChannel(value)),
+            3 => (3, (value) => SetOutput_AnalogChannel(value)),
             _ => throw new ArgumentException("Illegal Argument", nameof(channelNo))
         };
     }
 
+    /// <summary>
+    /// Converts a floating-point value into a nibble representation for an analog channel output.
+    /// </summary>
+    /// <remarks>The method maps the input value to a nibble representation based on predefined ranges for
+    /// positive, negative, and zero values. The zero value is represented by a specific nibble constant. The caller can
+    /// use the returned boolean to determine if the nibble corresponds to the zero value.</remarks>
+    /// <param name="value">The floating-point value to be converted. Negative values are mapped to the negative range, positive values are
+    /// mapped to the positive range, and zero is mapped to a predefined nibble.</param>
+    /// <returns>A tuple containing the following: <list type="bullet"> <item> <description> A <see cref="byte"/> representing
+    /// the nibble value for the analog channel output. </description> </item> <item> <description> A <see cref="bool"/>
+    /// indicating whether the nibble corresponds to the zero value. <see langword="true"/> if the nibble represents
+    /// zero; otherwise, <see langword="false"/>. </description> </item> </list></returns>
     private (byte, bool) SetOutput_AnalogChannel(float value)
     {
         // MK4: ZeroValueNibble = 0x08, Range_pos_Offset = 0x08
         // value <  0:  7 6 5 4 3 2 1                    range_neg: 0x07
         // value == 0:                0 8
         // value >  0:                    9 A B C D E F  range_pos: 0x07
+
         const byte ZeroValueNibble = 0x08;
         const byte Range_pos_Offset = 0x08;
         const int Range_pos = 0x07;

--- a/BrickController2/BrickController2/DeviceManagement/MouldKing/MK4.cs
+++ b/BrickController2/BrickController2/DeviceManagement/MouldKing/MK4.cs
@@ -2,16 +2,16 @@
 using BrickController2.PlatformServices.BluetoothLE;
 using BrickController2.Protocols;
 
-namespace BrickController2.DeviceManagement.MouldKing
+namespace BrickController2.DeviceManagement.MouldKing;
+
+/// <summary>
+/// MK 4.0 Module
+/// </summary>
+internal class MK4 : MKBaseNibble, IDeviceType<MK4>
 {
-    /// <summary>
-    /// MK 4.0 Module
-    /// </summary>
-    internal class MK4 : MKBaseNibble, IDeviceType<MK4>
-    {
-        public const string Device1 = "Device1";
-        public const string Device2 = "Device2";
-        public const string Device3 = "Device3";
+    public const string Device1 = "Device1";
+    public const string Device2 = "Device2";
+    public const string Device3 = "Device3";
 
     /// <summary>
     /// Telegram to connect to the MK4.0 device(s)
@@ -43,14 +43,14 @@ namespace BrickController2.DeviceManagement.MouldKing
     {
     }
 
-        public override DeviceType DeviceType => Type;
+    public override DeviceType DeviceType => Type;
 
-        public static DeviceType Type => DeviceType.MK4;
+    public static DeviceType Type => DeviceType.MK4;
 
-        public static string TypeName => "MK 4.0";
+    public static string TypeName => "MK 4.0";
 
     /// <summary>
-    /// Gets the number of audio channels supported by the current configuration.
+    /// Gets the number of channels supported by the device.
     /// <remarks><list type="bullet">
     /// <item><description>Channel 0..4: real existing channel</description></item> 
     /// </list></remarks>

--- a/BrickController2/BrickController2/DeviceManagement/MouldKing/MK4.cs
+++ b/BrickController2/BrickController2/DeviceManagement/MouldKing/MK4.cs
@@ -161,7 +161,7 @@ internal class MK4 : MKBaseNibble, IDeviceType<MK4>
             Device1 => 0,
             Device2 => 1,
             Device3 => 2,
-            _ => throw new ArgumentException("Illegal Argument", nameof(address))
+            _ => throw new ArgumentException($"Illegal Argument: \"{address}\"", nameof(address))
         };
     }
 }

--- a/BrickController2/BrickController2/DeviceManagement/MouldKing/MK5.cs
+++ b/BrickController2/BrickController2/DeviceManagement/MouldKing/MK5.cs
@@ -27,11 +27,11 @@ internal class MK5 : MKBaseNibble, IDeviceType<MK5>
     private static readonly TimeSpan ReconnectTimeSpan = TimeSpan.FromSeconds(3);
 
     /// <summary>
-    /// Offset for turrent rotation.
-    /// * 0x00: turrent is unlocked
-    /// * 0x02: turrent is locked
+    /// Offset for turret rotation.
+    /// * 0x00: turret is unlocked
+    /// * 0x02: turret is locked
     /// </summary>
-    private byte _turrentOffset = 0x00;
+    private byte _turretOffset = 0x00;
 
     public MK5(string name, string address, byte[] deviceData, IDeviceRepository deviceRepository, IBluetoothLEService bleService, IMKPlatformService mkPlatformService)
       : base(name, address, deviceData, deviceRepository, bleService, mkPlatformService, 0, Telegram_Connect, Telegram_Base)
@@ -81,10 +81,10 @@ internal class MK5 : MKBaseNibble, IDeviceType<MK5>
         return channelNo switch
         {
             0 => (0, SetOutput_AnalogChannel),                    // Tracks A + B forward, backward
-            1 => (1, SetOutput_AnalogChannel_Turrent),            // Turrent rotation
+            1 => (1, SetOutput_AnalogChannel_Turret),             // Turret rotation
             2 => (2, SetOutput_Shot),                             // shot canon
             3 => (3, SetOutput_AnalogChannel),                    // turn on spot
-            4 => (VIRTUALCHANNEL, SetOutput_Option_Turrent_Lock), // virtual channel: lock turrent
+            4 => (VIRTUALCHANNEL, SetOutput_Option_Turret_Lock),  // virtual channel: lock turret
             _ => throw new ArgumentException("Illegal Argument", nameof(channelNo))
         };
     }
@@ -152,19 +152,19 @@ internal class MK5 : MKBaseNibble, IDeviceType<MK5>
     /// to be set for the turret.</description> </item> <item> <description><c>zeroSet</c>: A boolean flag indicating
     /// whether the zero value nibble is used (<see langword="true"/> if the zero value nibble is applied; otherwise,
     /// <see langword="false"/>).</description> </item> </list></returns>
-    private (byte setValue_nibble, bool zeroSet) SetOutput_AnalogChannel_Turrent(float value)
+    private (byte setValue_nibble, bool zeroSet) SetOutput_AnalogChannel_Turret(float value)
     {
         // MK5: ZeroValueNibble = 0x00, Range_pos_Offset = 0x08
         // value <  0:  7 6 5 4 3 2 1                    range_neg: 0x07
         // value == 0:                0
         // value >  0:                  9 A B C D E F    range_pos: 0x07
 
-        byte ZeroValueNibble = _turrentOffset; // <-- turrentOffset is set by SetOutput_Option_Turrent_Lock
+        byte ZeroValueNibble = _turretOffset; // <-- turretOffset is set by SetOutput_Option_Turret_Lock
         const byte Range_pos_Offset = 0x08;
         const int Range_pos = 0x07;
         const int Range_neg = 0x07;
 
-        value *= -1; // invert value for turrent
+        value *= -1; // invert value for turret
 
         if (value < 0)
         {
@@ -230,25 +230,25 @@ internal class MK5 : MKBaseNibble, IDeviceType<MK5>
     /// indicating the nibble used for the turret lock operation. Always returns <c>0x00</c>.</description> </item>
     /// <item> <description><c>zeroSet</c>: A boolean value indicating whether the turret lock state was successfully
     /// updated.</description> </item> </list></returns>
-    private (byte setValue_nibble, bool zeroSet) SetOutput_Option_Turrent_Lock(float value)
+    private (byte setValue_nibble, bool zeroSet) SetOutput_Option_Turret_Lock(float value)
     {
         if (value == 0)
         {
-            _turrentOffset = 0x00; // turrent is unlocked
+            _turretOffset = 0x00; // turret is unlocked
         }
         else
         {
-            _turrentOffset = 0x02; // turrent is locked
+            _turretOffset = 0x02; // turret is locked
         }
 
         bool valueChanged = false;
         
-        valueChanged |= _setChannel[1](_storedValues[1]); // The turrent lock is a virtual channel, so call handler for real turrent channel
+        valueChanged |= _setChannel[1](_storedValues[1]); // The turret lock is a virtual channel, so call handler for real turret channel
 
         // to clarify the concept:
         // inside a virtual channel handler multiple calls to _setChannel are allowed
-        //valueChanged |= _setChannel[1](_storedValues[1]); // The turrent lock is a virtual channel, so call handler for real turrent channel
+        //valueChanged |= _setChannel[x](_storedValues[x]); 
 
-        return (_turrentOffset, valueChanged);
+        return (_turretOffset, valueChanged);
     }
 }

--- a/BrickController2/BrickController2/DeviceManagement/MouldKing/MK5.cs
+++ b/BrickController2/BrickController2/DeviceManagement/MouldKing/MK5.cs
@@ -77,30 +77,35 @@ internal class MK5 : MKBaseNibble, IDeviceType<MK5>
         new(_bleService, ManufacturerId, TryGetTelegram, ReconnectTimeSpan);
 
     /// <summary>
-    /// Creates a handler for the specified channel, providing a mapping between the channel number  and its associated
-    /// output function.
+    /// Determines whether the specified channel number corresponds to a virtual channel.
     /// </summary>
-    /// <remarks>Each channel number corresponds to a specific operation or behavior: <list type="bullet">
-    /// <item><description>Channel 0: Tracks A + B forward and backward.</description></item> <item><description>Channel
-    /// 1: Controls turret rotation.</description></item> <item><description>Channel 2: Fires the
-    /// cannon.</description></item> <item><description>Channel 3: Enables turning on the spot.</description></item>
-    /// <item><description>Channel 4: Virtual channel for locking the turret.</description></item> </list></remarks>
-    /// <param name="channelNo">The channel number for which the handler is to be created. Valid values are 0, 1, 2, 3, or 4.</param>
-    /// <returns>A tuple containing the channel identifier and a function that processes a float input to  produce a byte output
-    /// and a boolean status.</returns>
-    /// <exception cref="ArgumentException">Thrown if <paramref name="channelNo"/> is not a valid channel number.</exception>
-    protected override (int, Func<float, (byte, bool)>) CreateChannelHandler(int channelNo)
+    /// <param name="channelNo">The channel number to evaluate.</param>
+    /// <returns><see langword="true"/> if the specified channel number is a virtual channel;  otherwise, <see
+    /// langword="false"/>. </returns>
+    protected override bool IsVirtualChannel(int channelNo) => channelNo == 4;
+
+    /// <summary>
+    /// Processes the value for a specified channel and returns the processed result along with a status flag.
+    /// </summary>
+    /// <remarks>Each channel number corresponds to a specific operation: <list type="bullet">
+    /// <item><description>Channel 0: Tracks A + B forward or backward.</description></item> <item><description>Channel
+    /// 1: Turret rotation.</description></item> <item><description>Channel 2: Canon shot.</description></item>
+    /// <item><description>Channel 3: Turn on the spot.</description></item> <item><description>Channel 4: Virtual
+    /// channel for locking the turret.</description></item> </list></remarks>
+    /// <param name="channelNo">The channel number to process. Valid values are 0 through 4.</param>
+    /// <param name="value">The input value to be processed for the specified channel.</param>
+    /// <returns>A tuple containing the processed byte value and a boolean flag indicating the success or status of the
+    /// operation.</returns>
+    /// <exception cref="ArgumentException">Thrown if <paramref name="channelNo"/> is not within the valid range of 0 through 4.</exception>
+    protected override (byte value, bool flag) ProccessChannelValue(int channelNo, float value) => channelNo switch
     {
-        return channelNo switch
-        {
-            0 => (0, SetOutput_AnalogChannel),                    // Tracks A + B forward, backward
-            1 => (1, SetOutput_AnalogChannel_Turret),             // Turret rotation
-            2 => (2, SetOutput_Shot),                             // shot canon
-            3 => (3, SetOutput_AnalogChannel),                    // turn on spot
-            4 => (VIRTUALCHANNEL, SetOutput_Option_Turret_Lock),  // virtual channel: lock turret
-            _ => throw new ArgumentException("Illegal Argument", nameof(channelNo))
-        };
-    }
+        0 => SetOutput_AnalogChannel(value),                    // Tracks A + B forward, backward
+        1 => SetOutput_AnalogChannel_Turret(value),             // Turret rotation
+        2 => SetOutput_Shot(value),                             // shot canon
+        3 => SetOutput_AnalogChannel(value),                    // turn on spot
+        4 => SetOutput_Option_Turret_Lock(value),               // virtual channel: lock turret
+        _ => throw new ArgumentException("Illegal Argument", nameof(channelNo))
+    };
 
     /// <summary>
     /// Converts a floating-point value into a nibble representation for an analog channel output.
@@ -251,7 +256,7 @@ internal class MK5 : MKBaseNibble, IDeviceType<MK5>
         }
 
         bool valueChanged = false;
-        valueChanged |= _setChannel[1](_storedValues[1]); // The turret lock is a virtual channel, so call handler for real turret channel
+        valueChanged |= SetChannelOutput(1, _storedValues[1]); // The turret lock is a virtual channel, so call handler for real turret channel
 
         // to clarify the concept:
         // inside a virtual channel handler multiple calls to _setChannel are allowed

--- a/BrickController2/BrickController2/DeviceManagement/MouldKing/MK5.cs
+++ b/BrickController2/BrickController2/DeviceManagement/MouldKing/MK5.cs
@@ -26,6 +26,13 @@ internal class MK5 : MKBaseNibble, IDeviceType<MK5>
     /// </summary>
     private static readonly TimeSpan ReconnectTimeSpan = TimeSpan.FromSeconds(3);
 
+    /// <summary>
+    /// Offset for turrent rotation.
+    /// * 0x00: turrent is unlocked
+    /// * 0x02: turrent is locked
+    /// </summary>
+    private byte _turrentOffset = 0x00;
+
     public MK5(string name, string address, byte[] deviceData, IDeviceRepository deviceRepository, IBluetoothLEService bleService, IMKPlatformService mkPlatformService)
       : base(name, address, deviceData, deviceRepository, bleService, mkPlatformService, 0, Telegram_Connect, Telegram_Base)
     {
@@ -37,7 +44,14 @@ internal class MK5 : MKBaseNibble, IDeviceType<MK5>
 
     public static string TypeName => "MK 5.0";
 
-    public override int NumberOfChannels => 4;
+    /// <summary>
+    /// Gets the number of audio channels supported by the current configuration.
+    /// <remarks><list type="bullet">
+    /// <item><description>Channel 0..4: real existing channel</description></item> 
+    /// <item><description>Channel 5: virtual channel for locking the turret</description></item>
+    /// </list></remarks>
+    /// </summary>
+    public override int NumberOfChannels => 5;
 
     /// <summary>
     /// ManufacturerId to advertise
@@ -49,25 +63,51 @@ internal class MK5 : MKBaseNibble, IDeviceType<MK5>
         // there is only one instance of MK5.0
         new(_bleService, ManufacturerId, TryGetTelegram, ReconnectTimeSpan);
 
-
-    protected override Func<float, (byte, bool)> CreateSetChannel(int channelNo)
+    /// <summary>
+    /// Creates a handler for the specified channel, providing a mapping between the channel number  and its associated
+    /// output function.
+    /// </summary>
+    /// <remarks>Each channel number corresponds to a specific operation or behavior: <list type="bullet">
+    /// <item><description>Channel 0: Tracks A + B forward and backward.</description></item> <item><description>Channel
+    /// 1: Controls turret rotation.</description></item> <item><description>Channel 2: Fires the
+    /// cannon.</description></item> <item><description>Channel 3: Enables turning on the spot.</description></item>
+    /// <item><description>Channel 4: Virtual channel for locking the turret.</description></item> </list></remarks>
+    /// <param name="channelNo">The channel number for which the handler is to be created. Valid values are 0, 1, 2, 3, or 4.</param>
+    /// <returns>A tuple containing the channel identifier and a function that processes a float input to  produce a byte output
+    /// and a boolean status.</returns>
+    /// <exception cref="ArgumentException">Thrown if <paramref name="channelNo"/> is not a valid channel number.</exception>
+    protected override (int, Func<float, (byte, bool)>) CreateChannelHandler(int channelNo)
     {
         return channelNo switch
         {
-            0 => (float value) => SetOutput_AnalogChannel(value),
-            1 => (float value) => SetOutput_AnalogChannel(value),
-            2 => (float value) => SetOutput_Shot(value),
-            3 => (float value) => SetOutput_AnalogChannel(value),
+            0 => (0, (value) => SetOutput_AnalogChannel(value)),                    // Tracks A + B forward, backward
+            1 => (1, (value) => SetOutput_AnalogChannel_Turrent(value)),            // Turrent rotation
+            2 => (2, (value) => SetOutput_Shot(value)),                             // shot canon
+            3 => (3, (value) => SetOutput_AnalogChannel(value)),                    // turn on spot
+            4 => (VIRTUALCHANNEL, (value) => SetOutput_Option_Turrent_Lock(value)), // virtual channel: lock turrent
             _ => throw new ArgumentException("Illegal Argument", nameof(channelNo))
         };
     }
 
-    private (byte, bool) SetOutput_AnalogChannel(float value)
+    /// <summary>
+    /// Converts a floating-point value into a nibble representation for an analog channel output.
+    /// </summary>
+    /// <remarks>This method maps the input <paramref name="value"/> to a nibble (4-bit) representation based
+    /// on its sign and magnitude. Negative values are scaled using a predefined negative range, positive values are
+    /// scaled using a positive range with an offset,  and zero values are represented by a specific nibble
+    /// value.</remarks>
+    /// <param name="value">The floating-point value to be converted. Negative values, positive values, and zero are handled differently.</param>
+    /// <returns>A tuple containing: <list type="bullet"> <item> <description><c>setValue_nibble</c>: The 4-bit nibble
+    /// representation of the input value.</description> </item> <item> <description><c>zeroSet</c>: A boolean
+    /// indicating whether the input value was zero (<see langword="true"/>) or not (<see
+    /// langword="false"/>).</description> </item> </list></returns>
+    private (byte setValue_nibble, bool zeroSet) SetOutput_AnalogChannel(float value)
     {
         // MK5: ZeroValueNibble = 0x00, Range_pos_Offset = 0x08
         // value <  0:  7 6 5 4 3 2 1                    range_neg: 0x07
         // value == 0:                0
         // value >  0:                  9 A B C D E F    range_pos: 0x07
+
         const byte ZeroValueNibble = 0x00;
         const byte Range_pos_Offset = 0x08;
         const int Range_pos = 0x07;
@@ -100,20 +140,115 @@ internal class MK5 : MKBaseNibble, IDeviceType<MK5>
         }
     }
 
-    private (byte, bool) SetOutput_Shot(float value)
+    /// <summary>
+    /// Calculates the nibble value and zero-set flag for the analog channel turret based on the specified input value.
+    /// </summary>
+    /// <remarks>The method processes the input value by inverting it for turret-specific requirements and
+    /// calculates the appropriate nibble value  based on predefined positive and negative ranges. If the calculated
+    /// nibble value is zero, the zero value nibble is applied.</remarks>
+    /// <param name="value">The input value to be processed. Negative values represent the negative range, positive values represent the
+    /// positive range,  and zero represents the neutral state.</param>
+    /// <returns>A tuple containing: <list type="bullet"> <item> <description><c>setValue_nibble</c>: The calculated nibble value
+    /// to be set for the turret.</description> </item> <item> <description><c>zeroSet</c>: A boolean flag indicating
+    /// whether the zero value nibble is used (<see langword="true"/> if the zero value nibble is applied; otherwise,
+    /// <see langword="false"/>).</description> </item> </list></returns>
+    private (byte setValue_nibble, bool zeroSet) SetOutput_AnalogChannel_Turrent(float value)
     {
-        // Tank fires a shot when value is set to 0x0F
+        // MK5: ZeroValueNibble = 0x00, Range_pos_Offset = 0x08
+        // value <  0:  7 6 5 4 3 2 1                    range_neg: 0x07
+        // value == 0:                0
+        // value >  0:                  9 A B C D E F    range_pos: 0x07
+
+        byte ZeroValueNibble = _turrentOffset; // <-- turrentOffset is set by SetOutput_Option_Turrent_Lock
+        const byte Range_pos_Offset = 0x08;
+        const int Range_pos = 0x07;
+        const int Range_neg = 0x07;
+
+        value *= -1; // invert value for turrent
+
         if (value < 0)
         {
-            return (0x0F, false);
+            float value_abs = Math.Min(0x07, -value * Range_neg);
+            byte setValue_nibble = (byte)(0x0F & (byte)value_abs);
+
+            if (setValue_nibble == 0) // replace zero with ZeroValueNibble
+            {
+                return (ZeroValueNibble, true);
+            }
+            else
+            {
+                return (setValue_nibble, false);
+            }
         }
         else if (value > 0)
         {
-            return (0x0F, false);
+            float value_abs = Math.Min(0x0F, (value * Range_pos) + Range_pos_Offset);
+            byte setValue_nibble = (byte)(0x0F & (byte)(value_abs));
+
+            return (setValue_nibble, false);
         }
         else
         {
+            return (ZeroValueNibble, true);
+        }
+    }
+
+    /// <summary>
+    /// Determines the output value and status for firing a shot based on the provided input.
+    /// </summary>
+    /// <remarks>The method is designed to control the firing mechanism of a tank. When the input value is
+    /// <c>0</c>, the output indicates no firing (<c>0x00</c>), and <c>zeroSet</c> is <see langword="true"/>.  For all
+    /// other values, the output indicates a firing action (<c>0x0F</c>), and <c>zeroSet</c> is <see
+    /// langword="false"/>.</remarks>
+    /// <param name="value">The input value used to determine the output. Must be a floating-point number.</param>
+    /// <returns>A tuple containing: <list type="bullet"> <item><description><c>setValue_nibble</c>: A byte representing the
+    /// output value. Returns <c>0x00</c> if <paramref name="value"/> is <c>0</c>, or <c>0x0F</c>
+    /// otherwise.</description></item> <item><description><c>zeroSet</c>: A boolean indicating whether the input value
+    /// was zero. Returns <see langword="true"/> if <paramref name="value"/> is <c>0</c>; otherwise, <see
+    /// langword="false"/>.</description></item> </list></returns>
+    private (byte setValue_nibble, bool zeroSet) SetOutput_Shot(float value)
+    {
+        if (value == 0)
+        {
             return (0x00, true);
         }
+        else
+        {
+            // Tank fires a shot when value is set to 0x0F
+            return (0x0F, false);
+        }
+    }
+
+    /// <summary>
+    /// Configures the turret lock state based on the specified value.
+    /// </summary>
+    /// <remarks>The turret lock is managed as a virtual channel, and the method invokes the handler for the
+    /// corresponding real turret channel.</remarks>
+    /// <param name="value">A floating-point value representing the desired turret lock state.  A value of <see langword="0"/> unlocks the
+    /// turret, while any other value locks the turret.</param>
+    /// <returns>A tuple containing two elements: <list type="bullet"> <item> <description><c>setValue_nibble</c>: A byte value
+    /// indicating the nibble used for the turret lock operation. Always returns <c>0x00</c>.</description> </item>
+    /// <item> <description><c>zeroSet</c>: A boolean value indicating whether the turret lock state was successfully
+    /// updated.</description> </item> </list></returns>
+    private (byte setValue_nibble, bool zeroSet) SetOutput_Option_Turrent_Lock(float value)
+    {
+        if (value == 0)
+        {
+            _turrentOffset = 0x00; // turrent is unlocked
+        }
+        else
+        {
+            _turrentOffset = 0x02; // turrent is locked
+        }
+
+        bool valueChanged = false;
+        
+        valueChanged |= _setChannel[1](_storedValues[1]); // The turrent lock is a virtual channel, so call handler for real turrent channel
+
+        // to clarify the concept:
+        // inside a virtual channel handler multiple calls to _setChannel are allowed
+        //valueChanged |= _setChannel[1](_storedValues[1]); // The turrent lock is a virtual channel, so call handler for real turrent channel
+
+        return (_turrentOffset, valueChanged);
     }
 }

--- a/BrickController2/BrickController2/DeviceManagement/MouldKing/MK5.cs
+++ b/BrickController2/BrickController2/DeviceManagement/MouldKing/MK5.cs
@@ -31,7 +31,7 @@ internal class MK5 : MKBaseNibble, IDeviceType<MK5>
     /// * 0x00: turret is unlocked
     /// * 0x02: turret is locked
     /// </summary>
-    private byte _turretOffset = 0x00;
+    private byte _turret_lock_Nibble = 0x00;
 
     public MK5(string name, string address, byte[] deviceData, IDeviceRepository deviceRepository, IBluetoothLEService bleService, IMKPlatformService mkPlatformService)
       : base(name, address, deviceData, deviceRepository, bleService, mkPlatformService, 0, Telegram_Connect, Telegram_Base)
@@ -101,42 +101,39 @@ internal class MK5 : MKBaseNibble, IDeviceType<MK5>
     /// representation of the input value.</description> </item> <item> <description><c>zeroSet</c>: A boolean
     /// indicating whether the input value was zero (<see langword="true"/>) or not (<see
     /// langword="false"/>).</description> </item> </list></returns>
-    private (byte setValue_nibble, bool zeroSet) SetOutput_AnalogChannel(float value)
+    private (byte setValue_Nibble, bool zeroSet) SetOutput_AnalogChannel(float value)
     {
-        // MK5: ZeroValueNibble = 0x00, Range_pos_Offset = 0x08
-        // value <  0:  7 6 5 4 3 2 1                    range_neg: 0x07
+        // MK5: ZEROVALUE_NIBBLE = 0x00, Range_pos_Offset = 0x08
+        // value <  0:  7 6 5 4 3 2 1                    RANGE_NEG: 0x07
         // value == 0:                0
         // value >  0:                  9 A B C D E F    range_pos: 0x07
 
-        const byte ZeroValueNibble = 0x00;
-        const byte Range_pos_Offset = 0x08;
-        const int Range_pos = 0x07;
-        const int Range_neg = 0x07;
+        const byte RANGE_POS_OFFSET = 0x08;
+        const int RANGE_POS = 0x07;
+        const int RANGE_NEG = 0x07;
 
-        if (value < 0)
+        const float MIN_NEG_RANGE_THRESHOLD = -1f / RANGE_NEG;    // Minimum value for negative range
+        const float MIN_POS_RANGE_THRESHOLD = 1f / RANGE_POS;     // Minimum value for positive range
+
+        const byte ZEROVALUE_NIBBLE = 0x00;
+
+        if (value < MIN_NEG_RANGE_THRESHOLD)
         {
-            float value_abs = Math.Min(0x07, -value * Range_neg);
+            float value_abs = Math.Min(0x07, -value * RANGE_NEG);
             byte setValue_nibble = (byte)(0x0F & (byte)value_abs);
 
-            if (setValue_nibble == 0) // replace zero with ZeroValueNibble
-            {
-                return (ZeroValueNibble, true);
-            }
-            else
-            {
-                return (setValue_nibble, false);
-            }
+            return (setValue_nibble, false);
         }
-        else if (value > 0)
+        else if (value > MIN_POS_RANGE_THRESHOLD)
         {
-            float value_abs = Math.Min(0x0F, (value * Range_pos) + Range_pos_Offset);
-            byte setValue_nibble = (byte)(0x0F & (byte)(value_abs));
+            float value_abs = Math.Min(0x0F, (value * RANGE_POS) + RANGE_POS_OFFSET);
+            byte setValue_nibble = (byte)(0x0F & (byte)value_abs);
 
             return (setValue_nibble, false);
         }
         else
         {
-            return (ZeroValueNibble, true);
+            return (ZEROVALUE_NIBBLE, true);
         }
     }
 
@@ -152,44 +149,40 @@ internal class MK5 : MKBaseNibble, IDeviceType<MK5>
     /// to be set for the turret.</description> </item> <item> <description><c>zeroSet</c>: A boolean flag indicating
     /// whether the zero value nibble is used (<see langword="true"/> if the zero value nibble is applied; otherwise,
     /// <see langword="false"/>).</description> </item> </list></returns>
-    private (byte setValue_nibble, bool zeroSet) SetOutput_AnalogChannel_Turret(float value)
+    private (byte setValue_Nibble, bool zeroSet) SetOutput_AnalogChannel_Turret(float value)
     {
-        // MK5: ZeroValueNibble = 0x00, Range_pos_Offset = 0x08
-        // value <  0:  7 6 5 4 3 2 1                    range_neg: 0x07
+        // MK5: zeroValue_Nibble = 0x00/0x02, RANGE_POS_OFFSET = 0x08
+        // value <  0:  7 6 5 4 3 2 1                    RANGE_NEG: 0x07
         // value == 0:                0
-        // value >  0:                  9 A B C D E F    range_pos: 0x07
+        // value >  0:                  9 A B C D E F    RANGE_POS: 0x07
 
-        byte ZeroValueNibble = _turretOffset; // <-- turretOffset is set by SetOutput_Option_Turret_Lock
-        const byte Range_pos_Offset = 0x08;
-        const int Range_pos = 0x07;
-        const int Range_neg = 0x07;
+        const byte RANGE_POS_OFFSET = 0x08;
+        const int RANGE_POS = 0x07;
+        const int RANGE_NEG = 0x07;
+        const float MIN_NEG_RANGE_THRESHOLD = -1f / RANGE_NEG;    // Minimum value for negative range
+        const float MIN_POS_RANGE_THRESHOLD = 1f / RANGE_POS;     // Minimum value for positive range
+
+        byte zeroValue_Nibble = _turret_lock_Nibble; // <-- turretOffset is set by SetOutput_Option_Turret_Lock
 
         value *= -1; // invert value for turret
 
-        if (value < 0)
+        if (value < MIN_NEG_RANGE_THRESHOLD)
         {
-            float value_abs = Math.Min(0x07, -value * Range_neg);
+            float value_abs = Math.Min(0x07, -value * RANGE_NEG);
             byte setValue_nibble = (byte)(0x0F & (byte)value_abs);
 
-            if (setValue_nibble == 0) // replace zero with ZeroValueNibble
-            {
-                return (ZeroValueNibble, true);
-            }
-            else
-            {
-                return (setValue_nibble, false);
-            }
+            return (setValue_nibble, false);
         }
-        else if (value > 0)
+        else if (value > MIN_POS_RANGE_THRESHOLD)
         {
-            float value_abs = Math.Min(0x0F, (value * Range_pos) + Range_pos_Offset);
+            float value_abs = Math.Min(0x0F, (value * RANGE_POS) + RANGE_POS_OFFSET);
             byte setValue_nibble = (byte)(0x0F & (byte)(value_abs));
 
             return (setValue_nibble, false);
         }
         else
         {
-            return (ZeroValueNibble, true);
+            return (zeroValue_Nibble, true);
         }
     }
 
@@ -208,14 +201,17 @@ internal class MK5 : MKBaseNibble, IDeviceType<MK5>
     /// langword="false"/>.</description></item> </list></returns>
     private (byte setValue_nibble, bool zeroSet) SetOutput_Shot(float value)
     {
+        const byte ZEROVALUE_NIBBLE = 0x00;
+        const byte FIRE_SHOT_NIBBLE = 0x0F;
+
         if (value == 0)
         {
-            return (0x00, true);
+            return (ZEROVALUE_NIBBLE, true);
         }
         else
         {
             // Tank fires a shot when value is set to 0x0F
-            return (0x0F, false);
+            return (FIRE_SHOT_NIBBLE, false);
         }
     }
 
@@ -232,23 +228,25 @@ internal class MK5 : MKBaseNibble, IDeviceType<MK5>
     /// updated.</description> </item> </list></returns>
     private (byte setValue_nibble, bool zeroSet) SetOutput_Option_Turret_Lock(float value)
     {
+        const byte TURRET_UNLOCKED_NIBBLE = 0x00;
+        const byte TURRET_LOCKED_NIBBLE = 0x02;
+
         if (value == 0)
         {
-            _turretOffset = 0x00; // turret is unlocked
+            _turret_lock_Nibble = TURRET_UNLOCKED_NIBBLE; // turret is unlocked
         }
         else
         {
-            _turretOffset = 0x02; // turret is locked
+            _turret_lock_Nibble = TURRET_LOCKED_NIBBLE; // turret is locked
         }
 
         bool valueChanged = false;
-        
         valueChanged |= _setChannel[1](_storedValues[1]); // The turret lock is a virtual channel, so call handler for real turret channel
 
         // to clarify the concept:
         // inside a virtual channel handler multiple calls to _setChannel are allowed
         //valueChanged |= _setChannel[x](_storedValues[x]); 
 
-        return (_turretOffset, valueChanged);
+        return (_turret_lock_Nibble, valueChanged);
     }
 }

--- a/BrickController2/BrickController2/DeviceManagement/MouldKing/MK5.cs
+++ b/BrickController2/BrickController2/DeviceManagement/MouldKing/MK5.cs
@@ -11,8 +11,6 @@ internal class MK5 : MKBaseNibble, IDeviceType<MK5>
 {
     public const string Device = "Device";
 
-    public const int CHANNEL_START_OFFSET = 3;
-
     /// <summary>
     /// Telegram connect to MK5.0
     /// </summary>
@@ -29,7 +27,7 @@ internal class MK5 : MKBaseNibble, IDeviceType<MK5>
     private static readonly TimeSpan ReconnectTimeSpan = TimeSpan.FromSeconds(3);
 
     public MK5(string name, string address, byte[] deviceData, IDeviceRepository deviceRepository, IBluetoothLEService bleService, IMKPlatformService mkPlatformService)
-      : base(name, address, deviceData, deviceRepository, bleService, mkPlatformService, CHANNEL_START_OFFSET, Telegram_Connect, Telegram_Base)
+      : base(name, address, deviceData, deviceRepository, bleService, mkPlatformService, 0, Telegram_Connect, Telegram_Base)
     {
     }
 
@@ -46,42 +44,76 @@ internal class MK5 : MKBaseNibble, IDeviceType<MK5>
     /// </summary>
     protected override ushort ManufacturerId => MKProtocol.ManufacturerID;
 
-    /// <summary>
-    /// Number of bytes containing channel values in base telegram
-    /// </summary>
-    protected override int BaseTelegram_ChannelBytesCount => 2;
-
-    /// <summary>
-    /// Offset to position of first channel in base telegram
-    /// </summary>
-    protected override int BaseTelegram_ChannelStartOffset => CHANNEL_START_OFFSET;
-
-    // MK5: ZeroValueNibble = 0x00, ZeroValueOffset = 0x08
-    // value <  0:  7 6 5 4 3 2 1                    range_neg: 0x07
-    // value == 0:                0
-    // value >  0:                  9 A B C D E F    range_pos: 0x07
-
-    /// <summary>
-    /// Gets the nibble value that represents zero in the current encoding scheme.
-    /// </summary>
-    protected override byte ZeroValueNibble => 0x00;
-
-    /// <summary>
-    /// Gets the offset for positive values
-    /// </summary>
-    protected override byte Range_pos_Offset => 0x08;
-
-    /// <summary>
-    /// Gets the range for positive values
-    /// </summary>
-    protected override int Range_neg => 0x07;
-
-    /// <summary>
-    /// Gets the range for negative values
-    /// </summary>
-    protected override int Range_pos => 0x07;
-
     /// <inheritdoc/>>
     protected override BluetoothAdvertisingDeviceHandler GetBluetoothAdvertisingDeviceHandler() =>
+        // there is only one instance of MK5.0
         new(_bleService, ManufacturerId, TryGetTelegram, ReconnectTimeSpan);
+
+
+    protected override Func<float, (byte, bool)> CreateSetChannel(int channelNo)
+    {
+        return channelNo switch
+        {
+            0 => (float value) => SetOutput_AnalogChannel(value),
+            1 => (float value) => SetOutput_AnalogChannel(value),
+            2 => (float value) => SetOutput_Shot(value),
+            3 => (float value) => SetOutput_AnalogChannel(value),
+            _ => throw new ArgumentException("Illegal Argument", nameof(channelNo))
+        };
+    }
+
+    private (byte, bool) SetOutput_AnalogChannel(float value)
+    {
+        // MK5: ZeroValueNibble = 0x00, Range_pos_Offset = 0x08
+        // value <  0:  7 6 5 4 3 2 1                    range_neg: 0x07
+        // value == 0:                0
+        // value >  0:                  9 A B C D E F    range_pos: 0x07
+        const byte ZeroValueNibble = 0x00;
+        const byte Range_pos_Offset = 0x08;
+        const int Range_pos = 0x07;
+        const int Range_neg = 0x07;
+
+        if (value < 0)
+        {
+            float value_abs = Math.Min(0x07, -value * Range_neg);
+            byte setValue_nibble = (byte)(0x0F & (byte)value_abs);
+
+            if (setValue_nibble == 0) // replace zero with ZeroValueNibble
+            {
+                return (ZeroValueNibble, true);
+            }
+            else
+            {
+                return (setValue_nibble, false);
+            }
+        }
+        else if (value > 0)
+        {
+            float value_abs = Math.Min(0x0F, (value * Range_pos) + Range_pos_Offset);
+            byte setValue_nibble = (byte)(0x0F & (byte)(value_abs));
+
+            return (setValue_nibble, false);
+        }
+        else
+        {
+            return (ZeroValueNibble, true);
+        }
+    }
+
+    private (byte, bool) SetOutput_Shot(float value)
+    {
+        // Tank fires a shot when value is set to 0x0F
+        if (value < 0)
+        {
+            return (0x0F, false);
+        }
+        else if (value > 0)
+        {
+            return (0x0F, false);
+        }
+        else
+        {
+            return (0x00, true);
+        }
+    }
 }

--- a/BrickController2/BrickController2/DeviceManagement/MouldKing/MK5.cs
+++ b/BrickController2/BrickController2/DeviceManagement/MouldKing/MK5.cs
@@ -45,7 +45,7 @@ internal class MK5 : MKBaseNibble, IDeviceType<MK5>
     public static string TypeName => "MK 5.0";
 
     /// <summary>
-    /// Gets the number of audio channels supported by the current configuration.
+    /// Gets the number of channels supported by the device
     /// <remarks><list type="bullet">
     /// <item><description>Channel 0..4: real existing channel</description></item> 
     /// <item><description>Channel 5: virtual channel for locking the turret</description></item>

--- a/BrickController2/BrickController2/DeviceManagement/MouldKing/MK5.cs
+++ b/BrickController2/BrickController2/DeviceManagement/MouldKing/MK5.cs
@@ -117,14 +117,14 @@ internal class MK5 : MKBaseNibble, IDeviceType<MK5>
 
         const byte ZEROVALUE_NIBBLE = 0x00;
 
-        if (value < MIN_NEG_RANGE_THRESHOLD)
+        if (value <= MIN_NEG_RANGE_THRESHOLD)
         {
             float value_abs = Math.Min(0x07, -value * RANGE_NEG);
             byte setValue_nibble = (byte)(0x0F & (byte)value_abs);
 
             return (setValue_nibble, false);
         }
-        else if (value > MIN_POS_RANGE_THRESHOLD)
+        else if (value >= MIN_POS_RANGE_THRESHOLD)
         {
             float value_abs = Math.Min(0x0F, (value * RANGE_POS) + RANGE_POS_OFFSET);
             byte setValue_nibble = (byte)(0x0F & (byte)value_abs);
@@ -166,14 +166,14 @@ internal class MK5 : MKBaseNibble, IDeviceType<MK5>
 
         value *= -1; // invert value for turret
 
-        if (value < MIN_NEG_RANGE_THRESHOLD)
+        if (value <= MIN_NEG_RANGE_THRESHOLD)
         {
             float value_abs = Math.Min(0x07, -value * RANGE_NEG);
             byte setValue_nibble = (byte)(0x0F & (byte)value_abs);
 
             return (setValue_nibble, false);
         }
-        else if (value > MIN_POS_RANGE_THRESHOLD)
+        else if (value >= MIN_POS_RANGE_THRESHOLD)
         {
             float value_abs = Math.Min(0x0F, (value * RANGE_POS) + RANGE_POS_OFFSET);
             byte setValue_nibble = (byte)(0x0F & (byte)(value_abs));

--- a/BrickController2/BrickController2/DeviceManagement/MouldKing/MK5.cs
+++ b/BrickController2/BrickController2/DeviceManagement/MouldKing/MK5.cs
@@ -1,4 +1,7 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
 using BrickController2.PlatformServices.BluetoothLE;
 using BrickController2.Protocols;
 
@@ -10,6 +13,9 @@ namespace BrickController2.DeviceManagement.MouldKing;
 internal class MK5 : MKBaseNibble, IDeviceType<MK5>
 {
     public const string Device = "Device";
+
+    private const byte TURRET_UNLOCKED_NIBBLE = 0x00;
+    private const byte TURRET_LOCKED_NIBBLE = 0x02;
 
     /// <summary>
     /// Telegram connect to MK5.0
@@ -31,7 +37,7 @@ internal class MK5 : MKBaseNibble, IDeviceType<MK5>
     /// * 0x00: turret is unlocked
     /// * 0x02: turret is locked
     /// </summary>
-    private byte _turret_lock_Nibble = 0x00;
+    private byte _turret_lock_Nibble = TURRET_UNLOCKED_NIBBLE;
 
     public MK5(string name, string address, byte[] deviceData, IDeviceRepository deviceRepository, IBluetoothLEService bleService, IMKPlatformService mkPlatformService)
       : base(name, address, deviceData, deviceRepository, bleService, mkPlatformService, 0, Telegram_Connect, Telegram_Base)
@@ -52,6 +58,13 @@ internal class MK5 : MKBaseNibble, IDeviceType<MK5>
     /// </list></remarks>
     /// </summary>
     public override int NumberOfChannels => 5;
+
+    public override Task<DeviceConnectionResult> ConnectAsync(bool reconnect, Action<Device> onDeviceDisconnected, IEnumerable<ChannelConfiguration> channelConfigurations, bool startOutputProcessing, bool requestDeviceInformation, CancellationToken token)
+    {
+        _turret_lock_Nibble = TURRET_UNLOCKED_NIBBLE; // reset turret lock nibble on connect
+
+        return base.ConnectAsync(reconnect, onDeviceDisconnected, channelConfigurations, startOutputProcessing, requestDeviceInformation, token);
+    }
 
     /// <summary>
     /// ManufacturerId to advertise
@@ -228,9 +241,6 @@ internal class MK5 : MKBaseNibble, IDeviceType<MK5>
     /// updated.</description> </item> </list></returns>
     private (byte setValue_nibble, bool zeroSet) SetOutput_Option_Turret_Lock(float value)
     {
-        const byte TURRET_UNLOCKED_NIBBLE = 0x00;
-        const byte TURRET_LOCKED_NIBBLE = 0x02;
-
         if (value == 0)
         {
             _turret_lock_Nibble = TURRET_UNLOCKED_NIBBLE; // turret is unlocked

--- a/BrickController2/BrickController2/DeviceManagement/MouldKing/MK5.cs
+++ b/BrickController2/BrickController2/DeviceManagement/MouldKing/MK5.cs
@@ -80,11 +80,11 @@ internal class MK5 : MKBaseNibble, IDeviceType<MK5>
     {
         return channelNo switch
         {
-            0 => (0, (value) => SetOutput_AnalogChannel(value)),                    // Tracks A + B forward, backward
-            1 => (1, (value) => SetOutput_AnalogChannel_Turrent(value)),            // Turrent rotation
-            2 => (2, (value) => SetOutput_Shot(value)),                             // shot canon
-            3 => (3, (value) => SetOutput_AnalogChannel(value)),                    // turn on spot
-            4 => (VIRTUALCHANNEL, (value) => SetOutput_Option_Turrent_Lock(value)), // virtual channel: lock turrent
+            0 => (0, SetOutput_AnalogChannel),                    // Tracks A + B forward, backward
+            1 => (1, SetOutput_AnalogChannel_Turrent),            // Turrent rotation
+            2 => (2, SetOutput_Shot),                             // shot canon
+            3 => (3, SetOutput_AnalogChannel),                    // turn on spot
+            4 => (VIRTUALCHANNEL, SetOutput_Option_Turrent_Lock), // virtual channel: lock turrent
             _ => throw new ArgumentException("Illegal Argument", nameof(channelNo))
         };
     }

--- a/BrickController2/BrickController2/DeviceManagement/MouldKing/MKBaseByte.cs
+++ b/BrickController2/BrickController2/DeviceManagement/MouldKing/MKBaseByte.cs
@@ -85,16 +85,7 @@ internal abstract class MKBaseByte : BluetoothAdvertisingDevice
                 _telegram_Base[byteOffset] = byteValue;
 
                 // Zero was set -> check all channel's values
-                if (byteValue == 0x80)
-                {
-                    // notify data changed
-                    _bluetoothAdvertisingDeviceHandler.NotifyDataChanged(CheckAllChannelsZero());
-                }
-                else
-                {
-                    // notify data changed
-                    _bluetoothAdvertisingDeviceHandler.NotifyDataChanged(false);
-                }
+                _bluetoothAdvertisingDeviceHandler.NotifyDataChanged(channelNo, byteValue == 0x80);
             }
         }
     }
@@ -111,6 +102,16 @@ internal abstract class MKBaseByte : BluetoothAdvertisingDevice
         }
     }
 
+    /// <summary>
+    /// Attempts to retrieve the RF payload for the specified telegram type.
+    /// </summary>
+    /// <remarks>This method delegates the retrieval of the RF payload to the underlying platform
+    /// service.</remarks>
+    /// <param name="getConnectTelegram">A boolean value indicating the type of telegram to retrieve.  <see langword="true"/> to retrieve the connect
+    /// telegram; <see langword="false"/> to retrieve the base telegram.</param>
+    /// <param name="payload">When this method returns, contains the RF payload as a byte array if the operation succeeds; otherwise, <see
+    /// langword="null"/>.</param>
+    /// <returns><see langword="true"/> if the RF payload was successfully retrieved; otherwise, <see langword="false"/>.</returns>
     protected bool TryGetTelegram(bool getConnectTelegram, out byte[] payload)
     {
         if (getConnectTelegram)
@@ -121,18 +122,5 @@ internal abstract class MKBaseByte : BluetoothAdvertisingDevice
         {
             return _mkPlatformService.TryGetRfPayload(_telegram_Base, out payload);
         }
-    }
-
-    private bool CheckAllChannelsZero()
-    {
-        for (int index = 0; index < BaseTelegram_ChannelBytesCount; index++)
-        {
-            if (_telegram_Base[BaseTelegram_ChannelStartOffset + index] != 0x80)
-            {
-                return false;
-            }
-        }
-
-        return true;
     }
 }

--- a/BrickController2/BrickController2/DeviceManagement/MouldKing/MKBaseByte.cs
+++ b/BrickController2/BrickController2/DeviceManagement/MouldKing/MKBaseByte.cs
@@ -1,5 +1,6 @@
-﻿using System;
-using BrickController2.PlatformServices.BluetoothLE;
+﻿using BrickController2.PlatformServices.BluetoothLE;
+using System;
+using System.Threading.Channels;
 
 namespace BrickController2.DeviceManagement.MouldKing;
 
@@ -99,6 +100,26 @@ internal abstract class MKBaseByte : BluetoothAdvertisingDevice
         for (int index = 0; index < BaseTelegram_ChannelBytesCount; index++)
         {
             _telegram_Base[BaseTelegram_ChannelStartOffset + index] = 0x80;
+        }
+
+        for (int channelNo = 0; channelNo < NumberOfChannels; channelNo++)
+        {
+            // call _bluetoothAdvertisingDeviceHandler.SetChannelState() to set global channel state to zero
+            _bluetoothAdvertisingDeviceHandler.SetChannelState(channelNo, true);
+        }
+    }
+
+    /// <summary>
+    /// Disconnects the device and resets the state of all communication channels.
+    /// </summary>
+    /// <remarks>This method iterates through all available channels and sets their state to inactive.  It
+    /// ensures that the device is properly disconnected and all channels are reset.</remarks>
+    protected override void DisconnectDevice()
+    {
+        for (int channelNo = 0; channelNo < NumberOfChannels; channelNo++)
+        {
+            // call _bluetoothAdvertisingDeviceHandler.SetChannelState() to set global channel state to zero
+            _bluetoothAdvertisingDeviceHandler.SetChannelState(channelNo, true);
         }
     }
 

--- a/BrickController2/BrickController2/DeviceManagement/MouldKing/MKBaseByte.cs
+++ b/BrickController2/BrickController2/DeviceManagement/MouldKing/MKBaseByte.cs
@@ -84,8 +84,8 @@ internal abstract class MKBaseByte : BluetoothAdvertisingDevice
             {
                 _telegram_Base[byteOffset] = byteValue;
 
-                // Zero was set -> check all channel's values
-                _bluetoothAdvertisingDeviceHandler.NotifyDataChanged(channelNo, byteValue == 0x80);
+                _bluetoothAdvertisingDeviceHandler.SetChannelState(channelNo, byteValue == 0x80);
+                _bluetoothAdvertisingDeviceHandler.NotifyDataChanged();
             }
         }
     }

--- a/BrickController2/BrickController2/DeviceManagement/MouldKing/MKBaseNibble.cs
+++ b/BrickController2/BrickController2/DeviceManagement/MouldKing/MKBaseNibble.cs
@@ -19,6 +19,13 @@ internal abstract class MKBaseNibble : BluetoothAdvertisingDevice
     private const int MAX_CHANNEL_BYTES_PER_INSTANCE = 2;
 
     /// <summary>
+    /// Represents the virtual channel number used for specific operations.
+    /// </summary>
+    /// <remarks>This constant is intended for use in scenarios where a virtual channel identifier is
+    /// required. The value is set to -1, which may indicate a special or default channel.</remarks>
+    protected const int VIRTUALCHANNEL = -1; // virtual channel number
+
+    /// <summary>
     /// platform specific MouldKing stuff
     /// </summary>
     protected readonly IMKPlatformService _mkPlatformService;
@@ -35,10 +42,15 @@ internal abstract class MKBaseNibble : BluetoothAdvertisingDevice
     protected readonly byte[] _telegram_Base;
 
     /// <summary>
+    /// array to hold the incoming output values for all channels.
+    /// </summary>
+    protected readonly float[] _storedValues;
+
+    /// <summary>
     /// Represents an array of functions that process the channel's setvalue and return a tuple
     /// containing the baseTelegramChannelByteOffset, the channel specific setvalue and a boolean to indicate a zero value.
     /// </summary>
-    protected readonly Func<float, (int, int, (byte, bool))>[] _setChannel;
+    protected readonly Func<float, bool>[] _setChannel;
 
     /// <summary>
     /// instance number of specific device type
@@ -54,6 +66,7 @@ internal abstract class MKBaseNibble : BluetoothAdvertisingDevice
 
         _instanceNo = instanceNo;
 
+        _storedValues = new float[NumberOfChannels]; // initialize output values for all channels
         _setChannel = CreateSetChannelList();
     }
 
@@ -62,83 +75,129 @@ internal abstract class MKBaseNibble : BluetoothAdvertisingDevice
     /// </summary>
     public override string BatteryVoltageSign => string.Empty;
 
-
     /// <summary>
     /// Sets the output value for the specified channel.
     /// </summary>
-    /// <remarks>This method adjusts the output value based on the channel type and applies the appropriate
-    /// encoding. If the output value changes, a notification is triggered to indicate the change. For channels where
-    /// the value is set to zero, additional checks are performed to determine if all channels are zero.</remarks>
-    /// <param name="channelNo">The channel number for which the output value is to be set. Must be a valid channel index.</param>
-    /// <param name="value">The output value to set. The value is interpreted based on the channel type: negative values, zero, and positive
-    /// values may have different effects depending on the channel configuration.</param>
+    /// <remarks>This method updates the output value for the specified channel and ensures the value is
+    /// within the valid range. If the value changes, the method triggers a notification to indicate that data has been
+    /// updated.</remarks>
+    /// <param name="channelNo">The channel number for which the output value is being set. Must be a valid channel index.</param>
+    /// <param name="value">The output value to set. The value will be adjusted if it exceeds the allowable range.</param>
     public override void SetOutput(int channelNo, float value)
     {
         CheckChannel(channelNo);
         value = CutOutputValue(value);
 
-        (int byteOffset, int specificChannelNo, (byte setValue_nibble, bool zeroSet)) = _setChannel[channelNo](value);
-
-        byte originValue_byte = _telegram_Base[byteOffset];
-
-        bool isOdd = (channelNo & 0x01) == 0x01; // is odd
-        byte setValue_byte;
-        if (isOdd)
-        {
-            setValue_byte = (byte)((originValue_byte & 0xF0) + setValue_nibble);
-        }
-        else
-        {
-            setValue_byte = (byte)((originValue_byte & 0x0F) + (setValue_nibble << 4));
-        }
+        // store the incoming value in the stored values array
+        _storedValues[channelNo] = value;
 
         lock (_outputLock)
         {
-            // check for change
-            if (_telegram_Base[byteOffset] != setValue_byte)
-            {
-                _telegram_Base[byteOffset] = setValue_byte;
+            // call the channel specific set function
+            bool valueChanged = _setChannel[channelNo](value);
 
-                // notify data changed
-                _bluetoothAdvertisingDeviceHandler.NotifyDataChanged(specificChannelNo, zeroSet);
+            // check for change
+            if (valueChanged)
+            {
+                _bluetoothAdvertisingDeviceHandler.NotifyDataChanged();
             }
         }
     }
 
     /// <summary>
-    /// Creates and returns an array of functions, each corresponding to a channel
+    /// Updates a specific nibble of a byte in the telegram buffer and returns whether the value was changed.
     /// </summary>
-    /// <remarks>Each function in the returned array is specific to a channel and is generated using the <see
-    /// cref="CreateSetChannel"/> method. The number of functions in the array matches the value of <see
-    /// cref="NumberOfChannels"/>.</remarks>
-    /// <returns>An array of functions</returns>
-    protected Func<float, (int, int, (byte, bool))>[] CreateSetChannelList()
+    /// <remarks>This method modifies the telegram buffer by updating either the lower or upper nibble of the
+    /// specified byte. The operation is thread-safe and ensures exclusive access to the buffer during the
+    /// update.</remarks>
+    /// <param name="byteOffset">The zero-based index of the byte in the telegram buffer to modify.</param>
+    /// <param name="isLowerNibble">A value indicating whether the lower nibble of the byte should be updated.  <see langword="true"/> to update the
+    /// lower nibble; <see langword="false"/> to update the upper nibble.</param>
+    /// <param name="setValue_nibble">The new nibble value to set, represented as a byte (0-15).</param>
+    /// <returns><see langword="true"/> if the byte in the telegram buffer was modified;  otherwise, <see langword="false"/> if
+    /// the value remained unchanged.</returns>
+    protected bool SetChannelValue(int byteOffset, bool isLowerNibble, byte setValue_nibble)
     {
-        Func<float, (int, int, (byte, bool))>[] setChannelList = new Func<float, (int, int, (byte, bool))>[NumberOfChannels];
+        lock (_outputLock)
+        {
+            byte originValue_byte = _telegram_Base[byteOffset];
+
+            byte setValue_byte;
+            if (isLowerNibble)
+            {
+                setValue_byte = (byte)((originValue_byte & 0xF0) + setValue_nibble);
+            }
+            else
+            {
+                setValue_byte = (byte)((originValue_byte & 0x0F) + (setValue_nibble << 4));
+            }
+            _telegram_Base[byteOffset] = setValue_byte;
+            return _telegram_Base[byteOffset] != originValue_byte;
+        }
+    }
+
+    /// <summary>
+    /// Creates and initializes a list of channel-setting functions for all available channels.
+    /// </summary>
+    /// <remarks>Each function in the returned array is responsible for setting the state or value of a
+    /// specific channel. The behavior of the function depends on whether the channel is virtual or real: - For virtual
+    /// channels, the function determines whether the channel's state has been modified. - For real channels, the
+    /// function updates the channel's state and value based on the provided input.</remarks>
+    /// <returns>An array of functions, where each function takes a <see langword="float"/> value as input and returns a <see
+    /// langword="bool"/> indicating success or modification. The array contains one function per channel, corresponding
+    /// to the total number of channels.</returns>
+    protected Func<float, bool>[] CreateSetChannelList()
+    {
+        Func<float, bool>[] setChannelList = new Func<float, bool>[NumberOfChannels];
 
         for (int channelNo = 0; channelNo < NumberOfChannels; channelNo++)
         {
-            int byteOffset = GetSpecificChannelByteOffset(channelNo);
-            int specificChannelNo = GetSpecificChannelNumber(channelNo);
-            Func<float, (byte, bool)> createSetChannel = CreateSetChannel(channelNo);
+            (int realChannelNo, Func<float, (byte, bool)> handler) setChannelHandler = CreateChannelHandler(channelNo);
 
-            setChannelList[channelNo] = (float value) => (byteOffset, specificChannelNo, createSetChannel(value));
+            int realChannelNo = setChannelHandler.Item1;
+
+            // virtual channel
+            if (realChannelNo == VIRTUALCHANNEL)
+            {
+                setChannelList[channelNo] = (float value) =>
+                {
+                    // virtual channel handlers return isModified insted of zeroSet
+                    (byte a, bool isModified) = setChannelHandler.Item2(value);
+
+                    return isModified;
+                };
+            }
+            // real channel
+            else
+            {
+                bool isOdd = (realChannelNo & 0x01) == 0x01;
+                int byteOffset = GetByteOffset(realChannelNo);
+                int specificChannelNo = GetSpecificChannelNumber(realChannelNo);
+
+                setChannelList[channelNo] = (float value) =>
+                {
+                    (byte setValue_nibble, bool zeroSet) = setChannelHandler.Item2(value);
+
+                    _bluetoothAdvertisingDeviceHandler.SetChannelState(specificChannelNo, zeroSet); // set global channel state
+                    return SetChannelValue(byteOffset, isOdd, setValue_nibble);
+                };
+            }
         }
         return setChannelList;
     }
 
-
     /// <summary>
-    /// Creates a delegate that sets the value of a specific channel and returns the result as a tuple.
+    /// Creates a handler for processing a specific channel, returning the real channel number and a function to compute
+    /// channel-specific values.
     /// </summary>
-    /// <remarks>The returned delegate allows dynamic configuration of the specified channel. The exact
-    /// behavior and constraints of the delegate depend on the implementation in derived classes.</remarks>
-    /// <param name="channelNo">The channel number to configure. Must be a valid channel identifier.</param>
-    /// <returns>A function that takes a <see cref="float"/> value as input, representing the channel's desired state, and
-    /// returns a tuple containing a <see cref="byte"/> representing the processed channel value and a <see
-    /// langword="bool"/> indicating whether a zero value was set.</returns>
-    protected abstract Func<float, (byte, bool)> CreateSetChannel(int channelNo);
-
+    /// <remarks>This method is abstract and must be implemented by derived classes to define the behavior for
+    /// mapping and processing channel numbers.</remarks>
+    /// <param name="channelNo">The logical channel number to be processed. Must be a valid channel number within the expected range.</param>
+    /// <returns>A tuple containing: <list type="bullet"> <item> <description>The real channel number corresponding to the
+    /// provided logical channel number or constant VIRTUALCHANNEL to mark as virtual.</description> </item> <item> <description>A function that takes a float input
+    /// and returns a tuple consisting of a byte value (representing the nibble to set) and a boolean indicating whether
+    /// the zero set condition is met.</description> </item> </list></returns>
+    protected abstract (int realChannelNo, Func<float, (byte setValue_nibble, bool zeroSet)>) CreateChannelHandler(int channelNo);
 
     /// <summary>
     /// This method sets the device to initial state before advertising starts
@@ -151,7 +210,6 @@ internal abstract class MKBaseNibble : BluetoothAdvertisingDevice
             _setChannel[channelNo](0); // set all channels to zero using the channel specific function
         }
     }
-
 
     /// <summary>
     /// Attempts to retrieve the RF payload for the specified telegram type.
@@ -176,28 +234,32 @@ internal abstract class MKBaseNibble : BluetoothAdvertisingDevice
     }
 
     /// <summary>
-    /// Calculates the byte offset inside the baseTelegram of the DeviceType for the specified channel.
+    /// Calculates the byte offset for a given channel number within the current instance.
     /// </summary>
-    /// <param name="channelNo">The zero-based index of the channel for which to calculate the start offset.</param>
-    /// <returns>The start offset for the specified channel.</returns>
-    private int GetSpecificChannelByteOffset(int channelNo)
+    /// <remarks>The byte offset is determined based on the instance number, the maximum number of bytes
+    /// allocated per instance,  and the channel number. Each byte represents two channels.</remarks>
+    /// <param name="channelNo">The channel number for which to calculate the byte offset. Must be a non-negative integer.</param>
+    /// <returns>The byte offset corresponding to the specified channel number within the current instance.</returns>
+    private int GetByteOffset(int channelNo)
     {
+        // i.e. MK4.0 has 3 instances, each with 2 bytes for channels
         // instance 0: 3..4
         // instance 1: 5..6
         // instance 2: 7..8
-        return CHANNEL_START_OFFSET + _instanceNo * MAX_CHANNEL_BYTES_PER_INSTANCE + (channelNo >> 1); // div 2, 2 channels per byte
+        return CHANNEL_START_OFFSET + _instanceNo * MAX_CHANNEL_BYTES_PER_INSTANCE + (channelNo >> 1); // div 2 -> 2 channels per byte
     }
 
     /// <summary>
-    /// Calculates the channel number inside the DeviceType for the specified channel.
+    /// Calculates the absolute channel number based on the specified relative channel number and the instance number.
     /// </summary>
-    /// <param name="channelNo">The zero-based index of the channel for which to calculate the DeviceType specific channel number.</param>
-    /// <returns>The DeviceType specific channel number for the specified channel.</returns>
+    /// <param name="channelNo">The relative channel number within the current instance. Must be within the valid range for the instance.</param>
+    /// <returns>The absolute channel number, combining the instance number and the relative channel number.</returns>
     private int GetSpecificChannelNumber(int channelNo)
     {
-        // instance 0: 0..3
-        // instance 1: 4..7
-        // instance 2: 8..11
+        // i.e. MK4.0 has 3 instances, each with 4 channels
+        // instance 0:  0.. 3
+        // instance 1:  4.. 7
+        // instance 2:  8..11
         return _instanceNo * NumberOfChannels + channelNo;
     }
 }

--- a/BrickController2/BrickController2/DeviceManagement/MouldKing/MKBaseNibble.cs
+++ b/BrickController2/BrickController2/DeviceManagement/MouldKing/MKBaseNibble.cs
@@ -1,6 +1,4 @@
 ﻿using BrickController2.PlatformServices.BluetoothLE;
-using Newtonsoft.Json.Linq;
-using System;
 
 namespace BrickController2.DeviceManagement.MouldKing;
 
@@ -18,13 +16,6 @@ internal abstract class MKBaseNibble : BluetoothAdvertisingDevice
     /// number of maximal channels in the device type
     /// </summary>
     private const int MAX_CHANNEL_BYTES_PER_INSTANCE = 2;
-
-    /// <summary>
-    /// Represents the virtual channel number used for specific operations.
-    /// </summary>
-    /// <remarks>This constant is intended for use in scenarios where a virtual channel identifier is
-    /// required. The value is set to -1, which may indicate a special or default channel.</remarks>
-    protected const int VIRTUALCHANNEL = -1; // virtual channel number
 
     /// <summary>
     /// platform specific MouldKing stuff
@@ -48,12 +39,6 @@ internal abstract class MKBaseNibble : BluetoothAdvertisingDevice
     protected readonly float[] _storedValues;
 
     /// <summary>
-    /// Represents an array of functions that process the channel's setvalue and return a tuple
-    /// containing the baseTelegramChannelByteOffset, the channel specific setvalue and a boolean to indicate a zero value.
-    /// </summary>
-    protected readonly Func<float, bool>[] _setChannel;
-
-    /// <summary>
     /// instance number of specific device type
     /// </summary>
     protected readonly int _instanceNo;
@@ -68,7 +53,6 @@ internal abstract class MKBaseNibble : BluetoothAdvertisingDevice
         _instanceNo = instanceNo;
 
         _storedValues = new float[NumberOfChannels]; // initialize output values for all channels
-        _setChannel = CreateSetChannelList();
     }
 
     /// <summary>
@@ -95,7 +79,7 @@ internal abstract class MKBaseNibble : BluetoothAdvertisingDevice
         lock (_outputLock)
         {
             // call the channel specific set function
-            bool valueChanged = _setChannel[channelNo](value);
+            bool valueChanged = SetChannelOutput(channelNo, value);
 
             // check for change
             if (valueChanged)
@@ -104,6 +88,10 @@ internal abstract class MKBaseNibble : BluetoothAdvertisingDevice
             }
         }
     }
+
+    protected virtual bool IsVirtualChannel(int channelNo) => false;
+
+    protected abstract (byte value, bool flag) ProccessChannelValue(int channelNo, float value);
 
     /// <summary>
     /// Updates a specific nibble of a byte in the telegram buffer and returns whether the value was changed.
@@ -137,66 +125,27 @@ internal abstract class MKBaseNibble : BluetoothAdvertisingDevice
         }
     }
 
-    /// <summary>
-    /// Creates and initializes a list of channel-setting functions for all available channels.
-    /// </summary>
-    /// <remarks>Each function in the returned array is responsible for setting the state or value of a
-    /// specific channel. The behavior of the function depends on whether the channel is virtual or real: - For virtual
-    /// channels, the function determines whether the channel's state has been modified. - For real channels, the
-    /// function updates the channel's state and value based on the provided input.</remarks>
-    /// <returns>An array of functions, where each function takes a <see langword="float"/> value as input and returns a <see
-    /// langword="bool"/> indicating success or modification. The array contains one function per channel, corresponding
-    /// to the total number of channels.</returns>
-    protected Func<float, bool>[] CreateSetChannelList()
+    protected bool SetChannelOutput(int channelNo, float value)
     {
-        Func<float, bool>[] setChannelList = new Func<float, bool>[NumberOfChannels];
-
-        for (int channelNo = 0; channelNo < NumberOfChannels; channelNo++)
+        if (IsVirtualChannel(channelNo))
         {
-            var (realChannelNo, handler) = CreateChannelHandler(channelNo);
-
             // virtual channel
-            if (realChannelNo == VIRTUALCHANNEL)
-            {
-                setChannelList[channelNo] = (float value) =>
-                {
-                    // virtual channel handlers return isModified insted of zeroSet
-                    (byte a, bool isModified) = handler(value);
-
-                    return isModified;
-                };
-            }
-            // real channel
-            else
-            {
-                bool isOdd = (realChannelNo & 0x01) == 0x01;
-                int byteOffset = GetByteOffset(realChannelNo);
-                int specificChannelNo = GetSpecificChannelNumber(realChannelNo);
-
-                setChannelList[channelNo] = (float value) =>
-                {
-                    (byte setValue_nibble, bool zeroSet) = handler(value);
-
-                    _bluetoothAdvertisingDeviceHandler.SetChannelState(specificChannelNo, zeroSet); // set global channel state
-                    return SetChannelValue(byteOffset, isOdd, setValue_nibble);
-                };
-            }
+            (byte _, bool isModified) = ProccessChannelValue(channelNo, value);
+            return isModified;
         }
-        return setChannelList;
-    }
+        else
+        {
+            // real channel
+            bool isOdd = (channelNo & 0x01) == 0x01;
+            int byteOffset = GetByteOffset(channelNo);
+            int specificChannelNo = GetSpecificChannelNumber(channelNo);
 
-    /// <summary>
-    /// Creates a handler for processing a specific channel, returning the real channel number and a function to compute
-    /// channel-specific values.
-    /// </summary>
-    /// <remarks>This method is abstract and must be implemented by derived classes to define the behavior for
-    /// mapping and processing channel numbers.</remarks>
-    /// <param name="channelNo">The logical channel number to be processed. Must be a valid channel number within the expected range.</param>
-    /// <returns>A tuple containing: <list type="bullet"> <item> <description>The real channel number corresponding to the
-    /// provided logical channel number or constant VIRTUALCHANNEL to mark as virtual.</description> </item> <item> <description>A function that takes a float input
-    /// and returns a tuple consisting of a byte value (representing the nibble to set) and a boolean indicating whether
-    /// the zero set condition is met.</description> </item> </list></returns>
-    protected abstract (int realChannelNo, Func<float, (byte setValue_nibble, bool zeroSet)>) CreateChannelHandler(int channelNo);
+            (byte setValue_nibble, bool zeroSet) = ProccessChannelValue(channelNo, value);
+
+            _bluetoothAdvertisingDeviceHandler.SetChannelState(specificChannelNo, zeroSet); // set global channel state
+            return SetChannelValue(byteOffset, isOdd, setValue_nibble);
+        }
+    }
 
     /// <summary>
     /// This method sets the device to initial state before advertising starts
@@ -209,7 +158,7 @@ internal abstract class MKBaseNibble : BluetoothAdvertisingDevice
         for (int channelNo = 0; channelNo < NumberOfChannels; channelNo++)
         {
             _storedValues[channelNo] = zeroValue;   // restore stored values to zero
-            _setChannel[channelNo](zeroValue);      // set all channels to zero using the channel specific function
+            SetChannelOutput(channelNo, zeroValue); // set all channels to zero using the channel specific function
         }
     }
 

--- a/BrickController2/BrickController2/DeviceManagement/MouldKing/MKBaseNibble.cs
+++ b/BrickController2/BrickController2/DeviceManagement/MouldKing/MKBaseNibble.cs
@@ -163,6 +163,22 @@ internal abstract class MKBaseNibble : BluetoothAdvertisingDevice
     }
 
     /// <summary>
+    /// Disconnects the device and resets the output state of all channels to zero.
+    /// </summary>
+    /// <remarks>This method ensures that all channels are set to a zero output state during the disconnection
+    /// process. It is intended to be called as part of the device's disconnection workflow.</remarks>
+    protected override void DisconnectDevice()
+    {
+        const float zeroValue = 0.0f;
+
+        for (int channelNo = 0; channelNo < NumberOfChannels; channelNo++)
+        {
+            // call _bluetoothAdvertisingDeviceHandler.SetChannelState() to set global channel state to zero
+            SetChannelOutput(channelNo, zeroValue);
+        }
+    }
+
+    /// <summary>
     /// Attempts to retrieve the RF payload for the specified telegram type.
     /// </summary>
     /// <remarks>This method delegates the retrieval of the RF payload to the underlying platform

--- a/BrickController2/BrickController2/DeviceManagement/MouldKing/MKBaseNibble.cs
+++ b/BrickController2/BrickController2/DeviceManagement/MouldKing/MKBaseNibble.cs
@@ -9,20 +9,14 @@ namespace BrickController2.DeviceManagement.MouldKing;
 internal abstract class MKBaseNibble : BluetoothAdvertisingDevice
 {
     /// <summary>
-    /// Channel types
+    /// offset to position of first channel in base telegram
     /// </summary>
-    protected enum ChannelType
-    {
-        /// <summary>
-        /// channel is analog
-        /// </summary>
-        Analog,
+    private const int CHANNEL_START_OFFSET = 3;
 
-        /// <summary>
-        /// channel can be set to left, off or right
-        /// </summary>
-        Left_Off_Right
-    }
+    /// <summary>
+    /// number of maximal channels in the device type
+    /// </summary>
+    private const int MAX_CHANNEL_BYTES_PER_INSTANCE = 2;
 
     /// <summary>
     /// platform specific MouldKing stuff
@@ -41,24 +35,26 @@ internal abstract class MKBaseNibble : BluetoothAdvertisingDevice
     protected readonly byte[] _telegram_Base;
 
     /// <summary>
-    /// byte offset to first channel in _telegram_base
+    /// Represents an array of functions that process the channel's setvalue and return a tuple
+    /// containing the baseTelegramChannelByteOffset, the channel specific setvalue and a boolean to indicate a zero value.
     /// </summary>
-    protected readonly int _channelStartOffset;
+    protected readonly Func<float, (int, int, (byte, bool))>[] _setChannel;
 
     /// <summary>
-    /// combined low and high nibble of zeroValue
+    /// instance number of specific device type
     /// </summary>
-    protected readonly byte _zeroValueByte;
+    protected readonly int _instanceNo;
 
-    protected MKBaseNibble(string name, string address, byte[] deviceData, IDeviceRepository deviceRepository, IBluetoothLEService bleService, IMKPlatformService mkPlatformService, int channelStartOffset, byte[] telegram_Connect, byte[] telegram_Base)
+    protected MKBaseNibble(string name, string address, byte[] deviceData, IDeviceRepository deviceRepository, IBluetoothLEService bleService, IMKPlatformService mkPlatformService, int instanceNo, byte[] telegram_Connect, byte[] telegram_Base)
         : base(name, address, deviceData, deviceRepository, bleService)
     {
-        _channelStartOffset = channelStartOffset;
         _telegram_Connect = telegram_Connect;
         _telegram_Base = telegram_Base;
         _mkPlatformService = mkPlatformService;
 
-        _zeroValueByte = (byte)((ZeroValueNibble << 4) + ZeroValueNibble); // combined low and high nibble of zeroValue
+        _instanceNo = instanceNo;
+
+        _setChannel = CreateSetChannelList();
     }
 
     /// <summary>
@@ -66,39 +62,6 @@ internal abstract class MKBaseNibble : BluetoothAdvertisingDevice
     /// </summary>
     public override string BatteryVoltageSign => string.Empty;
 
-    /// <summary>
-    /// byte offset to position of first channel in base telegram
-    /// </summary>
-    protected abstract int BaseTelegram_ChannelStartOffset { get; }
-
-    /// <summary>
-    /// number of bytes containing channel values in base telegram
-    /// </summary>
-    protected abstract int BaseTelegram_ChannelBytesCount { get; }
-
-    /// <summary>
-    /// Gets the nibble value that represents zero in the current encoding scheme.
-    /// MK3.8 has 0x09, MK4.0 has 0x08, MK5.0 has 0x00
-    /// </summary>
-    protected abstract byte ZeroValueNibble { get; }
-
-    /// <summary>
-    /// Gets the offset for positive values
-    /// MK3.8 has 0x09, MK4.0 has 0x08, MK5.0 has 0x08
-    /// </summary>
-    protected abstract byte Range_pos_Offset { get; }
-
-    /// <summary>
-    /// Gets the range for positive values
-    /// MK3.8 has 0x06, MK4 has 0x07, MK5 has 0x07
-    /// </summary>
-    protected abstract int Range_pos { get; }
-
-    /// <summary>
-    /// Gets the range for negative values
-    /// MK3.8 has 0x07, MK4 has 0x07, MK5 has 0x07
-    /// </summary>
-    protected abstract int Range_neg { get; }
 
     /// <summary>
     /// Sets the output value for the specified channel.
@@ -109,123 +72,73 @@ internal abstract class MKBaseNibble : BluetoothAdvertisingDevice
     /// <param name="channelNo">The channel number for which the output value is to be set. Must be a valid channel index.</param>
     /// <param name="value">The output value to set. The value is interpreted based on the channel type: negative values, zero, and positive
     /// values may have different effects depending on the channel configuration.</param>
-    /// <exception cref="ArgumentOutOfRangeException">Thrown if the channel type is unknown or unsupported.</exception>
     public override void SetOutput(int channelNo, float value)
     {
         CheckChannel(channelNo);
         value = CutOutputValue(value);
 
-        int channelOffset;
-        ChannelType channelType;
-        SelectChannel(channelNo, out channelOffset, out channelType);
+        (int byteOffset, int specificChannelNo, (byte setValue_nibble, bool zeroSet)) = _setChannel[channelNo](value);
 
-        byte originValue_byte = _telegram_Base[channelOffset];
+        byte originValue_byte = _telegram_Base[byteOffset];
 
+        bool isOdd = (channelNo & 0x01) == 0x01; // is odd
         byte setValue_byte;
-        bool zeroSet;
-
-        switch (channelType)
+        if (isOdd)
         {
-            case ChannelType.Analog:
-                // MK4: ZeroValueNibble = 0x08, ZeroValueOffset = 0x08
-                // value <  0:  7 6 5 4 3 2 1                    range_neg: 0x07
-                // value == 0:                0 8
-                // value >  0:                    9 A B C D E F  range_pos: 0x07
-
-                // MK3.8: ZeroValueNibble = 0x09, ZeroValueOffset = 0x09
-                // value <  0:  7 6 5 4 3 2 1                    range_neg: 0x07
-                // value == 0:                0 9
-                // value >  0:                    A B C D E F    range_pos: 0x06
-
-                // MK5: ZeroValueNibble = 0x00, ZeroValueOffset = 0x08
-                // value <  0:  7 6 5 4 3 2 1                    range_neg: 0x07
-                // value == 0:                0
-                // value >  0:                  9 A B C D E F    range_pos: 0x07
-
-                byte setValue_nibble;
-                if (value < 0)
-                {
-                    float value_abs = Math.Min(0x07, -value * Range_neg);
-                    setValue_nibble = (byte)(0x0F & (byte)value_abs);
-
-                    if (setValue_nibble == 0) // replace zero with ZeroValueNibble
-                    {
-                        setValue_nibble = ZeroValueNibble;
-                        zeroSet = true;
-                    }
-                    else
-                    {
-                        zeroSet = false;
-                    }
-                }
-                else if (value > 0)
-                {
-                    float value_abs = Math.Min(0x0F, (value * Range_pos) + Range_pos_Offset);
-                    setValue_nibble = (byte)(0x0F & (byte)(value_abs));
-                    zeroSet = false;
-                }
-                else
-                {
-                    setValue_nibble = ZeroValueNibble;
-                    zeroSet = true;
-                }
-
-                bool isOdd = (channelNo & 0x01) == 0x01; // is odd
-                if (isOdd)
-                {
-                    setValue_byte = (byte)((originValue_byte & 0xF0) + setValue_nibble);
-                }
-                else
-                {
-                    setValue_byte = (byte)((originValue_byte & 0x0F) + (setValue_nibble << 4));
-                }
-
-                break;
-            case ChannelType.Left_Off_Right:
-
-                if (value < 0)
-                {
-                    setValue_byte = 1;
-                    zeroSet = false;
-                }
-                else if (value > 0)
-                {
-                    setValue_byte = 2;
-                    zeroSet = false;
-                }
-                else
-                {
-                    setValue_byte = 0;
-                    zeroSet = true;
-                }
-
-                break;
-            default:
-                throw new ArgumentOutOfRangeException(nameof(channelType), $"Unknown channel type: {channelType}.");
+            setValue_byte = (byte)((originValue_byte & 0xF0) + setValue_nibble);
         }
-
+        else
+        {
+            setValue_byte = (byte)((originValue_byte & 0x0F) + (setValue_nibble << 4));
+        }
 
         lock (_outputLock)
         {
             // check for change
-            if (_telegram_Base[channelOffset] != setValue_byte)
+            if (_telegram_Base[byteOffset] != setValue_byte)
             {
-                _telegram_Base[channelOffset] = setValue_byte;
+                _telegram_Base[byteOffset] = setValue_byte;
 
-                // Zero was set -> check all channel's values
-                if (zeroSet)
-                {
-                    // notify data changed
-                    _bluetoothAdvertisingDeviceHandler.NotifyDataChanged(CheckAllChannelsZero());
-                }
-                else
-                {
-                    // notify data changed
-                    _bluetoothAdvertisingDeviceHandler.NotifyDataChanged(false);
-                }
+                // notify data changed
+                _bluetoothAdvertisingDeviceHandler.NotifyDataChanged(specificChannelNo, zeroSet);
             }
         }
     }
+
+    /// <summary>
+    /// Creates and returns an array of functions, each corresponding to a channel
+    /// </summary>
+    /// <remarks>Each function in the returned array is specific to a channel and is generated using the <see
+    /// cref="CreateSetChannel"/> method. The number of functions in the array matches the value of <see
+    /// cref="NumberOfChannels"/>.</remarks>
+    /// <returns>An array of functions</returns>
+    protected Func<float, (int, int, (byte, bool))>[] CreateSetChannelList()
+    {
+        Func<float, (int, int, (byte, bool))>[] setChannelList = new Func<float, (int, int, (byte, bool))>[NumberOfChannels];
+
+        for (int channelNo = 0; channelNo < NumberOfChannels; channelNo++)
+        {
+            int byteOffset = GetSpecificChannelByteOffset(channelNo);
+            int specificChannelNo = GetSpecificChannelNumber(channelNo);
+            Func<float, (byte, bool)> createSetChannel = CreateSetChannel(channelNo);
+
+            setChannelList[channelNo] = (float value) => (byteOffset, specificChannelNo, createSetChannel(value));
+        }
+        return setChannelList;
+    }
+
+
+    /// <summary>
+    /// Creates a delegate that sets the value of a specific channel and returns the result as a tuple.
+    /// </summary>
+    /// <remarks>The returned delegate allows dynamic configuration of the specified channel. The exact
+    /// behavior and constraints of the delegate depend on the implementation in derived classes.</remarks>
+    /// <param name="channelNo">The channel number to configure. Must be a valid channel identifier.</param>
+    /// <returns>A function that takes a <see cref="float"/> value as input, representing the channel's desired state, and
+    /// returns a tuple containing a <see cref="byte"/> representing the processed channel value and a <see
+    /// langword="bool"/> indicating whether a zero value was set.</returns>
+    protected abstract Func<float, (byte, bool)> CreateSetChannel(int channelNo);
+
 
     /// <summary>
     /// This method sets the device to initial state before advertising starts
@@ -233,26 +146,12 @@ internal abstract class MKBaseNibble : BluetoothAdvertisingDevice
     /// </summary>
     protected override void InitDevice()
     {
-        // set all channels to zero
-        for (int index = 0; index < BaseTelegram_ChannelBytesCount; index++)
+        for (int channelNo = 0; channelNo < NumberOfChannels; channelNo++)
         {
-            _telegram_Base[BaseTelegram_ChannelStartOffset + index] = _zeroValueByte;
+            _setChannel[channelNo](0); // set all channels to zero using the channel specific function
         }
     }
 
-    /// <summary>
-    /// Selects a channel based on the specified channel number and provides its offset and type.
-    /// </summary>
-    /// <remarks>The method calculates the channel offset based on the provided channel number and assigns a
-    /// default channel type. Override this method in a derived class to customize channel selection behavior.</remarks>
-    /// <param name="channelNo">The number of the channel to select. Must be a non-negative integer.</param>
-    /// <param name="channelOffset">When this method returns, contains the calculated offset for the selected channel.</param>
-    /// <param name="channelType">When this method returns, contains the type of the selected channel.</param>
-    protected virtual void SelectChannel(int channelNo, out int channelOffset, out ChannelType channelType)
-    {
-        channelOffset = _channelStartOffset + (channelNo >> 1); // div 2
-        channelType = ChannelType.Analog;
-    }
 
     /// <summary>
     /// Attempts to retrieve the RF payload for the specified telegram type.
@@ -277,19 +176,28 @@ internal abstract class MKBaseNibble : BluetoothAdvertisingDevice
     }
 
     /// <summary>
-    /// check all channels for zeroValue
+    /// Calculates the byte offset inside the baseTelegram of the DeviceType for the specified channel.
     /// </summary>
-    /// <returns>True if all channel equals zeroValue</returns>
-    protected virtual bool CheckAllChannelsZero()
+    /// <param name="channelNo">The zero-based index of the channel for which to calculate the start offset.</param>
+    /// <returns>The start offset for the specified channel.</returns>
+    private int GetSpecificChannelByteOffset(int channelNo)
     {
-        for (int index = 0; index < BaseTelegram_ChannelBytesCount; index++)
-        {
-            if (_telegram_Base[BaseTelegram_ChannelStartOffset + index] != _zeroValueByte)
-            {
-                return false;
-            }
-        }
+        // instance 0: 3..4
+        // instance 1: 5..6
+        // instance 2: 7..8
+        return CHANNEL_START_OFFSET + _instanceNo * MAX_CHANNEL_BYTES_PER_INSTANCE + (channelNo >> 1); // div 2, 2 channels per byte
+    }
 
-        return true;
+    /// <summary>
+    /// Calculates the channel number inside the DeviceType for the specified channel.
+    /// </summary>
+    /// <param name="channelNo">The zero-based index of the channel for which to calculate the DeviceType specific channel number.</param>
+    /// <returns>The DeviceType specific channel number for the specified channel.</returns>
+    private int GetSpecificChannelNumber(int channelNo)
+    {
+        // instance 0: 0..3
+        // instance 1: 4..7
+        // instance 2: 8..11
+        return _instanceNo * NumberOfChannels + channelNo;
     }
 }

--- a/BrickController2/BrickController2/DeviceManagement/MouldKing/MKBaseNibble.cs
+++ b/BrickController2/BrickController2/DeviceManagement/MouldKing/MKBaseNibble.cs
@@ -1,5 +1,6 @@
-﻿using System;
-using BrickController2.PlatformServices.BluetoothLE;
+﻿using BrickController2.PlatformServices.BluetoothLE;
+using Newtonsoft.Json.Linq;
+using System;
 
 namespace BrickController2.DeviceManagement.MouldKing;
 
@@ -203,9 +204,12 @@ internal abstract class MKBaseNibble : BluetoothAdvertisingDevice
     /// </summary>
     protected override void InitDevice()
     {
+        const float zeroValue = 0.0f;
+
         for (int channelNo = 0; channelNo < NumberOfChannels; channelNo++)
         {
-            _setChannel[channelNo](0); // set all channels to zero using the channel specific function
+            _storedValues[channelNo] = zeroValue;   // restore stored values to zero
+            _setChannel[channelNo](zeroValue);      // set all channels to zero using the channel specific function
         }
     }
 

--- a/BrickController2/BrickController2/DeviceManagement/MouldKing/MKBaseNibble.cs
+++ b/BrickController2/BrickController2/DeviceManagement/MouldKing/MKBaseNibble.cs
@@ -152,9 +152,7 @@ internal abstract class MKBaseNibble : BluetoothAdvertisingDevice
 
         for (int channelNo = 0; channelNo < NumberOfChannels; channelNo++)
         {
-            (int realChannelNo, Func<float, (byte, bool)> handler) setChannelHandler = CreateChannelHandler(channelNo);
-
-            int realChannelNo = setChannelHandler.Item1;
+            var (realChannelNo, handler) = CreateChannelHandler(channelNo);
 
             // virtual channel
             if (realChannelNo == VIRTUALCHANNEL)
@@ -162,7 +160,7 @@ internal abstract class MKBaseNibble : BluetoothAdvertisingDevice
                 setChannelList[channelNo] = (float value) =>
                 {
                     // virtual channel handlers return isModified insted of zeroSet
-                    (byte a, bool isModified) = setChannelHandler.Item2(value);
+                    (byte a, bool isModified) = handler(value);
 
                     return isModified;
                 };
@@ -176,7 +174,7 @@ internal abstract class MKBaseNibble : BluetoothAdvertisingDevice
 
                 setChannelList[channelNo] = (float value) =>
                 {
-                    (byte setValue_nibble, bool zeroSet) = setChannelHandler.Item2(value);
+                    (byte setValue_nibble, bool zeroSet) = handler(value);
 
                     _bluetoothAdvertisingDeviceHandler.SetChannelState(specificChannelNo, zeroSet); // set global channel state
                     return SetChannelValue(byteOffset, isOdd, setValue_nibble);

--- a/BrickController2/BrickController2/UI/Controls/DeviceChannelLabel.cs
+++ b/BrickController2/BrickController2/UI/Controls/DeviceChannelLabel.cs
@@ -12,7 +12,7 @@ namespace BrickController2.UI.Controls
         private readonly static string[] _pfxBricks = ["A", "B", "1", "2", "3", "4", "5", "6", "7", "8"];
         private readonly static string[] _circuitCubesChannelLetters = new[] { "A", "B", "C" };
         private readonly static string[] _buwizz3ChannelLetters = new[] { "1", "2", "3", "4", "A", "B" };
-        private readonly static string[] _mk5ChannelLetters = ["AB", "C", "M", "AB+C"];
+        private readonly static string[] _mk5ChannelLetters = ["AB", "T", "C", "AB+T", "TL"];
         private readonly static string[] _mk6ChannelLetters = new[] { "A", "B", "C", "D", "E", "F" };
 
         public static readonly BindableProperty DeviceTypeProperty = BindableProperty.Create(nameof(DeviceType), typeof(DeviceType), typeof(DeviceChannelLabel), default(DeviceType), BindingMode.OneWay, null, OnDeviceChanged);

--- a/BrickController2/BrickController2/UI/Controls/DeviceChannelSelector.xaml
+++ b/BrickController2/BrickController2/UI/Controls/DeviceChannelSelector.xaml
@@ -304,7 +304,10 @@
                     <controls:ChannelSelectorRadioButton x:Name="MK5Channel0" DeviceType="MK5" Channel="0" HorizontalOptions="End" VerticalOptions="End"/>
                 </Grid>
 
-                <Image Grid.Column="1" Source="{extensions:ImageResource Source=mk5_image.png}" WidthRequest="150" HeightRequest="112"/>
+                <Grid Grid.Column="1">
+                    <Image Source="{extensions:ImageResource Source=mk5_image.png}" WidthRequest="150" HeightRequest="112"/>
+                    <controls:ChannelSelectorRadioButton x:Name="MK5Channel4" DeviceType="MK5" Channel="4" HorizontalOptions="Center" VerticalOptions="End" />
+                </Grid>
 
                 <Grid Grid.Column="2">
                     <controls:ChannelSelectorRadioButton x:Name="MK5Channel1" DeviceType="MK5" Channel="1" HorizontalOptions="Start" VerticalOptions="Start"/>

--- a/BrickController2/BrickController2/UI/Controls/DeviceChannelSelector.xaml.cs
+++ b/BrickController2/BrickController2/UI/Controls/DeviceChannelSelector.xaml.cs
@@ -73,6 +73,7 @@ namespace BrickController2.UI.Controls
             MK5Channel1.Command = new SafeCommand(() => SelectedChannel = 1);
             MK5Channel2.Command = new SafeCommand(() => SelectedChannel = 2);
             MK5Channel3.Command = new SafeCommand(() => SelectedChannel = 3);
+            MK5Channel4.Command = new SafeCommand(() => SelectedChannel = 4);
             MK6Channel0.Command = new SafeCommand(() => SelectedChannel = 0);
             MK6Channel1.Command = new SafeCommand(() => SelectedChannel = 1);
             MK6Channel2.Command = new SafeCommand(() => SelectedChannel = 2);
@@ -194,6 +195,7 @@ namespace BrickController2.UI.Controls
                 dcs.MK5Channel1.SelectedChannel = selectedChannel;
                 dcs.MK5Channel2.SelectedChannel = selectedChannel;
                 dcs.MK5Channel3.SelectedChannel = selectedChannel;
+                dcs.MK5Channel4.SelectedChannel = selectedChannel;
                 dcs.MK6Channel0.SelectedChannel = selectedChannel;
                 dcs.MK6Channel1.SelectedChannel = selectedChannel;
                 dcs.MK6Channel2.SelectedChannel = selectedChannel;


### PR DESCRIPTION
Please have a look...

Now different channel types are possible.
I.e. the "shot canon" function of the tank on MK5.Channel3 is handled diffently then the other channels.
The virtual MK5.Channel5 handles the "turret lock option".

```
protected override (int, Func<float, (byte, bool)>) CreateChannelHandler(int channelNo)
    {
        return channelNo switch
        {
            0 => (0, SetOutput_AnalogChannel),                    // Tracks A + B forward, backward
            1 => (1, SetOutput_AnalogChannel_Turret),             // Turret rotation
            2 => (2, SetOutput_Shot),                             // shot canon
            3 => (3, SetOutput_AnalogChannel),                    // turn on spot
            4 => (VIRTUALCHANNEL, SetOutput_Option_Turret_Lock),  // virtual channel: lock turret
            _ => throw new ArgumentException("Illegal Argument", nameof(channelNo))
        };
    }
```