### PR TITLE
fixed warning "Possible null reference return."

### DIFF
--- a/BrickController2/BrickController2.iOS/PlatformServices/BluetoothLE/BluetoothLEDevice.cs
+++ b/BrickController2/BrickController2.iOS/PlatformServices/BluetoothLE/BluetoothLEDevice.cs
@@ -29,7 +29,7 @@ namespace BrickController2.iOS.PlatformServices.BluetoothLE
             _centralManager = centralManager;
         }
 
-        public string Address => _peripheral.Identifier!.ToString();
+        public string Address => _peripheral?.Identifier!.ToString() ?? string.Empty;
         public BluetoothLEDeviceState State { get; private set; } = BluetoothLEDeviceState.Disconnected;
 
         public async Task<IEnumerable<IGattService>?> ConnectAndDiscoverServicesAsync(

--- a/BrickController2/BrickController2.iOS/PlatformServices/BluetoothLE/BluetoothLEDevice.cs
+++ b/BrickController2/BrickController2.iOS/PlatformServices/BluetoothLE/BluetoothLEDevice.cs
@@ -29,7 +29,7 @@ namespace BrickController2.iOS.PlatformServices.BluetoothLE
             _centralManager = centralManager;
         }
 
-        public string Address => _peripheral?.Identifier!.ToString() ?? string.Empty;
+public string Address => _peripheral.Identifier?.ToString() ?? throw new InvalidOperationException("CBPeripheral.Identifier is null.");
         public BluetoothLEDeviceState State { get; private set; } = BluetoothLEDeviceState.Disconnected;
 
         public async Task<IEnumerable<IGattService>?> ConnectAndDiscoverServicesAsync(

--- a/BrickController2/BrickController2.iOS/PlatformServices/BluetoothLE/BluetoothLEDevice.cs
+++ b/BrickController2/BrickController2.iOS/PlatformServices/BluetoothLE/BluetoothLEDevice.cs
@@ -29,7 +29,6 @@ namespace BrickController2.iOS.PlatformServices.BluetoothLE
             _centralManager = centralManager;
         }
 
-public string Address => _peripheral.Identifier?.ToString() ?? throw new InvalidOperationException("CBPeripheral.Identifier is null.");
         public BluetoothLEDeviceState State { get; private set; } = BluetoothLEDeviceState.Disconnected;
 
         public async Task<IEnumerable<IGattService>?> ConnectAndDiscoverServicesAsync(

--- a/BrickController2/BrickController2/PlatformServices/BluetoothLE/IBluetoothLEDevice.cs
+++ b/BrickController2/BrickController2/PlatformServices/BluetoothLE/IBluetoothLEDevice.cs
@@ -7,7 +7,6 @@ namespace BrickController2.PlatformServices.BluetoothLE
 {
     public interface IBluetoothLEDevice
     {
-        string Address { get; }
         BluetoothLEDeviceState State { get; }
 
         Task<IEnumerable<IGattService>?> ConnectAndDiscoverServicesAsync(


### PR DESCRIPTION
I've fixed that warning:

BrickController iOS Build: BrickController2/BrickController2.iOS/PlatformServices/BluetoothLE/BluetoothLEDevice.cs#L32 Possible null reference return.