### PR TITLE
Fix WinUI build - release upload [pipeline]

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -112,7 +112,7 @@ jobs:
       uses: actions/upload-release-asset@v1
       with:
         upload_url: ${{ fromJson(steps.get_release.outputs.data).upload_url }}
-        asset_path: BrickController2\BrickController2.WinUI\bin\x64\Release\net10.0-windows10.0.19041.0\win-x64\AppPackages\BrickController2.WinUI_${{env.APP_PACKAGE_VERSION}}_Test\BrickController2.WinUI_${{env.APP_PACKAGE_VERSION}}_x64.msix
+        asset_path: BrickController2\BrickController2.WinUI\AppPackages\BrickController2.WinUI_${{env.APP_PACKAGE_VERSION}}_Test\BrickController2.WinUI_${{env.APP_PACKAGE_VERSION}}_x64.msix
         asset_name: BrickController2_${{env.APP_DISPLAY_VERSION}}.msix
         asset_content_type: application/vnd.ms-appx
       env:


### PR DESCRIPTION
```
Error: ENOENT: no such file or directory, stat 'D:\a\brickcontroller2\brickcontroller2\BrickController2\BrickController2.WinUI\bin\x64\Release\net10.0-windows10.0.19041.0\win-x64\AppPackages\BrickController2.WinUI_2026.1.0.0_Test\BrickController2.WinUI_2026.1.0.0_x64.msix'
```