### PR TITLE
BrickController Legacy & IOS build

### DIFF
--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - default
-      - 'releases/**'
+      - 'release/**'
     paths:
       - '.github/**/*android.yml'
       - 'BrickController2/*.props'
@@ -14,7 +14,7 @@ on:
   pull_request:
     branches:    
       - default
-      - 'releases/**'
+      - 'release/**'
     paths:
       - '.github/**/*android.yml'
       - 'BrickController2/*.props'

--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -76,15 +76,15 @@ jobs:
       uses: actions/upload-artifact@v4
       with:
         name: brickcontroller-android-ci-build
-        path: BrickController2/BrickController2.Android/bin/Release/net9.0-android/com.scn.BrickController2-Signed.apk
+        path: BrickController2/BrickController2.Android/bin/Release/net9.0-android/cz.vico.BrickControllerLegacy-Signed.apk
 
     - name: Upload Artifact to Release
       if: github.event_name == 'release' && github.event.action == 'published'
       uses: actions/upload-release-asset@v1
       with:
         upload_url: ${{ fromJson(steps.get_release.outputs.data).upload_url }}
-        asset_path: BrickController2/BrickController2.Android/bin/Release/net9.0-android/com.scn.BrickController2-Signed.apk
-        asset_name: BrickController2_${{env.APP_DISPLAY_VERSION}}.apk
+        asset_path: BrickController2/BrickController2.Android/bin/Release/net9.0-android/cz.vico.BrickControllerLegacy-Signed.apk
+        asset_name: BrickControllerLegacy_${{env.APP_DISPLAY_VERSION}}.apk
         asset_content_type: application/vnd.android.package-archive
       env:
         GITHUB_TOKEN: ${{ secrets.CI_RELEASE_ASSETS_PAT }}

--- a/.github/workflows/build-core.yml
+++ b/.github/workflows/build-core.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - default
-      - 'releases/**'
+      - 'release/**'
     paths:
       - '.github/**/*core.yml'
       - 'BrickController2/*.props'
@@ -14,7 +14,7 @@ on:
   pull_request:
     branches:    
       - default
-      - 'releases/**'
+      - 'release/**'
     paths:
       - '.github/**/*core.yml'
       - 'BrickController2/*.props'

--- a/.github/workflows/build-ios.yml
+++ b/.github/workflows/build-ios.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - default
-      - 'releases/**'
+      - 'release/**'
     paths:
       - '.github/**/*ios.yml'
       - 'BrickController2/*.props'
@@ -14,7 +14,7 @@ on:
   pull_request:
     branches:    
       - default
-      - 'releases/**'
+      - 'release/**'
     paths:
       - '.github/**/*ios.yml'
       - 'BrickController2/*.props'

