### PR TITLE
Force MAUI to override WinUI's native minimum width directly

### DIFF
--- a/BrickController2/BrickController2/UI/Pages/ManualDeviceListPage.xaml
+++ b/BrickController2/BrickController2/UI/Pages/ManualDeviceListPage.xaml
@@ -58,7 +58,7 @@
                                 </Grid.ColumnDefinitions>
                                 <Label Grid.Column="1" Text="{Binding DeviceFactoryData.Address}" FontSize="Medium" VerticalTextAlignment="Center"/>
                                 <Switch Grid.Column="2" IsToggled="{Binding Selected}" ToolTipProperties.Text="{extensions:Translate AddDevice}" HorizontalOptions="End"
-                                        MinimumWidthRequest="{OnPlatform WinUI=80, Default=-1}"/>
+                                        MinimumWidthRequest="{OnPlatform WinUI=80, Default=Unset}"/>
                             </Grid>
                         </DataTemplate>
                     </CollectionView.ItemTemplate>

--- a/BrickController2/BrickController2/UI/Pages/ManualDeviceListPage.xaml
+++ b/BrickController2/BrickController2/UI/Pages/ManualDeviceListPage.xaml
@@ -57,7 +57,8 @@
                                     <ColumnDefinition Width="*" />
                                 </Grid.ColumnDefinitions>
                                 <Label Grid.Column="1" Text="{Binding DeviceFactoryData.Address}" FontSize="Medium" VerticalTextAlignment="Center"/>
-                                <Switch Grid.Column="2" IsToggled="{Binding Selected}" ToolTipProperties.Text="{extensions:Translate AddDevice}" HorizontalOptions="End"/>
+                                <Switch Grid.Column="2" IsToggled="{Binding Selected}" ToolTipProperties.Text="{extensions:Translate AddDevice}" HorizontalOptions="End"
+                                        MinimumWidthRequest="{OnPlatform WinUI=80}"/>
                             </Grid>
                         </DataTemplate>
                     </CollectionView.ItemTemplate>

--- a/BrickController2/BrickController2/UI/Pages/ManualDeviceListPage.xaml
+++ b/BrickController2/BrickController2/UI/Pages/ManualDeviceListPage.xaml
@@ -58,7 +58,7 @@
                                 </Grid.ColumnDefinitions>
                                 <Label Grid.Column="1" Text="{Binding DeviceFactoryData.Address}" FontSize="Medium" VerticalTextAlignment="Center"/>
                                 <Switch Grid.Column="2" IsToggled="{Binding Selected}" ToolTipProperties.Text="{extensions:Translate AddDevice}" HorizontalOptions="End"
-                                        MinimumWidthRequest="{OnPlatform WinUI=80, Default=Unset}"/>
+                                        MinimumWidthRequest="{OnPlatform WinUI=80, Default=-1}"/>
                             </Grid>
                         </DataTemplate>
                     </CollectionView.ItemTemplate>

--- a/BrickController2/BrickController2/UI/Pages/ManualDeviceListPage.xaml
+++ b/BrickController2/BrickController2/UI/Pages/ManualDeviceListPage.xaml
@@ -58,7 +58,7 @@
                                 </Grid.ColumnDefinitions>
                                 <Label Grid.Column="1" Text="{Binding DeviceFactoryData.Address}" FontSize="Medium" VerticalTextAlignment="Center"/>
                                 <Switch Grid.Column="2" IsToggled="{Binding Selected}" ToolTipProperties.Text="{extensions:Translate AddDevice}" HorizontalOptions="End"
-                                        MinimumWidthRequest="{OnPlatform WinUI=80}"/>
+                                        MinimumWidthRequest="{OnPlatform WinUI=80, Default=Unset}"/>
                             </Grid>
                         </DataTemplate>
                     </CollectionView.ItemTemplate>


### PR DESCRIPTION
Applied reasonable workaround:
<img width="405" height="266" alt="image" src="https://github.com/user-attachments/assets/3929755a-e0f6-45e2-8f39-ddff5a816cbc" />


Resolves #247 