### PR TITLE
Add unit tests for vendors BuWizz, Lego and Vengit

### DIFF
--- a/BrickController2/BrickController2.Tests/DeviceManagement/DI/BuWizzVendorTests.cs
+++ b/BrickController2/BrickController2.Tests/DeviceManagement/DI/BuWizzVendorTests.cs
@@ -1,0 +1,78 @@
+using Autofac;
+using BrickController2.DeviceManagement;
+using BrickController2.PlatformServices.BluetoothLE;
+using BrickController2.UI.Images;
+using FluentAssertions;
+using Moq;
+using Xunit;
+using BuWizzVendor = BrickController2.DeviceManagement.BuWizz.BuWizz;
+
+namespace BrickController2.Tests.DeviceManagement.DI;
+
+public class BuWizzVendorTests : VendorTestsBase
+{
+    private readonly DeviceFactory _deviceFactory;
+
+    public BuWizzVendorTests()
+    {
+        // Act
+        var container = InitializeContainer().Build();
+
+        _deviceFactory = container.Resolve<DeviceFactory>();
+    }
+
+    protected override ContainerBuilder InitializeContainer()
+    {
+        var builder = base.InitializeContainer();
+
+        // Arrange
+        builder.RegisterInstance(Mock.Of<IBluetoothLEService>());
+
+        // additional dependencies
+        builder.RegisterInstance(Mock.Of<IDeviceImageRegistry>()); // needed because RegisterDevice<BuWizzDevice>().WithImages("buwizz_image.png", "buwizz_image_small.png");
+
+        // execute registration of vendor BuWizz
+        builder.RegisterModule<BuWizzVendor>();
+
+        return builder;
+    }
+
+    [Theory]
+    [InlineData("BuWizzDevice")]
+    public void RegisterDevice_BuWizzDevice_ReturnedDevice(string address)
+    {
+        DeviceType deviceType = DeviceType.BuWizz;
+        string name = "TestDevice";
+
+        var device = _deviceFactory(deviceType, name, address, [], []);
+
+        device.Should().NotBeNull();
+        device.Should().BeOfType<BuWizzDevice>();
+    }
+
+    [Theory]
+    [InlineData("BuWizz2Device")]
+    public void RegisterDevice_BuWizz2Device_ReturnedDevice(string address)
+    {
+        DeviceType deviceType = DeviceType.BuWizz2;
+        string name = "TestDevice";
+
+        var device = _deviceFactory(deviceType, name, address, [], []);
+
+        device.Should().NotBeNull();
+        device.Should().BeOfType<BuWizz2Device>();
+    }
+
+    [Theory]
+    [InlineData("BuWizz3Device")]
+    public void RegisterDevice_BuWizz3Device_ReturnedDevice(string address)
+    {
+        DeviceType deviceType = DeviceType.BuWizz3;
+        string name = "TestDevice";
+
+        var device = _deviceFactory(deviceType, name, address, [], []);
+
+        device.Should().NotBeNull();
+        device.Should().BeOfType<BuWizz3Device>();
+    }
+}

--- a/BrickController2/BrickController2.Tests/DeviceManagement/DI/CaDAVendorTests.cs
+++ b/BrickController2/BrickController2.Tests/DeviceManagement/DI/CaDAVendorTests.cs
@@ -1,7 +1,6 @@
 using Autofac;
 using BrickController2.DeviceManagement;
 using BrickController2.DeviceManagement.CaDA;
-using BrickController2.DeviceManagement.DI;
 using BrickController2.PlatformServices.BluetoothLE;
 using FluentAssertions;
 using Moq;

--- a/BrickController2/BrickController2.Tests/DeviceManagement/DI/JieStarVendorTests.cs
+++ b/BrickController2/BrickController2.Tests/DeviceManagement/DI/JieStarVendorTests.cs
@@ -1,6 +1,5 @@
 using Autofac;
 using BrickController2.DeviceManagement;
-using BrickController2.DeviceManagement.DI;
 using BrickController2.DeviceManagement.JieStar;
 using BrickController2.PlatformServices.BluetoothLE;
 using FluentAssertions;

--- a/BrickController2/BrickController2.Tests/DeviceManagement/DI/LegoVendorTests.cs
+++ b/BrickController2/BrickController2.Tests/DeviceManagement/DI/LegoVendorTests.cs
@@ -101,7 +101,7 @@ public class LegoVendorTests : VendorTestsBase
 
     [Theory]
     [InlineData("WeDo2")]