--- a/.github/workflows/build-ios.yml
+++ b/.github/workflows/build-ios.yml
@@ -1,0 +1,125 @@
+name: Build BrickController iOS 
+
+on:
+  push:
+    branches:
+      - default
+      - 'releases/**'
+    paths:
+      - '.github/**/*ios.yml'
+      - 'BrickController2/*.props'
+      - 'BrickController2/*.sln'
+      - 'BrickController2/BrickController2/**'
+      - 'BrickController2/BrickController2.iOS/**'
+  pull_request:
+    branches:    
+      - default
+      - 'releases/**'
+    paths:
+      - '.github/**/*ios.yml'
+      - 'BrickController2/*.props'
+      - 'BrickController2/*.sln'
+      - 'BrickController2/BrickController2/**'
+      - 'BrickController2/BrickController2.iOS/**'
+  release:
+    types:
+      - published
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  build-ios:
+    runs-on: macos-15
+    name: BrickController iOS Build
+    env:
+      APP_DISPLAY_VERSION: ""
+    steps:
+    - uses: actions/checkout@v4
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: 9.0.x
+
+    # fix error with missing XCode 16.4
+    - name: Select Xcode 16.4
+      run: sudo xcode-select -s /Applications/Xcode_16.4.app/Contents/Developer
+        
+    - name: Install MAUI workload
+      run: dotnet workload install maui
+
+    - name: Find Current Release Info
+      if: github.event_name == 'release' && github.event.action == 'published'
+      id: get_release
+      uses: octokit/request-action@v2.x
+      with:
+        route: GET /repos/${{ github.repository }}/releases/tags/${{ github.event.release.tag_name }}
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Set APP_DISPLAY_VERSION for release
+      if: github.event_name == 'release' && github.event.action == 'published'
+      shell: bash 
+      run: echo "APP_DISPLAY_VERSION=$(echo '${{ fromJson(steps.get_release.outputs.data).tag_name }}')" >> $GITHUB_ENV
+
+    - name: Import Code-Signing Certificates
+      uses: Apple-Actions/import-codesign-certs@v1
+      with:
+        p12-file-base64: ${{ secrets.APPLE_SIGNING_CERTIFICATE_BASE64 }}
+        p12-password: ${{ secrets.APPLE_SIGNING_CERTIFICATE_PASSWORD }}
+
+    - name: Download Apple Provisioning Profiles
+      uses: Apple-Actions/download-provisioning-profiles@v1
+      with:
+        bundle-id: 'cz.vico.brickcontrollerlegacy'
+        issuer-id: ${{ secrets.APPSTORE_ISSUER_ID }}
+        api-key-id: ${{ secrets.APPSTORE_KEY_ID }}
+        api-private-key: ${{ secrets.APPSTORE_PRIVATE_KEY }}
+
+    - name: List Keychain Certificates
+      run: security find-identity -v -p codesigning
+            
+    - name: Restore Dependencies
+      run: dotnet restore BrickController2/BrickController2.iOS/BrickController2.iOS.csproj
+    - name: Build MAUI iOS
+      run: >-
+        dotnet publish BrickController2/BrickController2.iOS/BrickController2.iOS.csproj
+        --no-restore
+        -c Release
+        -f net9.0-iOS
+        -p:ArchiveOnBuild=true
+        -p:EnableAssemblyILStripping=false
+        -p:CodesignKey="iPhone Distribution"
+        -p:CodesignProvision=Automatic
+        -p:ApplicationDisplayVersion="${{ env.APP_DISPLAY_VERSION }}"
+
+    - name: List build output
+      run: ls -R BrickController2/BrickController2.iOS/bin/Release/net9.0-ios/ios-arm64/publish/
+
+    - name: Upload IOS Artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: brickcontroller-ios-ci-build
+        path: BrickController2/BrickController2.iOS/bin/Release/net9.0-ios/ios-arm64/publish/BrickController2.iOS.ipa
+
+    - name: Upload Artifact to Release
+      if: github.event_name == 'release' && github.event.action == 'published'
+      uses: actions/upload-release-asset@v1
+      with:
+        upload_url: ${{ fromJson(steps.get_release.outputs.data).upload_url }}
+        asset_path: BrickController2/BrickController2.iOS/bin/Release/net9.0-ios/ios-arm64/publish/BrickController2.iOS.ipa
+        asset_name: BrickControllerLegacy_${{env.APP_DISPLAY_VERSION}}.ipa
+        asset_content_type: application/vnd.android.package-archive
+      env:
+        GITHUB_TOKEN: ${{ secrets.CI_RELEASE_ASSETS_PAT }}
+
+    - name: Upload app to TestFlight
+      if: github.event_name == 'release' && github.event.action == 'published'
+      uses: Apple-Actions/upload-testflight-build@v1
+      with:
+        app-path: 'BrickController2/BrickController2.iOS/bin/Release/net9.0-ios/ios-arm64/publish/BrickController2.iOS.ipa'
+        issuer-id: ${{ secrets.APPSTORE_ISSUER_ID }}
+        api-key-id: ${{ secrets.APPSTORE_KEY_ID }}
+        api-private-key: ${{ secrets.APPSTORE_PRIVATE_KEY }}
+

--- a/.github/workflows/build-ios.yml
+++ b/.github/workflows/build-ios.yml
@@ -110,7 +110,7 @@ jobs:
         upload_url: ${{ fromJson(steps.get_release.outputs.data).upload_url }}
         asset_path: BrickController2/BrickController2.iOS/bin/Release/net9.0-ios/ios-arm64/publish/BrickController2.iOS.ipa
         asset_name: BrickControllerLegacy_${{env.APP_DISPLAY_VERSION}}.ipa
