### PR TITLE
Refactor BluetoothAdvertisingDevice, BluetoothAdvertisingDeviceHandler, BluetoothLEAdvertiserDevice for iOS

### DIFF
--- a/BrickController2/BrickController2.iOS/PlatformServices/BluetoothLE/BluetoothLEAdvertiserDevice.cs
+++ b/BrickController2/BrickController2.iOS/PlatformServices/BluetoothLE/BluetoothLEAdvertiserDevice.cs
@@ -75,6 +75,7 @@ internal class BluetoothLEAdvertiserDevice : CBPeripheralManagerDelegate, IBluet
 
         TaskCompletionSource<NSError?>? advertisingStartedCompletionSource = null;
 
+        // lock to synchronize fields _peripheralManager, _advData and _advertisingStartedCompletion
         lock (_lock)
         {
             _advData = new StartAdvertisingOptions { ServicesUUID = servicesUUID };
@@ -124,6 +125,12 @@ internal class BluetoothLEAdvertiserDevice : CBPeripheralManagerDelegate, IBluet
         }
     }
 
+    /// <summary>
+    /// Start advertising if the peripheral manager is powered on and advertising data is set.
+    /// </summary>
+    /// <remarks>
+    /// ⚠️ Must be called *within a lock* to synchronize the fields _peripheralManager, _advData and _advertisingStartedCompletion.
+    /// </remarks>
     private void StartAdvertisingInternal()
     {
         // Initialize peripheral manager if not already done.
@@ -146,12 +153,19 @@ internal class BluetoothLEAdvertiserDevice : CBPeripheralManagerDelegate, IBluet
         }
     }
 
+    /// <summary>
+    /// Stop advertising and reset advertising data and completion source.
+    /// </summary>
     private void StopAdvertiseInternal()
     {
-        _peripheralManager?.StopAdvertising();
-        // Reset data so that it does not start advertising automatically if the interface goes ON.
-        _advData = null;
-        _advertisingStartedCompletionSource?.TrySetCanceled();
-        _advertisingStartedCompletionSource = null;
+        // lock to synchronize fields _peripheralManager, _advData and _advertisingStartedCompletion
+        lock (_lock)
+        {
+            _peripheralManager?.StopAdvertising();
+            // Reset data so that it does not start advertising automatically if the interface goes ON.
+            _advData = null;
+            _advertisingStartedCompletionSource?.TrySetCanceled();
+            _advertisingStartedCompletionSource = null;
+        }
     }
 }

--- a/BrickController2/BrickController2.iOS/PlatformServices/BluetoothLE/BluetoothLEAdvertiserDevice.cs
+++ b/BrickController2/BrickController2.iOS/PlatformServices/BluetoothLE/BluetoothLEAdvertiserDevice.cs
@@ -1,13 +1,20 @@
-﻿using System.Threading.Tasks;
+﻿using System;
+using System.Threading.Tasks;
 using CoreBluetooth;
