### PR TITLE
Unify release app versioning + fix IOS builds: XCODE 26

### DIFF
--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -44,9 +44,7 @@ jobs:
 
     - name: Get App Version from Build Properties
       shell: bash
-      run: |
-        APP_VERSION=$(sed -n 's|.*<ApplicationDisplayVersion>\(.*\)</ApplicationDisplayVersion>.*|\1|p' Directory.Build.props)
-        echo "Found version: $APP_VERSION"
+      run: echo "APP_VERSION=$(sed -n 's|.*<ApplicationDisplayVersion>\(.*\)</ApplicationDisplayVersion>.*|\1|p' Directory.Build.props)" >> $GITHUB_ENV
 
     - name: Find Current Release Info
       if: github.event_name == 'release' && github.event.action == 'published'

--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -45,8 +45,7 @@ jobs:
     - name: Get App Version from Build Properties
       shell: bash
       run: |
-        # Extract ApplicationDisplayVersion from Directory.Build.props using grep and sed
-        APP_VERSION=$(grep -oP '<ApplicationDisplayVersion>\K[^<]*' Directory.Build.props)
+        APP_VERSION=$(sed -n 's|.*<ApplicationDisplayVersion>\(.*\)</ApplicationDisplayVersion>.*|\1|p' Directory.Build.props)
         echo "Found version: $APP_VERSION"
 
     - name: Find Current Release Info

--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -33,8 +33,6 @@ jobs:
   build-android:
     runs-on: windows-2025
     name: BrickController Android Build
-    env:
-      APP_DISPLAY_VERSION: ""
 
     steps:
 
@@ -43,6 +41,13 @@ jobs:
       uses: actions/setup-dotnet@v4
       with:
         dotnet-version: 9.0.x
+
+    - name: Get App Version from Build Properties
+      shell: bash
+      run: |
+        # Extract ApplicationDisplayVersion from Directory.Build.props using grep and sed
+        APP_VERSION=$(grep -oP '<ApplicationDisplayVersion>\K[^<]*' Directory.Build.props)
+        echo "Found version: $APP_VERSION"
 
     - name: Find Current Release Info
       if: github.event_name == 'release' && github.event.action == 'published'
@@ -53,11 +58,6 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-    - name: Set APP_DISPLAY_VERSION for release
-      if: github.event_name == 'release' && github.event.action == 'published'
-      shell: bash 
-      run: echo "APP_DISPLAY_VERSION=$(echo '${{ fromJson(steps.get_release.outputs.data).tag_name }}')" >> $GITHUB_ENV
-            
     - name: Restore Dependencies
       run: dotnet restore BrickController2/BrickController2.Android/BrickController2.Android.csproj
     - name: Setup Android signing 
