### PR TITLE
Typo: "Warining" -> "Warning"

### DIFF
--- a/BrickController2/BrickController2/UI/ViewModels/SequenceEditorPageViewModel.cs
+++ b/BrickController2/BrickController2/UI/ViewModels/SequenceEditorPageViewModel.cs
@@ -163,7 +163,7 @@ namespace BrickController2.UI.ViewModels
                     if (intValue < 300 || 10000 < intValue)
                     {
                         await _dialogService.ShowMessageBoxAsync(
-                            Translate("Warining"),
+                            Translate("Warning"),
                             Translate("ValueOutOfRange"),
                             Translate("Ok"),
                             DisappearingToken);


### PR DESCRIPTION
Fix for a little typo