+using CoreFoundation;
+using Foundation;
 using BrickController2.PlatformServices.BluetoothLE;
 
 namespace BrickController2.iOS.PlatformServices.BluetoothLE;
 
 internal class BluetoothLEAdvertiserDevice : CBPeripheralManagerDelegate, IBluetoothLEAdvertiserDevice
 {
+    private static readonly TimeSpan AdvertisingStartTimeout = TimeSpan.FromSeconds(5);
+    private readonly object _lock = new();
+
     private CBPeripheralManager? _peripheralManager;
     private StartAdvertisingOptions? _advData;
+    private TaskCompletionSource<NSError?>? _advertisingStartedCompletionSource;
 
     public BluetoothLEAdvertiserDevice()
     {
@@ -22,11 +29,7 @@ internal class BluetoothLEAdvertiserDevice : CBPeripheralManagerDelegate, IBluet
     }
 
     public Task StartAdvertiseAsync(AdvertisingInterval advertisingIterval, TxPowerLevel txPowerLevel, ushort manufacturerId, byte[] rawData)
-    {
-        SetAdvertisingData(manufacturerId, rawData);
-
-        return Task.CompletedTask;
-    }
+        => SetAdvertisingDataAsync(manufacturerId, rawData, waitForAdvertisingStart: true);
 
     public Task StopAdvertiseAsync()
     {
@@ -36,13 +39,25 @@ internal class BluetoothLEAdvertiserDevice : CBPeripheralManagerDelegate, IBluet
     }
 
     public Task UpdateAdvertisedDataAsync(ushort manufacturerId, byte[] rawData)
-    {
-        SetAdvertisingData(manufacturerId, rawData);
+        => SetAdvertisingDataAsync(manufacturerId, rawData, waitForAdvertisingStart: false);
 
-        return Task.CompletedTask;
+    public override void StateUpdated(CBPeripheralManager peripheral)
+    {
+        lock (_lock)
+        {
+            StartAdvertisingInternal();
+        }
     }
 
-    private void SetAdvertisingData(ushort manufacturerId, byte[] rawData)
+    public override void AdvertisingStarted(CBPeripheralManager peripheral, NSError? error)
+    {
+        lock (_lock)
+        {
+            _advertisingStartedCompletionSource?.TrySetResult(error);
+        }
+    }
+
+    private async Task SetAdvertisingDataAsync(ushort manufacturerId, byte[] rawData, bool waitForAdvertisingStart)
     {
         // JK: no check - rawDataLength has to be even!
 
@@ -58,14 +73,55 @@ internal class BluetoothLEAdvertiserDevice : CBPeripheralManagerDelegate, IBluet
                 rawData[manufacturerSpecificDataIndex + 0]]);
         }
 
-        _advData = new StartAdvertisingOptions { ServicesUUID = servicesUUID };
+        TaskCompletionSource<NSError?>? advertisingStartedCompletionSource = null;
 
-        if (_peripheralManager?.Advertising == true)
+        lock (_lock)
         {
-            _peripheralManager.StopAdvertising();
+            _advData = new StartAdvertisingOptions { ServicesUUID = servicesUUID };
+
+            if (waitForAdvertisingStart)
+            {
+                advertisingStartedCompletionSource = new TaskCompletionSource<NSError?>(TaskCreationOptions.RunContinuationsAsynchronously);
+                _advertisingStartedCompletionSource = advertisingStartedCompletionSource;
+            }
+
+            if (_peripheralManager?.Advertising == true)
+            {
+                _peripheralManager.StopAdvertising();
+            }
+
+            StartAdvertisingInternal();
         }
 
-        StartAdvertisingInternal();
+        if (advertisingStartedCompletionSource is null)
+        {
+            return;
+        }
+
+        try
+        {
+            var completedTask = await Task.WhenAny(advertisingStartedCompletionSource.Task, Task.Delay(AdvertisingStartTimeout)).ConfigureAwait(false);
+            if (completedTask != advertisingStartedCompletionSource.Task)
+            {
+                throw new TimeoutException($"Bluetooth LE advertising did not start within {AdvertisingStartTimeout.TotalSeconds:0} seconds. Peripheral manager state: {_peripheralManager?.State.ToString() ?? "not created"}.");
+            }
+
+            var error = await advertisingStartedCompletionSource.Task.ConfigureAwait(false);
+            if (error is not null)
+            {
+                throw new InvalidOperationException($"Bluetooth LE advertising failed: {error.LocalizedDescription ?? error.ToString()}");
+            }
+        }
+        finally
+        {
+            lock (_lock)
+            {
+                if (ReferenceEquals(_advertisingStartedCompletionSource, advertisingStartedCompletionSource))
+                {
+                    _advertisingStartedCompletionSource = null;
+                }
+            }
+        }
     }
 
     private void StartAdvertisingInternal()