-        asset_content_type: application/vnd.android.package-archive
+        asset_content_type: application/octet-stream
       env:
         GITHUB_TOKEN: ${{ secrets.CI_RELEASE_ASSETS_PAT }}
 

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - default
-      - 'releases/**'
+      - 'release/**'
     paths:
       - '.github/**/*windows.yml'
       - 'BrickController2/*.props'
@@ -14,7 +14,7 @@ on:
   pull_request:
     branches:    
       - default
-      - 'releases/**'
+      - 'release/**'
     paths:
       - '.github/**/*windows.yml'
       - 'BrickController2/*.props'

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -110,7 +110,7 @@ jobs:
       with:
         upload_url: ${{ fromJson(steps.get_release.outputs.data).upload_url }}
         asset_path: BrickController2\BrickController2.WinUI\bin\x64\Release\net9.0-windows10.0.19041.0\win10-x64\AppPackages\BrickController2.WinUI_${{env.APP_PACKAGE_VERSION}}_Test\BrickController2.WinUI_${{env.APP_PACKAGE_VERSION}}_x64.msix
-        asset_name: BrickController2_${{env.APP_DISPLAY_VERSION}}.msix
+        asset_name: BrickControllerLegacy_${{env.APP_DISPLAY_VERSION}}.msix
         asset_content_type: application/vnd.ms-appx
       env:
         GITHUB_TOKEN: ${{ secrets.CI_RELEASE_ASSETS_PAT }}

--- a/BrickController2/BrickController2.Android/BrickController2.Android.csproj
+++ b/BrickController2/BrickController2.Android/BrickController2.Android.csproj
@@ -3,10 +3,11 @@
 
 	<PropertyGroup>
 		<TargetFrameworks>net9.0-android</TargetFrameworks>
-    <SupportedOSPlatformVersion>23.0</SupportedOSPlatformVersion>
-    <TargetPlatformVersion>35.0</TargetPlatformVersion>
-    <OutputType>Exe</OutputType>
+		<SupportedOSPlatformVersion>23.0</SupportedOSPlatformVersion>
+		<TargetPlatformVersion>35.0</TargetPlatformVersion>
+		<OutputType>Exe</OutputType>
 		<RootNamespace>BrickController2.Droid</RootNamespace>
+		<AssemblyName>BrickController Legacy</AssemblyName>
 		<GenerateAssemblyInfo>true</GenerateAssemblyInfo>
 		<AndroidResgenClass>Resource</AndroidResgenClass>
 		<AndroidKeyStore>false</AndroidKeyStore>

