### PR TITLE
Fix broken legacy pipeline - explicitly install XCODE 26.0

### DIFF
--- a/.github/workflows/build-ios.yml
+++ b/.github/workflows/build-ios.yml
@@ -31,7 +31,6 @@ permissions:
 
 env:
   XCODE_VERSION: '26.0'
-  TARGET_FRAMEWORK: 'net10.0-ios'
 
 jobs:
   build-ios:
@@ -49,7 +48,6 @@ jobs:
       run: dotnet workload install maui ios
 
     - name: Set XCode Version
-      if: runner.os == 'macOS'
       shell: bash
       run: |
         sudo xcode-select -s "/Applications/Xcode_${{ env.XCODE_VERSION }}.app"

--- a/.github/workflows/build-ios.yml
+++ b/.github/workflows/build-ios.yml
@@ -29,6 +29,10 @@ on:
 permissions:
   contents: read
 
+env:
+  XCODE_VERSION: '26.0'
+  TARGET_FRAMEWORK: 'net10.0-ios'
+
 jobs:
   build-ios:
     runs-on: macos-26
@@ -42,7 +46,17 @@ jobs:
         dotnet-version: 9.0.x
         
     - name: Install MAUI workload
-      run: dotnet workload install maui
+      run: dotnet workload install maui ios
+
+    - name: Set XCode Version
+      if: runner.os == 'macOS'
+      shell: bash
+      run: |
+        sudo xcode-select -s "/Applications/Xcode_${{ env.XCODE_VERSION }}.app"
+        echo "MD_APPLE_SDK_ROOT=/Applications/Xcode_${{ env.XCODE_VERSION }}.app" >> $GITHUB_ENV
+
+    - name: Verify Xcode version
+      run: xcodebuild -version
 
     - name: Get App Version from Build Properties
       shell: bash


### PR DESCRIPTION
```
/Users/runner/.dotnet/packs/Microsoft.iOS.Sdk.net9.0_26.0/26.0.9783/targets/Xamarin.Shared.Sdk.targets(2346,3): error : This version of .NET for iOS (26.0.9783) requires Xcode 26.0. The current version of Xcode is 26.2. Either install Xcode 26.0, or use a different version of .NET for iOS. See https://aka.ms/xcode-requirement for more information. [/Users/runner/work/brickcontroller2/brickcontroller2/BrickController2/BrickController2.iOS/BrickController2.iOS.csproj::TargetFramework=net9.0-iOS]
```