@@ -73,19 +129,20 @@ internal class BluetoothLEAdvertiserDevice : CBPeripheralManagerDelegate, IBluet
         // Initialize peripheral manager if not already done.
         if (_peripheralManager == null)
         {
-            _peripheralManager = new CBPeripheralManager();
-            _peripheralManager.StateUpdated += (sender, e) =>
-            {
-                if (_peripheralManager.State == CBManagerState.PoweredOn && _advData != null)
-                {
-                    _peripheralManager.StartAdvertising(_advData);
-                }
-            };
+            _peripheralManager = new CBPeripheralManager(this, DispatchQueue.MainQueue);
         }
 
         if (_peripheralManager.State == CBManagerState.PoweredOn && _advData != null)
         {
             _peripheralManager.StartAdvertising(_advData);
+            return;
+        }
+
+        if (_peripheralManager.State is CBManagerState.PoweredOff or
+            CBManagerState.Unauthorized or
+            CBManagerState.Unsupported)
+        {
+            _advertisingStartedCompletionSource?.TrySetException(new InvalidOperationException($"Bluetooth LE advertising is unavailable. Peripheral manager state: {_peripheralManager.State}."));
         }
     }
 
@@ -94,5 +151,7 @@ internal class BluetoothLEAdvertiserDevice : CBPeripheralManagerDelegate, IBluet
         _peripheralManager?.StopAdvertising();
         // Reset data so that it does not start advertising automatically if the interface goes ON.
         _advData = null;
+        _advertisingStartedCompletionSource?.TrySetCanceled();
+        _advertisingStartedCompletionSource = null;
     }
 }

--- a/BrickController2/BrickController2.iOS/PlatformServices/BluetoothLE/BluetoothLEService.cs
+++ b/BrickController2/BrickController2.iOS/PlatformServices/BluetoothLE/BluetoothLEService.cs
@@ -165,7 +165,7 @@ namespace BrickController2.iOS.PlatformServices.BluetoothLE
                 for (nuint i = 0; i < arrayObject.Count; i++)
                 {
                     var cbuuid = arrayObject.GetItem<CBUUID>(i);
-                    if (cbuuid.Data.Length == 16)
+                    if (cbuuid?.Data?.Length == 16)
                     {
                         // Service UUID's are read backwards (little endian) according to specs
                         var serviceUUid = cbuuid.Data.ToArray();

--- a/BrickController2/BrickController2/DeviceManagement/BluetoothAdvertisingDevice.cs
+++ b/BrickController2/BrickController2/DeviceManagement/BluetoothAdvertisingDevice.cs
@@ -73,8 +73,12 @@ namespace BrickController2.DeviceManagement
                     if (startOutputProcessing)
                     {
                         InitDevice();
-                        
-                        await _bluetoothAdvertisingDeviceHandler.StartOutputTaskAsync(this);
+
+                        if (!await _bluetoothAdvertisingDeviceHandler.StartOutputTaskAsync(this))
+                        {
+                            await DisconnectInternalAsync();
+                            return DeviceConnectionResult.Error;
+                        }
                     }
 
                     token.ThrowIfCancellationRequested();
@@ -84,13 +88,13 @@ namespace BrickController2.DeviceManagement
                 }
                 catch (OperationCanceledException)
                 {
-                    await DisconnectAsync();
+                    await DisconnectInternalAsync();
 
                     return DeviceConnectionResult.Canceled;
                 }
                 catch
                 {
-                    await DisconnectAsync();
+                    await DisconnectInternalAsync();
 
                     return DeviceConnectionResult.Error;
                 }
@@ -104,18 +108,23 @@ namespace BrickController2.DeviceManagement
         {
             using (await _asyncLock.LockAsync())
             {
-                if (DeviceState == DeviceState.Disconnected)
-                {
-                    return;
-                }
-
-                DeviceState = DeviceState.Disconnecting;
-
-                await _bluetoothAdvertisingDeviceHandler.StopOutputTaskAsync(this);
-                await _bluetoothAdvertisingDeviceHandler.TryDisconnectAsync(this);
-
-                DeviceState = DeviceState.Disconnected;
+                await DisconnectInternalAsync();
             }
+        }
+
+        private async Task DisconnectInternalAsync()
+        {
+            if (DeviceState == DeviceState.Disconnected)
+            {
+                return;
+            }
+
+            DeviceState = DeviceState.Disconnecting;
+
+            await _bluetoothAdvertisingDeviceHandler.StopOutputTaskAsync(this);
+            await _bluetoothAdvertisingDeviceHandler.TryDisconnectAsync(this);
+
+            DeviceState = DeviceState.Disconnected;
         }
 
         /// <summary>

--- a/BrickController2/BrickController2/DeviceManagement/BluetoothAdvertisingDeviceHandler.cs
+++ b/BrickController2/BrickController2/DeviceManagement/BluetoothAdvertisingDeviceHandler.cs
@@ -319,6 +319,7 @@ namespace BrickController2.DeviceManagement
                 catch (Exception ex)
                 {
                     startupCompletionSource.TrySetException(ex);
+                    throw;
                 }
             });
 