-    public void RegisterDevice_Wedo2Device_ReturnedDevice(string address)
+public void RegisterDevice_WeDo2Device_ReturnedDevice(string address)
     {
         DeviceType deviceType = DeviceType.WeDo2;
         string name = "TestDevice";

--- a/BrickController2/BrickController2.Tests/DeviceManagement/DI/LegoVendorTests.cs
+++ b/BrickController2/BrickController2.Tests/DeviceManagement/DI/LegoVendorTests.cs
@@ -1,0 +1,140 @@
+using Autofac;
+using BrickController2.DeviceManagement;
+using BrickController2.DeviceManagement.Lego;
+using BrickController2.InputDeviceManagement;
+using BrickController2.PlatformServices.BluetoothLE;
+using BrickController2.PlatformServices.InputDeviceService;
+using BrickController2.UI.Images;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+using LegoVendor = BrickController2.DeviceManagement.Lego.Lego;
+
+namespace BrickController2.Tests.DeviceManagement.DI;
+
+public class LegoVendorTests : VendorTestsBase
+{
+    private readonly DeviceFactory _deviceFactory;
+
+    public LegoVendorTests()
+    {
+        // Act
+        var container = InitializeContainer().Build();
+
+        _deviceFactory = container.Resolve<DeviceFactory>();
+    }
+
+    protected override ContainerBuilder InitializeContainer()
+    {
+        var builder = base.InitializeContainer();
+
+        // Arrange
+        builder.RegisterInstance(Mock.Of<IBluetoothLEService>());
+
+        // additional dependencies
+        builder.RegisterInstance(Mock.Of<IDeviceImageRegistry>()); // needed because builder.RegisterDevice<RemoteControl>().WithImage("remotecontrol_image_small.png");
+
+        // needed because of constructor for LegoControllerService
+        builder.RegisterInstance(Mock.Of<IDeviceManager>());
+        builder.RegisterInstance(Mock.Of<IInputDeviceManagerService>());
+        builder.RegisterInstance(Mock.Of<IInputDeviceEventServiceInternal>());
+        builder.RegisterInstance(Mock.Of<ILogger<LegoControllerService>>());
+
+        // execute registration of vendor Lego
+        builder.RegisterModule<LegoVendor>();
+
+        return builder;
+    }
+
+    [Theory]
+    [InlineData("PoweredUp")]
+    public void RegisterDevice_PoweredUpDevice_ReturnedDevice(string address)
+    {
+        DeviceType deviceType = DeviceType.PoweredUp;
+        string name = "TestDevice";
+
+        var device = _deviceFactory(deviceType, name, address, [], []);
+
+        device.Should().NotBeNull();
+        device.Should().BeOfType<PoweredUpDevice>();
+    }
+
+    [Theory]
+    [InlineData("Boost")]
+    public void RegisterDevice_BoostDevice_ReturnedDevice(string address)
+    {
+        DeviceType deviceType = DeviceType.Boost;
+        string name = "TestDevice";
+
+        var device = _deviceFactory(deviceType, name, address, [], []);
+
+        device.Should().NotBeNull();
+        device.Should().BeOfType<BoostDevice>();
+    }
+
+    [Theory]
+    [InlineData("TechnicHub")]
+    public void RegisterDevice_TechnicHubDevice_ReturnedDevice(string address)
+    {
+        DeviceType deviceType = DeviceType.TechnicHub;
+        string name = "TestDevice";
+
+        var device = _deviceFactory(deviceType, name, address, [], []);
+
+        device.Should().NotBeNull();
+        device.Should().BeOfType<TechnicHubDevice>();
+    }
+
+    [Theory]
+    [InlineData("DuploTrainHub")]
+    public void RegisterDevice_DuploTrainHubDevice_ReturnedDevice(string address)
+    {
+        DeviceType deviceType = DeviceType.DuploTrainHub;
+        string name = "TestDevice";
+
+        var device = _deviceFactory(deviceType, name, address, [], []);
+
+        device.Should().NotBeNull();
+        device.Should().BeOfType<DuploTrainHubDevice>();
+    }
+
+    [Theory]
+    [InlineData("WeDo2")]
+    public void RegisterDevice_Wedo2Device_ReturnedDevice(string address)
+    {
+        DeviceType deviceType = DeviceType.WeDo2;
+        string name = "TestDevice";
+
+        var device = _deviceFactory(deviceType, name, address, [], []);
+
+        device.Should().NotBeNull();
+        device.Should().BeOfType<Wedo2Device>();
+    }
+
+    [Theory]
+    [InlineData("TechnicMove")]
+    public void RegisterDevice_TechnicMoveDevice_ReturnedDevice(string address)
+    {
+        DeviceType deviceType = DeviceType.TechnicMove;
+        string name = "TestDevice";
+
+        var device = _deviceFactory(deviceType, name, address, [], []);
+
+        device.Should().NotBeNull();
+        device.Should().BeOfType<TechnicMoveDevice>();
+    }
+
+    [Theory]
+    [InlineData("RemoteControl")]
+    public void RegisterDevice_RemoteControl_ReturnedDevice(string address)
+    {
+        DeviceType deviceType = DeviceType.RemoteControl;
+        string name = "TestDevice";
+
+        var device = _deviceFactory(deviceType, name, address, [], []);
+
+        device.Should().NotBeNull();
+        device.Should().BeOfType<RemoteControl>();
+    }
+}

--- a/BrickController2/BrickController2.Tests/DeviceManagement/DI/MouldKingVendorTests.cs
+++ b/BrickController2/BrickController2.Tests/DeviceManagement/DI/MouldKingVendorTests.cs
@@ -1,6 +1,5 @@
 using Autofac;
 using BrickController2.DeviceManagement;
-using BrickController2.DeviceManagement.DI;
 using BrickController2.DeviceManagement.MouldKing;
 using BrickController2.PlatformServices.BluetoothLE;
 using FluentAssertions;

--- a/BrickController2/BrickController2.Tests/DeviceManagement/DI/PowerFunctionsVendorTests.cs
+++ b/BrickController2/BrickController2.Tests/DeviceManagement/DI/PowerFunctionsVendorTests.cs
@@ -1,6 +1,5 @@
 using Autofac;
 using BrickController2.DeviceManagement;
-using BrickController2.DeviceManagement.DI;
 using BrickController2.DeviceManagement.PowerFunctions;
 using BrickController2.PlatformServices.Infrared;
 using BrickController2.UI.Images;

--- a/BrickController2/BrickController2.Tests/DeviceManagement/DI/VengitVendorTests.cs
+++ b/BrickController2/BrickController2.Tests/DeviceManagement/DI/VengitVendorTests.cs
@@ -1,0 +1,62 @@
+using Autofac;
+using BrickController2.DeviceManagement;
+using BrickController2.DeviceManagement.Vengit;
+using BrickController2.PlatformServices.BluetoothLE;
+using FluentAssertions;
+using Moq;
+using Xunit;
+using VengitVendor = BrickController2.DeviceManagement.Vengit.Vengit;
+
+namespace BrickController2.Tests.DeviceManagement.DI;
+
+public class VengitVendorTests : VendorTestsBase
+{
+    private readonly DeviceFactory _deviceFactory;
+
+    public VengitVendorTests()
+    {
+        // Act
+        var container = InitializeContainer().Build();
+
+        _deviceFactory = container.Resolve<DeviceFactory>();
+    }
+
+    protected override ContainerBuilder InitializeContainer()
+    {
+        var builder = base.InitializeContainer();
+
+        // Arrange
+        builder.RegisterInstance(Mock.Of<IBluetoothLEService>());
+
+        // execute registration of vendor Vengit
+        builder.RegisterModule<VengitVendor>();
+
+        return builder;
+    }
+
+    [Theory]
+    [InlineData("SBrickDevice")]
+    public void RegisterDevice_SBrickDevice_ReturnedDevice(string address)
+    {
+        DeviceType deviceType = DeviceType.SBrick;
+        string name = "TestDevice";
+
+        var device = _deviceFactory(deviceType, name, address, [], []);
+
+        device.Should().NotBeNull();
+        device.Should().BeOfType<SBrickDevice>();
+    }
+
+    [Theory]
+    [InlineData("SBrickLight")]
+    public void RegisterDevice_SBrickLight_ReturnedDevice(string address)
+    {
+        DeviceType deviceType = DeviceType.SBrickLight;
+        string name = "TestDevice";
+
+        var device = _deviceFactory(deviceType, name, address, [], []);
+
+        device.Should().NotBeNull();
+        device.Should().BeOfType<SBrickLightDevice>();
+    }
+}


### PR DESCRIPTION
I've added some more unit tests for vendors

* BuWizz
* Lego
* Vengit

to check DI registration and creation of the specific devices by calling the devicefactory with parameters `DeviceType` (and some dummies)