--- a/BrickController2/BrickController2.Android/MainActivity.cs
+++ b/BrickController2/BrickController2.Android/MainActivity.cs
@@ -15,7 +15,7 @@ using static BrickController2.PlatformServices.GameController.GameControllers;
 namespace BrickController2.Droid
 {
     [Activity(
-        Label = "BrickController2",
+        Label = "BrickControllerLegacy",
         Icon = "@mipmap/ic_launcher",
         Theme = "@style/MainTheme",
         MainLauncher = true,

--- a/BrickController2/BrickController2.Android/Properties/AndroidManifest.xml
+++ b/BrickController2/BrickController2.Android/Properties/AndroidManifest.xml
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android" package="com.scn.BrickController2" android:installLocation="auto">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" package="cz.vico.brickcontrollerlegacy" android:installLocation="auto">
 	<!--<uses-sdk android:targetSdkVersion="34" android:minSdkVersion="21" />-->
 	<uses-permission android:name="android.permission.BLUETOOTH" android:maxSdkVersion="30" />
 	<uses-permission android:name="android.permission.BLUETOOTH_ADMIN" android:maxSdkVersion="30" />
@@ -14,5 +14,5 @@
 	<uses-permission android:name="android.permission.BLUETOOTH_ADVERTISE" />
 	<uses-feature android:name="android.hardware.bluetooth" android:required="true" />
 	<uses-feature android:name="android.hardware.bluetooth_le" android:required="true" />
-	<application android:label="BrickController2.Android" android:icon="@mipmap/ic_launcher"></application>
+	<application android:label="BrickController Legacy" android:icon="@mipmap/ic_launcher"></application>
 </manifest>

--- a/BrickController2/BrickController2.WinUI/Package.appxmanifest
+++ b/BrickController2/BrickController2.WinUI/Package.appxmanifest
@@ -28,7 +28,7 @@
   <Applications>
     <Application Id="App" Executable="$targetnametoken$.exe" EntryPoint="$targetentrypoint$">
       <uap:VisualElements
-        DisplayName="BrickController2"
+        DisplayName="BrickController Legacy"
         Square150x150Logo="Assets\Square150x150Logo.png"
         Square44x44Logo="Assets\Square44x44Logo.png"
         Description="Windows application for controlling Lego creations using a bluetooth gamepad."

--- a/BrickController2/BrickController2.WinUI/Properties/AssemblyInfo.cs
+++ b/BrickController2/BrickController2.WinUI/Properties/AssemblyInfo.cs
@@ -3,10 +3,10 @@
 // General Information about an assembly is controlled through the following 
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
-[assembly: AssemblyTitle("BrickController2")]
+[assembly: AssemblyTitle("BrickController Legacy")]
 [assembly: AssemblyDescription("Cross platform mobile application for controlling Lego creations using a bluetooth gamepad.")]
-[assembly: AssemblyProduct("BrickController2")]
-[assembly: AssemblyCopyright("Copyright © 2024")]
+[assembly: AssemblyProduct("BrickControllerLegacy")]
+[assembly: AssemblyCopyright("Copyright © 2025")]
 
 // Version information for an assembly consists of the following four values:
 //

--- a/BrickController2/BrickController2.iOS/BrickController2.iOS.csproj
+++ b/BrickController2/BrickController2.iOS/BrickController2.iOS.csproj
@@ -6,7 +6,7 @@
     <RuntimeIdentifier>ios-arm64</RuntimeIdentifier>
 		<SupportedOSPlatformVersion>12.2</SupportedOSPlatformVersion>
     <OutputType>Exe</OutputType>
-		<ApplicationId>com.scn.BrickController2</ApplicationId>
+		<ApplicationId>cz.vico.brickcontrollerlegacy</ApplicationId>
 		<RootNamespace>BrickController2.iOS</RootNamespace>
     <GenerateAssemblyInfo>true</GenerateAssemblyInfo>
   </PropertyGroup>

--- a/BrickController2/BrickController2.iOS/Info.plist
+++ b/BrickController2/BrickController2.iOS/Info.plist
@@ -23,11 +23,11 @@
 	<key>MinimumOSVersion</key>
 	<string>12.2</string>
 	<key>CFBundleDisplayName</key>
-	<string>BrickController2</string>
+	<string>BrickController Legacy</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.scn.brickcontroller2</string>
+	<string>cz.vico.brickcontrollerlegacy</string>
 	<key>CFBundleName</key>
-	<string>BrickController2</string>
+	<string>BrickControllerLegacy</string>
 	<key>NSBluetoothPeripheralUsageDescription</key>
 	<string>Bluetooth access is required to use SBrick, BuWizz or Powered-Up devices.</string>
 	<key>NSCalendarsUsageDescription</key>
@@ -43,7 +43,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>3.4</string>
 	<key>CFBundleVersion</key>
-	<string>50</string>
+	<string>51</string>
 	<key>NSBluetoothAlwaysUsageDescription</key>
 	<string>Bluetooth access is required to use SBrick, BuWizz or Powered-Up devices.</string>
 	<key>NSContactsUsageDescription</key>

--- a/BrickController2/BrickController2/UI/Pages/AboutPage.xaml
+++ b/BrickController2/BrickController2/UI/Pages/AboutPage.xaml
@@ -19,7 +19,8 @@
                 <ScrollView>
                     <VerticalStackLayout Padding="20" Spacing="6">
 
-                        <Label Text="BrickController 2" FontSize="Medium" FontAttributes="Bold"/>
+                        <Label Text="BrickController Legacy" FontSize="Medium" FontAttributes="Bold"/>
+                        <Label Text="A fork of BrickController 2"/>
 
                         <HorizontalStackLayout Spacing="6">
                             <Label Text="{extensions:Translate Version}  "/>
@@ -28,7 +29,8 @@
 
                         <BoxView Style="{StaticResource DividerBoxViewStyle}" Margin="6,16,6,16"/>
 
-                        <Label Text="Copyright © 2025, István Murvai (SCN)"/>
+                        <Label Text="Copyright © 2025"/>
+                        <Label Text="István Murvai (SCN), Vít Německý (Vico)"/>
 
                         <BoxView Style="{StaticResource DividerBoxViewStyle}" Margin="6,16,6,16"/>
 
@@ -47,7 +49,7 @@
                         <BoxView Style="{StaticResource DividerBoxViewStyle}" Margin="6,16,6,16"/>
 
                         <Label Text="{extensions:Translate Disclaimer}" FontAttributes="Bold"/>
-                        <Label Text="LEGO® is a trademark of the LEGO Group of companies which does not sponsor, authorize or endorse this application" FontSize="Small"/>
+                        <Label Text="LEGO® is a trademark of the LEGO Group of companies which does not sponsor, authorize or endorse this application." FontSize="Small"/>
 
                     </VerticalStackLayout>
                 </ScrollView>

--- a/BrickController2/BrickController2/UI/ViewModels/ControllerActionPageViewModel.cs
+++ b/BrickController2/BrickController2/UI/ViewModels/ControllerActionPageViewModel.cs
@@ -60,7 +60,7 @@ namespace BrickController2.UI.ViewModels
             }
             else
             {
-                var lastSelectedDeviceId = _preferences.Get<string>("LastSelectedDeviceId", string.Empty, "com.scn.BrickController2.ControllerActionPage");
+                var lastSelectedDeviceId = _preferences.Get<string>("LastSelectedDeviceId", string.Empty, "ControllerActionPage");
                 SelectedDevice = _deviceManager.GetDeviceById(lastSelectedDeviceId) ?? _deviceManager.Devices.FirstOrDefault();
                 Action.Channel = 0;
                 Action.IsInvert = false;
@@ -136,7 +136,7 @@ namespace BrickController2.UI.ViewModels
 
         public override void OnDisappearing()
         {
-            _preferences.Set<string>("LastSelectedDeviceId", _selectedDevice!.Id, "com.scn.BrickController2.ControllerActionPage");
+            _preferences.Set<string>("LastSelectedDeviceId", _selectedDevice!.Id, "ControllerActionPage");
 
             base.OnDisappearing();
         }

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -20,7 +20,7 @@
   </PropertyGroup>
   <!--App information-->
   <PropertyGroup>
-    <ApplicationDisplayVersion>3.4</ApplicationDisplayVersion>
-    <ApplicationVersion>50</ApplicationVersion>
+    <ApplicationDisplayVersion>3.4.2505</ApplicationDisplayVersion>
+    <ApplicationVersion>51</ApplicationVersion>
   </PropertyGroup>
 </Project>

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
-# BrickController 2
+# BrickController Legacy
 
-Cross platform mobile application for controlling your creations using a bluetooth gamepad.
+Cross-platform application, forked from [BrickController 2](https://github.com/imurvai/brickcontroller2), for controlling LEGO® and compatible brick creations using a Bluetooth gamepad.
+
+This app lets you control your motorized builds — whether made from LEGO® or other compatible brick systems—using a standard Bluetooth game controller.
 
 ## Supported platforms
 
@@ -32,7 +34,7 @@ Cross platform mobile application for controlling your creations using a bluetoo
 
 ## Project details
 
-BrickController 2 is a MAUI application and can be compiled using Visual Studio 2022 (Professional, Enterprise and Community Editions)
+BrickController Legacy is a MAUI application and can be compiled using Visual Studio 2022 (Professional, Enterprise and Community Editions)
 or Visual Studio for Mac.
 
 ## 3rd party libraries used


### PR DESCRIPTION
Rebranding to BrickController Legacy so as it can be (hopefully) published to app stores. Addtionally there is workflow for IOS builds.