--- a/BrickController2/BrickController2/DeviceManagement/BluetoothAdvertisingDeviceHandler.cs
+++ b/BrickController2/BrickController2/DeviceManagement/BluetoothAdvertisingDeviceHandler.cs
@@ -224,14 +224,14 @@ namespace BrickController2.DeviceManagement
             }
         }
 
-        public async Task StartOutputTaskAsync(BluetoothAdvertisingDevice requestingDevice)
+        public async Task<bool> StartOutputTaskAsync(BluetoothAdvertisingDevice requestingDevice)
         {
             using (await _asyncLock.LockAsync())
             {
                 if (!_connectedDeviceList.Contains(requestingDevice) || // requestingDevice is not connected
                   _advertisingDeviceList.Contains(requestingDevice))    // requestingDevice is added to _advertisingDeviceList already
                 {
-                    return; // nothing to do
+                    return true; // nothing to do
                 }
 
                 // add requestingDevice to _advertisingDeviceList
@@ -240,8 +240,22 @@ namespace BrickController2.DeviceManagement
                 // on first device added
                 if (_advertisingDeviceList.Count == 1)
                 {
-                    StartOutputTaskInternal();
+                    try
+                    {
+                        if (!await StartOutputTaskInternalAsync())
+                        {
+                            _advertisingDeviceList.Remove(requestingDevice);
+                            return false;
+                        }
+                    }
+                    catch
+                    {
+                        _advertisingDeviceList.Remove(requestingDevice);
+                        throw;
+                    }
                 }
+
+                return true;
             }
         }
 
@@ -273,10 +287,11 @@ namespace BrickController2.DeviceManagement
         /// <summary>
         /// start output loop
         /// </summary>
-        private void StartOutputTaskInternal()
+        private Task<bool> StartOutputTaskInternalAsync()
         {
             _outputTaskTokenSource = new CancellationTokenSource();
             CancellationToken token = _outputTaskTokenSource.Token;
+            var startupCompletionSource = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
 
             _outputTask = Task.Run(async () =>
             {
@@ -288,14 +303,26 @@ namespace BrickController2.DeviceManagement
                         await _bleAdvertiserDevice.StartAdvertiseAsync(AdvertisingInterval, TxPowerLevel, _manufacturerId, currentData);
 
                         _waitForNewData = new(false);
+                        startupCompletionSource.TrySetResult(true);
 
                         await ProcessOutputsAsync(token);
+                    }
+                    else
+                    {
+                        startupCompletionSource.TrySetResult(false);
                     }
                 }
                 catch (TaskCanceledException) // catch this valid exception thrown on cancellation
                 {
+                    startupCompletionSource.TrySetCanceled(token);
+                }
+                catch (Exception ex)
+                {
+                    startupCompletionSource.TrySetException(ex);
                 }
             });