@@ -68,18 +68,18 @@ jobs:
         -c Release `
         -f net9.0-android `
         --no-restore `
-        -p:ApplicationDisplayVersion="${{ env.APP_DISPLAY_VERSION }}" `
+        -p:ApplicationVersion="${{ github.run_number }}" `
         -p:AndroidSigningKeyPass=${{secrets.KEYSTORE_PASSWORD}} `
         -p:AndroidSigningStorePass=${{secrets.KEYSTORE_PASSWORD}} `
         -p:AndroidPackageFormat=apk
 
-    - name: Build MAUI Android (AAB)
+    - name: Build MAUI Android (AAB) for Release
       if: github.event_name == 'release' && github.event.action == 'published'  
       run: dotnet publish BrickController2/BrickController2.Android/BrickController2.Android.csproj `
         -c Release `
         -f net9.0-android `
         --no-restore `
-        -p:ApplicationDisplayVersion="${{ env.APP_DISPLAY_VERSION }}" `
+        -p:ApplicationVersion="${{ github.run_number }}" `
         -p:AndroidSigningKeyPass=${{secrets.KEYSTORE_PASSWORD}} `
         -p:AndroidSigningStorePass=${{secrets.KEYSTORE_PASSWORD}} `
         -p:AndroidPackageFormat=aab
@@ -96,7 +96,7 @@ jobs:
       with:
         upload_url: ${{ fromJson(steps.get_release.outputs.data).upload_url }}
         asset_path: BrickController2/BrickController2.Android/bin/Release/net9.0-android/cz.vico.BrickControllerLegacy-Signed.apk
-        asset_name: BrickControllerLegacy_${{env.APP_DISPLAY_VERSION}}.apk
+        asset_name: BrickControllerLegacy_${{env.APP_VERSION}}.apk
         asset_content_type: application/vnd.android.package-archive
       env:
         GITHUB_TOKEN: ${{ secrets.CI_RELEASE_ASSETS_PAT }}
@@ -107,7 +107,7 @@ jobs:
       with:
         upload_url: ${{ fromJson(steps.get_release.outputs.data).upload_url }}
         asset_path: BrickController2/BrickController2.Android/bin/Release/net9.0-android/cz.vico.BrickControllerLegacy-Signed.aab
-        asset_name: BrickControllerLegacy_${{env.APP_DISPLAY_VERSION}}.aab
+        asset_name: BrickControllerLegacy_${{env.APP_VERSION}}.aab
         asset_content_type: application/x-authorware-bin
       env:
         GITHUB_TOKEN: ${{ secrets.CI_RELEASE_ASSETS_PAT }}

--- a/.github/workflows/build-ios.yml
+++ b/.github/workflows/build-ios.yml
@@ -42,7 +42,7 @@ jobs:
       with:
         dotnet-version: 9.0.x
 
-    # fix error with missing XCode 16.4
+    # fix error with missing XCode 26
     - name: Select Xcode 16.4
       run: sudo xcode-select -s /Applications/Xcode_16.4.app/Contents/Developer
         

--- a/.github/workflows/build-ios.yml
+++ b/.github/workflows/build-ios.yml
@@ -42,9 +42,9 @@ jobs:
       with:
         dotnet-version: 9.0.x
 
-    # fix error with missing XCode 26
-    - name: Select Xcode 16.4
-      run: sudo xcode-select -s /Applications/Xcode_16.4.app/Contents/Developer
+    # # fix error with missing XCode 26
+    # - name: Select Xcode 16.4
+    #   run: sudo xcode-select -s /Applications/Xcode_16.4.app/Contents/Developer
         
     - name: Install MAUI workload
       run: dotnet workload install maui

--- a/.github/workflows/build-ios.yml
+++ b/.github/workflows/build-ios.yml
@@ -47,8 +47,7 @@ jobs:
     - name: Get App Version from Build Properties
       shell: bash
       run: |
-        # Extract ApplicationDisplayVersion from Directory.Build.props using grep and sed
-        APP_VERSION=$(grep -oP '<ApplicationDisplayVersion>\K[^<]*' Directory.Build.props)
+        APP_VERSION=$(sed -n 's|.*<ApplicationDisplayVersion>\(.*\)</ApplicationDisplayVersion>.*|\1|p' Directory.Build.props)
         echo "Found version: $APP_VERSION"
 
     - name: Find Current Release Info

--- a/.github/workflows/build-ios.yml
+++ b/.github/workflows/build-ios.yml
@@ -42,9 +42,9 @@ jobs:
       with:
         dotnet-version: 9.0.x
 
-    # # fix error with missing XCode 26
-    # - name: Select Xcode 16.4
-    #   run: sudo xcode-select -s /Applications/Xcode_16.4.app/Contents/Developer
+    # fix error with missing XCode 26
+    - name: Select Xcode 26
+      run: sudo xcode-select -s /Applications/Xcode_26.app/Contents/Developer
         
     - name: Install MAUI workload
       run: dotnet workload install maui

--- a/.github/workflows/build-ios.yml
+++ b/.github/workflows/build-ios.yml
@@ -46,9 +46,7 @@ jobs:
 
     - name: Get App Version from Build Properties
       shell: bash
-      run: |
-        APP_VERSION=$(sed -n 's|.*<ApplicationDisplayVersion>\(.*\)</ApplicationDisplayVersion>.*|\1|p' Directory.Build.props)
-        echo "Found version: $APP_VERSION"
+      run: echo "APP_VERSION=$(sed -n 's|.*<ApplicationDisplayVersion>\(.*\)</ApplicationDisplayVersion>.*|\1|p' Directory.Build.props)" >> $GITHUB_ENV
 
     - name: Find Current Release Info
       if: github.event_name == 'release' && github.event.action == 'published'

--- a/.github/workflows/build-ios.yml
+++ b/.github/workflows/build-ios.yml
@@ -33,21 +33,23 @@ jobs:
   build-ios:
     runs-on: macos-26
     name: BrickController iOS Build
-    env:
-      APP_DISPLAY_VERSION: ""
+
     steps:
     - uses: actions/checkout@v4
     - name: Setup .NET
       uses: actions/setup-dotnet@v4
       with:
         dotnet-version: 9.0.x
-
-    # # fix error with missing XCode 26
-    # - name: Select Xcode 26
-    #   run: sudo xcode-select -s /Applications/Xcode_26.app/Contents/Developer
         
     - name: Install MAUI workload
       run: dotnet workload install maui
+
+    - name: Get App Version from Build Properties
+      shell: bash
+      run: |
+        # Extract ApplicationDisplayVersion from Directory.Build.props using grep and sed
+        APP_VERSION=$(grep -oP '<ApplicationDisplayVersion>\K[^<]*' Directory.Build.props)
+        echo "Found version: $APP_VERSION"
 
     - name: Find Current Release Info
       if: github.event_name == 'release' && github.event.action == 'published'
@@ -57,11 +59,6 @@ jobs:
         route: GET /repos/${{ github.repository }}/releases/tags/${{ github.event.release.tag_name }}
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-    - name: Set APP_DISPLAY_VERSION for release
-      if: github.event_name == 'release' && github.event.action == 'published'
-      shell: bash 
-      run: echo "APP_DISPLAY_VERSION=$(echo '${{ fromJson(steps.get_release.outputs.data).tag_name }}')" >> $GITHUB_ENV
 
     - name: Import Code-Signing Certificates
       uses: Apple-Actions/import-codesign-certs@v1
@@ -92,7 +89,7 @@ jobs:
         -p:EnableAssemblyILStripping=false
         -p:CodesignKey="iPhone Distribution"
         -p:CodesignProvision=Automatic
-        -p:ApplicationDisplayVersion="${{ env.APP_DISPLAY_VERSION }}"
+        -p:ApplicationVersion="${{ github.run_number }}"
 
     - name: List build output
       run: ls -R BrickController2/BrickController2.iOS/bin/Release/net9.0-ios/ios-arm64/publish/
@@ -109,7 +106,7 @@ jobs:
       with:
         upload_url: ${{ fromJson(steps.get_release.outputs.data).upload_url }}
         asset_path: BrickController2/BrickController2.iOS/bin/Release/net9.0-ios/ios-arm64/publish/BrickController2.iOS.ipa
-        asset_name: BrickControllerLegacy_${{env.APP_DISPLAY_VERSION}}.ipa
+        asset_name: BrickControllerLegacy_${{env.APP_VERSION}}.ipa
         asset_content_type: application/octet-stream
       env:
         GITHUB_TOKEN: ${{ secrets.CI_RELEASE_ASSETS_PAT }}

--- a/.github/workflows/build-ios.yml
+++ b/.github/workflows/build-ios.yml
@@ -31,7 +31,7 @@ permissions:
 
 jobs:
   build-ios:
-    runs-on: macos-15
+    runs-on: macos-26
     name: BrickController iOS Build
     env:
       APP_DISPLAY_VERSION: ""
@@ -42,9 +42,9 @@ jobs:
       with:
         dotnet-version: 9.0.x
 
-    # fix error with missing XCode 26
-    - name: Select Xcode 26
-      run: sudo xcode-select -s /Applications/Xcode_26.app/Contents/Developer
+    # # fix error with missing XCode 26
+    # - name: Select Xcode 26
+    #   run: sudo xcode-select -s /Applications/Xcode_26.app/Contents/Developer
         
     - name: Install MAUI workload
       run: dotnet workload install maui

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -95,7 +95,7 @@ jobs:
       uses: actions/upload-release-asset@v1
       with:
         upload_url: ${{ fromJson(steps.get_release.outputs.data).upload_url }}
-        asset_path: BrickController2\BrickController2.WinUI\bin\x64\Release\net9.0-windows10.0.19041.0\win10-x64\AppPackages\BrickController2.WinUI_${{env.APP_PACKAGE_VERSION}}.${{github.run_number}}_Test\BrickController2.WinUI_${{env.APP_PACKAGE_VERSION}}.${{github.run_number}}_x64.msix
+        asset_path: BrickController2\BrickController2.WinUI\bin\x64\Release\net9.0-windows10.0.19041.0\win10-x64\AppPackages\BrickController2.WinUI_${{env.APP_VERSION}}.${{github.run_number}}_Test\BrickController2.WinUI_${{env.APP_VERSION}}.${{github.run_number}}_x64.msix
         asset_name: BrickControllerLegacy_${{env.APP_VERSION}}.msix
         asset_content_type: application/vnd.ms-appx
       env:

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -46,9 +46,7 @@ jobs:
 
     - name: Get App Version from Build Properties
       shell: bash
-      run: |
-        APP_VERSION=$(sed -n 's|.*<ApplicationDisplayVersion>\(.*\)</ApplicationDisplayVersion>.*|\1|p' Directory.Build.props)
-        echo "Found version: $APP_VERSION"
+      run: echo "APP_VERSION=$(sed -n 's|.*<ApplicationDisplayVersion>\(.*\)</ApplicationDisplayVersion>.*|\1|p' Directory.Build.props)" >> $GITHUB_ENV
 
     - name: Find Current Release Info
       if: github.event_name == 'release' && github.event.action == 'published'

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -36,9 +36,6 @@ jobs:
   build-winui:
     runs-on: windows-2025
     name: BrickController WinUI Build
-    env:
-      APP_DISPLAY_VERSION: ""
-      APP_PACKAGE_VERSION: ""
 
     steps:
     - uses: actions/checkout@v4
@@ -56,19 +53,6 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-    - name: Set app version for release
-      if: github.event_name == 'release' && github.event.action == 'published'
-      shell: bash
-      run: |
-        TAG_NAME=$(echo '${{ fromJson(steps.get_release.outputs.data).tag_name }}')
-        # Split the tag into parts, remove leading zeros and add missing parts as zeros
-        IFS='.' read -r -a VERSION_PARTS <<< "$TAG_NAME"  
-        for i in "${!VERSION_PARTS[@]}"; do  
-          VERSION_PARTS[$i]=$(echo "${VERSION_PARTS[$i]}" | sed 's/^0*//')  
-        done  
-        echo "APP_DISPLAY_VERSION=$TAG_NAME" >> $GITHUB_ENV  
-        echo "APP_PACKAGE_VERSION=${VERSION_PARTS[0]:-0}.${VERSION_PARTS[1]:-0}.${VERSION_PARTS[2]:-0}.${VERSION_PARTS[3]:-0}" >> $GITHUB_ENV
-
     - name: Decode Signing Certificate
       run: |
         echo "${{ secrets.SIGNING_CERTIFICATE_BASE_64_CONTENT }}" > cert.asc
@@ -85,9 +69,7 @@ jobs:
         -c Release `
         -r win10-x64 `
         -p:Platform=x64 `
