### PR TITLE
Refactor: Move device‑specific acceleration logic into device classes

### DIFF
--- a/BrickController2/BrickController2/BusinessLogic/PlayLogic.cs
+++ b/BrickController2/BrickController2/BusinessLogic/PlayLogic.cs
@@ -100,12 +100,12 @@ namespace BrickController2.BusinessLogic
                                     continue;
                                 }
 
-                                var outputValue = ProcessButtonEvent(isPressed, controllerAction, device!.DeviceType);
+                                var outputValue = ProcessButtonEvent(isPressed, controllerAction, device);
                                 device.SetOutput(channel, outputValue);
                             }
                             else if (gameControllerEvent.Key.EventType == InputDeviceEventType.Axis)
                             {
-                                var (useAxisValue, axisValue) = ProcessAxisEvent(gameControllerEvent.Key.EventCode, gameControllerEvent.Value, controllerAction, device!.DeviceType);
+                                var (useAxisValue, axisValue) = ProcessAxisEvent(gameControllerEvent.Key.EventCode, gameControllerEvent.Value, controllerAction, device);
                                 if (useAxisValue)
                                 {
                                     StoreAxisOutputValue(axisValue, controllerAction.DeviceId, controllerAction.Channel, controllerEvent.EventType, controllerEvent.EventCode);
@@ -124,7 +124,7 @@ namespace BrickController2.BusinessLogic
             return controllerAction.ButtonType == ControllerButtonType.Normal || isPressed;
         }
 
-        private float ProcessButtonEvent(bool isPressed, ControllerAction controllerAction, DeviceType deviceType)
+        private float ProcessButtonEvent(bool isPressed, ControllerAction controllerAction, Device device)
         {
             var previousOutputs = GetPreviousOutputs(controllerAction);
             float currentOutput = 0;
@@ -176,7 +176,7 @@ namespace BrickController2.BusinessLogic
                     break;
 
                 case ControllerButtonType.Accelerator:
-                    var accelarationStep = GetAccelarationStep(deviceType);
+                    var accelarationStep = device.AccelarationStep;
                     accelarationStep = controllerAction.IsInvert ? -accelarationStep : accelarationStep;
                     currentOutput = Math.Min(Math.Max(previousOutputs[0] + accelarationStep, -1), 1);
                     break;
@@ -215,7 +215,7 @@ namespace BrickController2.BusinessLogic
             buttonOutputs[0] = value;
         }
 
-        private (bool UseAxisValue, float AxisValue) ProcessAxisEvent(string gameControllerEventCode, float axisValue, ControllerAction controllerAction, DeviceType deviceType)
+        private (bool UseAxisValue, float AxisValue) ProcessAxisEvent(string gameControllerEventCode, float axisValue, ControllerAction controllerAction, Device device)
         {
             var previousAxisValue = GetPreviousAxisOutput(gameControllerEventCode, controllerAction);
 
@@ -317,7 +317,7 @@ namespace BrickController2.BusinessLogic
                 case ControllerAxisType.Accelerator:
                     if (Math.Abs(axisValue) == 1)
                     {
-                        var accelarationStep = GetAccelarationStep(deviceType);
+                        var accelarationStep = device.AccelarationStep;
                         axisValue = Math.Min(Math.Max(previousAxisValue + (axisValue * accelarationStep), -1), 1);
                     }
                     else
@@ -415,21 +415,6 @@ namespace BrickController2.BusinessLogic
             }
 
             return outputValue;
-        }
-
-        private float GetAccelarationStep(DeviceType deviceType)
-        {
-            switch (deviceType)
-            {
-                case DeviceType.BuWizz:
-                case DeviceType.BuWizz2:
-                case DeviceType.Infrared:
-                case DeviceType.SBrick:
-                    return 1F / 7;
-
-                default:
-                    return 0.1F;
-            }
         }
     }
 }

--- a/BrickController2/BrickController2/DeviceManagement/BuWizz2Device.cs
+++ b/BrickController2/BrickController2/DeviceManagement/BuWizz2Device.cs
@@ -57,6 +57,9 @@ namespace BrickController2.DeviceManagement
         public override int NumberOfChannels => 4;
         public override int NumberOfOutputLevels => 4;
         public override int DefaultOutputLevel => (int)GetSettingValue(DefaultOutputLevelName, DefaultLevel);
+
+        public override float AccelarationStep => 1.0f / 7.0f;
+
         protected override bool AutoConnectOnFirstConnect => false;
 
         public override string BatteryVoltageSign => "V";

--- a/BrickController2/BrickController2/DeviceManagement/BuwizzDevice.cs
+++ b/BrickController2/BrickController2/DeviceManagement/BuwizzDevice.cs
@@ -40,6 +40,8 @@ namespace BrickController2.DeviceManagement
         public override int DefaultOutputLevel => (int)GetSettingValue(DefaultOutputLevelName, DefaultLevel);
         protected override bool AutoConnectOnFirstConnect => false;
 
+        public override float AccelarationStep => 1.0f / 7.0f;
+
         public override void SetOutput(int channel, float value)
         {
             CheckChannel(channel);

--- a/BrickController2/BrickController2/DeviceManagement/Device.cs
+++ b/BrickController2/BrickController2/DeviceManagement/Device.cs
@@ -76,6 +76,8 @@ namespace BrickController2.DeviceManagement
         public virtual int NumberOfOutputLevels => 1;
         public virtual int DefaultOutputLevel => 1;
 
+        public virtual float AccelarationStep => 0.1F;
+
         /// <summary>
         /// Check whether the output type specified in <paramref name="outputType"/> is supported
         /// for given channel <paramref name="channel"/> 

--- a/BrickController2/BrickController2/DeviceManagement/PowerFunctions/PowerFunctionsDevice.cs
+++ b/BrickController2/BrickController2/DeviceManagement/PowerFunctions/PowerFunctionsDevice.cs
@@ -20,6 +20,7 @@ namespace BrickController2.DeviceManagement.PowerFunctions
         public static string TypeName => "Power Functions";
         public override DeviceType DeviceType => Type;
         public override int NumberOfChannels => 2;
+        public override float AccelarationStep => 1.0f / 7.0f;
 
         public override async Task<DeviceConnectionResult> ConnectAsync(
             bool reconnect,

--- a/BrickController2/BrickController2/DeviceManagement/SBrickDevice.cs
+++ b/BrickController2/BrickController2/DeviceManagement/SBrickDevice.cs
@@ -35,6 +35,7 @@ namespace BrickController2.DeviceManagement
         public override DeviceType DeviceType => DeviceType.SBrick;
         public override string BatteryVoltageSign => "V";
         public override int NumberOfChannels => 4;
+        public override float AccelarationStep => 1.0f / 7.0f;
         protected override bool AutoConnectOnFirstConnect => false;
 
         public override void SetOutput(int channel, float value)


### PR DESCRIPTION
`PlayLogic.ProcessButtonEvent` and `PlayLogic.ProcessAxisEvent` previously relied on GetAccelerationStep(DeviceType) to determine device‑dependent acceleration values.

```C
        private float GetAccelarationStep(DeviceType deviceType)
        {
            switch (deviceType)
            {
                case DeviceType.BuWizz:
                case DeviceType.BuWizz2:
                case DeviceType.Infrared:
                case DeviceType.SBrick:
                    return 1F / 7;

                default:
                    return 0.1F;
            }
        }

```

Since this logic is device‑specific, it should not reside in shared PlayLogic code.

The acceleration step is now exposed as a property on each device, removing the central switch statement and improving encapsulation and extensibility.