+
+            return startupCompletionSource.Task;
         }
 
         /// <summary>
@@ -355,7 +382,7 @@ namespace BrickController2.DeviceManagement
 
                 // if all channels are zero and _reconnectTimeSpan has elapsed
                 // then the connect telegram should be sent
-                inConnectMode = _allChannelsSetState == 0 && 
+                inConnectMode = _allChannelsSetState == 0 &&
                     _allZeroStopwatch.Elapsed > _reconnectTimeSpan;
 
                 // if connectMode is requested and if previous was not a connect telegram

--- a/BrickController2/BrickController2/InputDeviceManagement/IInputDeviceManagerService.cs
+++ b/BrickController2/BrickController2/InputDeviceManagement/IInputDeviceManagerService.cs
@@ -1,6 +1,7 @@
 ﻿using BrickController2.PlatformServices.InputDevice;
 using BrickController2.PlatformServices.InputDeviceService;
 using System;
+using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 
 namespace BrickController2.InputDeviceManagement;
@@ -17,6 +18,11 @@ public interface IInputDeviceManagerService : IInputDeviceEventServiceInternal
     /// returns true if inputdevice events can be processed (i.e. if there is at least one listener)
     /// </summary>
     bool CanProcessEvents { get; }
+
+    /// <summary>
+    /// Get a snapshot of currently available input devices.
+    /// </summary>
+    IReadOnlyCollection<IInputDevice> GetInputDevices();
 
     /// <summary>
     /// add inputdevice to the manager

--- a/BrickController2/BrickController2/InputDeviceManagement/InputDeviceManagerService.cs
+++ b/BrickController2/BrickController2/InputDeviceManagement/InputDeviceManagerService.cs
@@ -93,17 +93,24 @@ public sealed class InputDeviceManagerService : IInputDeviceManagerService
         _registeredInputDeviceServices.Add(inputDeviceService);
     }
 
+    /// <summary>
+    /// raise inputdevice event
+    /// </summary>
+    /// <param name="eventArgs"></param>
     public void RaiseEvent(InputDeviceEventArgs eventArgs)
     {
         InputDeviceEventInternal?.Invoke(this, eventArgs);
     }
 
     /// <summary>
-    /// Initialize collection of available InputDeviceServices (including listening of connected/disconnected controller)
+    /// Get a snapshot of currently available input devices.
     /// </summary>
-    private void InitializeInputDeviceServices()
+    public IReadOnlyCollection<IInputDevice> GetInputDevices()
     {
-        _registeredInputDeviceServices.ForEach(service => service?.Initialize());
+        lock (_lockObject)
+        {
+            return _availableInputDevices.ToArray();
+        }
     }
 
     /// <summary>
@@ -178,6 +185,14 @@ public sealed class InputDeviceManagerService : IInputDeviceManagerService
             inputDevice = _availableInputDevices.OfType<TInputDevice>().FirstOrDefault(x => predicate(x));
             return inputDevice is not null;
         }
+    }
+
+    /// <summary>
+    /// Initialize collection of available InputDeviceServices (including listening of connected/disconnected controller)
+    /// </summary>
+    private void InitializeInputDeviceServices()
+    {
+        _registeredInputDeviceServices.ForEach(service => service?.Initialize());
     }
 
     /// <summary>


### PR DESCRIPTION
I've incorporated some **improvements** to the `BluetoothAdvertising components` that I found in this fork:
https://github.com/volzinnovation/brickcontroller2.

The affected components are:
* `BluetoothAdvertisingDevice`
* `BluetoothAdvertisingDeviceHandler`
* `BluetoothLEAdvertiserDevice` for iOS

@volzinnovation also extended the `IInputDeviceManagerService` interface for use with a `HttpInputDevice`.
This extension is not used in your repository yet, but it provides useful functionality for future use cases.

---

I've tested it on my iPad through a TestFlight invitation provided by @volzinnovation.