-        -p:ApplicationDisplayVersion="${{ env.APP_DISPLAY_VERSION }}" `
-        -p:ApplicationVersion="0" `
-        -p:PackageVersion="${{ env.APP_PACKAGE_VERSION }}"
+        -p:ApplicationVersion="${{ github.run_number }}"
 
     - name: Build MAUI WinUI App
       run: dotnet publish ${{env.PROJECT_PATH}} `
@@ -110,7 +92,7 @@ jobs:
       with:
         upload_url: ${{ fromJson(steps.get_release.outputs.data).upload_url }}
         asset_path: BrickController2\BrickController2.WinUI\bin\x64\Release\net9.0-windows10.0.19041.0\win10-x64\AppPackages\BrickController2.WinUI_${{env.APP_PACKAGE_VERSION}}_Test\BrickController2.WinUI_${{env.APP_PACKAGE_VERSION}}_x64.msix
-        asset_name: BrickControllerLegacy_${{env.APP_DISPLAY_VERSION}}.msix
+        asset_name: BrickControllerLegacy_${{env.APP_VERSION}}.msix
         asset_content_type: application/vnd.ms-appx
       env:
         GITHUB_TOKEN: ${{ secrets.CI_RELEASE_ASSETS_PAT }}

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -44,6 +44,12 @@ jobs:
       with:
         dotnet-version: 9.0.x
 
+    - name: Get App Version from Build Properties
+      shell: bash
+      run: |
+        APP_VERSION=$(sed -n 's|.*<ApplicationDisplayVersion>\(.*\)</ApplicationDisplayVersion>.*|\1|p' Directory.Build.props)
+        echo "Found version: $APP_VERSION"
+
     - name: Find Current Release Info
       if: github.event_name == 'release' && github.event.action == 'published'
       id: get_release

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -97,7 +97,7 @@ jobs:
       uses: actions/upload-release-asset@v1
       with:
         upload_url: ${{ fromJson(steps.get_release.outputs.data).upload_url }}
-        asset_path: BrickController2\BrickController2.WinUI\bin\x64\Release\net9.0-windows10.0.19041.0\win10-x64\AppPackages\BrickController2.WinUI_${{env.APP_PACKAGE_VERSION}}_Test\BrickController2.WinUI_${{env.APP_PACKAGE_VERSION}}_x64.msix
+        asset_path: BrickController2\BrickController2.WinUI\bin\x64\Release\net9.0-windows10.0.19041.0\win10-x64\AppPackages\BrickController2.WinUI_${{env.APP_PACKAGE_VERSION}}.${{github.run_number}}_Test\BrickController2.WinUI_${{env.APP_PACKAGE_VERSION}}.${{github.run_number}}_x64.msix
         asset_name: BrickControllerLegacy_${{env.APP_VERSION}}.msix
         asset_content_type: application/vnd.ms-appx
       env:


### PR DESCRIPTION
* unified versioning of apps based on `ApplicationDisplayVersion` but not release tag
* fix of IOS build due to recently released  XCODE 26
```
/Users/runner/.dotnet/packs/Microsoft.iOS.Sdk.net9.0_26.0/26.0.9752/targets/Xamarin.Shared.Sdk.targets(2346,3): error : This version of .NET for iOS (26.0.9752) requires Xcode 26.0. The current version of Xcode is 16.4. Either install Xcode 26.0, or use a different version of .NET for iOS. See https://aka.ms/xcode-requirement for more information. [/Users/runner/work/brickcontroller2/brickcontroller2/BrickController2/BrickController2.iOS/BrickController2.iOS.csproj::TargetFramework=net9.0-iOS]
Error: Process completed with exit code 1.
```