### PR TITLE
Add multiple datagram payload tests with mocks and helpers

### DIFF
--- a/BrickController2/BrickController2.Tests/DeviceManagement/CaDA/CaDADeviceManagerTests.cs
+++ b/BrickController2/BrickController2.Tests/DeviceManagement/CaDA/CaDADeviceManagerTests.cs
@@ -2,7 +2,6 @@
 using BrickController2.DeviceManagement.CaDA;
 using BrickController2.PlatformServices.BluetoothLE;
 using BrickController2.UI.Services.AppIdentifier;
-using BrickController2.UI.Services.Preferences;
 using FluentAssertions;
 using Moq;
 using System.Collections.Generic;
@@ -12,17 +11,20 @@ namespace BrickController2.Tests.DeviceManagement.CaDA;
 
 public class CaDADeviceManagerTests
 {
+    private const byte AppIdentifier1 = 0x61; // This is the first byte of an randomly chosen AppIdentifier for UnitTesting
+    private const byte AppIdentifier2 = 0x62; // This is the second byte of an randomly chosen AppIdentifier for UnitTesting
+    private const byte AppIdentifier3 = 0x63; // This is the third byte of an randomly chosen AppIdentifier for UnitTesting
+
     private readonly CaDADeviceManager _manager;
-    private readonly Mock<IPreferencesService> _preferencesService = new(MockBehavior.Strict);
+    private readonly Mock<IAppIdentifierService> _appIdentifierService = new(MockBehavior.Strict);
     private readonly Mock<ICaDAPlatformService> _cadaPlatformService = new(MockBehavior.Strict);
 
     public CaDADeviceManagerTests()
     {
-        _preferencesService.Setup(x => x.ContainsKey("Identifier", "App")).Returns(true);
-        _preferencesService.Setup(x => x.Get("Identifier", "", "App")).Returns("YWJj");
+        _appIdentifierService.Setup(x => x.GetAppId(2)).Returns(new byte[] { AppIdentifier1, AppIdentifier2 });
+        _appIdentifierService.Setup(x => x.GetAppId(3)).Returns(new byte[] { AppIdentifier1, AppIdentifier2, AppIdentifier3 });
 
-        IAppIdentifierService appIdentifierService = new AppIdentifierService(_preferencesService.Object);
-        _manager = new CaDADeviceManager(appIdentifierService, _cadaPlatformService.Object);
+        _manager = new CaDADeviceManager(_appIdentifierService.Object, _cadaPlatformService.Object);
     }
 
     [Fact]
@@ -155,9 +157,9 @@ public class CaDADeviceManagerTests
     {
         var appId = _manager.GetAppId();
         appId.Length.Should().Be(3);
-        appId.Span[0].Should().Be(0x61); // 'a' = 0x61
-        appId.Span[1].Should().Be(0x62); // 'b' = 0x62
-        appId.Span[2].Should().Be(0x63); // 'c' = 0x63
+        appId.Span[0].Should().Be(AppIdentifier1);
+        appId.Span[1].Should().Be(AppIdentifier2);
+        appId.Span[2].Should().Be(AppIdentifier3);
     }
 
     [Fact]

--- a/BrickController2/BrickController2.Tests/DeviceManagement/JieStar/JieStarDatagramTestsBase.cs
+++ b/BrickController2/BrickController2.Tests/DeviceManagement/JieStar/JieStarDatagramTestsBase.cs
@@ -1,4 +1,5 @@
-﻿using BrickController2.DeviceManagement.JieStar;
+﻿using BrickController2.DeviceManagement;
+using BrickController2.DeviceManagement.JieStar;
 using BrickController2.PlatformServices.BluetoothLE;
 using Moq;
 
@@ -27,6 +28,7 @@ public abstract class JieStarDatagramTestsBase
     protected readonly Mock<IBluetoothLEService> _bluetoothLEService = new(MockBehavior.Strict);
     protected readonly Mock<IJieStarDeviceManager> _manager = new(MockBehavior.Strict);
     protected readonly TestJieStarPlatformService _jieStarPlatformService = new();
+    internal readonly Mock<IDeviceRepository> _deviceRepository = new(MockBehavior.Strict);
 
     protected JieStarDatagramTestsBase()
     {

--- a/BrickController2/BrickController2.Tests/DeviceManagement/JieStar/JieStarDatagramTestsBase.cs
+++ b/BrickController2/BrickController2.Tests/DeviceManagement/JieStar/JieStarDatagramTestsBase.cs
@@ -1,0 +1,35 @@
+﻿using BrickController2.DeviceManagement.JieStar;
+using BrickController2.PlatformServices.BluetoothLE;
+using Moq;
+
+namespace BrickController2.Tests.DeviceManagement.JieStar;
+
+public abstract class JieStarDatagramTestsBase
+{
+    protected const byte AppIdentifier1 = 0x61; // This is the first byte of an randomly choosen AppIdentifier for UnitTesting
+    protected const byte AppIdentifier2 = 0x62; // This is the second byte of an randomly choosen AppIdentifier for UnitTesting
+
+    protected static readonly byte[] AppIdentifier = [AppIdentifier1, AppIdentifier2];
+
+    /// <summary>
+    /// This class is a test implementation of the IJieStarPlatformService interface that simulates the behavior of the TryGetRfPayload method for testing purposes.
+    /// It always returns true and sets the rfPayload to the rawData provided.
+    /// </summary>
+    protected class TestJieStarPlatformService : IJieStarPlatformService
+    {
+        public bool TryGetRfPayload(byte ctxValue2, byte[] rawData, out byte[] rfPayload)
+        {
+            rfPayload = rawData;
+            return true; // Simulate success
+        }
+    }
+
+    protected readonly Mock<IBluetoothLEService> _bluetoothLEService = new(MockBehavior.Strict);
+    protected readonly Mock<IJieStarDeviceManager> _manager = new(MockBehavior.Strict);
+    protected readonly TestJieStarPlatformService _jieStarPlatformService = new();
+
+    protected JieStarDatagramTestsBase()
+    {
+        _manager.Setup(x => x.GetAppId()).Returns(AppIdentifier);
+    }
+}

--- a/BrickController2/BrickController2.Tests/DeviceManagement/JieStar/JieStarDeviceManagerTests.cs
+++ b/BrickController2/BrickController2.Tests/DeviceManagement/JieStar/JieStarDeviceManagerTests.cs
@@ -1,6 +1,5 @@
 ﻿using BrickController2.DeviceManagement.JieStar;
 using BrickController2.UI.Services.AppIdentifier;
-using BrickController2.UI.Services.Preferences;
 using FluentAssertions;
 using Moq;
 using Xunit;
@@ -9,16 +8,17 @@ namespace BrickController2.Tests.DeviceManagement.JieStar;
 
 public class JieStarDeviceManagerTests
 {
+    private const byte AppIdentifier1 = 0x61; // This is the first byte of an randomly chosen AppIdentifier for UnitTesting
+    private const byte AppIdentifier2 = 0x62; // This is the second byte of an randomly chosen AppIdentifier for UnitTesting
+
     private readonly IJieStarDeviceManager _manager;
-    private readonly Mock<IPreferencesService> _preferencesService = new(MockBehavior.Strict);
+    private readonly Mock<IAppIdentifierService> _appIdentifierService = new(MockBehavior.Strict);
 
     public JieStarDeviceManagerTests()
     {
-        _preferencesService.Setup(x => x.ContainsKey("Identifier", "App")).Returns(true);
-        _preferencesService.Setup(x => x.Get("Identifier", "", "App")).Returns("YWJj");
+        _appIdentifierService.Setup(x => x.GetAppId(2)).Returns(new byte[] { AppIdentifier1, AppIdentifier2 });
 
-        IAppIdentifierService appIdentifierService = new AppIdentifierService(_preferencesService.Object);
-        _manager = new JieStarDeviceManager(appIdentifierService);
+        _manager = new JieStarDeviceManager(_appIdentifierService.Object);
     }
 
     [Fact]
@@ -26,7 +26,7 @@ public class JieStarDeviceManagerTests
     {
         var appId = _manager.GetAppId();
         appId.Length.Should().Be(2);
-        appId.Span[0].Should().Be(0x61); // 'a' = 0x61
-        appId.Span[1].Should().Be(0x62); // 'b' = 0x62
+        appId.Span[0].Should().Be(AppIdentifier1);
+        appId.Span[1].Should().Be(AppIdentifier2);
     }
 }

--- a/BrickController2/BrickController2.Tests/DeviceManagement/JieStar/JieStarDeviceManagerTests.cs
+++ b/BrickController2/BrickController2.Tests/DeviceManagement/JieStar/JieStarDeviceManagerTests.cs
@@ -9,7 +9,7 @@ namespace BrickController2.Tests.DeviceManagement.JieStar;
 
 public class JieStarDeviceManagerTests
 {
-    private readonly JieStarDeviceManager _manager;
+    private readonly IJieStarDeviceManager _manager;
     private readonly Mock<IPreferencesService> _preferencesService = new(MockBehavior.Strict);
 
     public JieStarDeviceManagerTests()

--- a/BrickController2/BrickController2.Tests/DeviceManagement/JieStar/JieStarSCM4DatagramTests.cs
+++ b/BrickController2/BrickController2.Tests/DeviceManagement/JieStar/JieStarSCM4DatagramTests.cs
@@ -120,10 +120,7 @@ public sealed class JieStarSCM4DatagramTests : JieStarDatagramTestsBase
         device.TryGetTelegram(false, out byte[] payload).Should().BeTrue();
 
         // Check that the payload matches the expected values
-        for (int i = 0; i < expectedPayload.Length; i++)
-        {
-            payload[i].Should().Be(expectedPayload[i]);
-        }
+        payload.Should().BeEquivalentTo(expectedPayload);
     }
 
     /// <summary>
@@ -149,25 +146,25 @@ public sealed class JieStarSCM4DatagramTests : JieStarDatagramTestsBase
     [Fact]
     public void TryGetTelegram_CommandDatagram_InstanceInteraction()
     {
-        float[] setValues_1 = [1.0f, 1.0f, 1.0f, 1.0f];
-        byte[] expectedPayload_1 = [PayloadIdentifierCommand1, AppIdentifier1, AppIdentifier2, 0xff, 0xff, 0x80, 0x80, PayloadIdentifierCommand2];
+        float[] setValues1 = [1.0f, 1.0f, 1.0f, 1.0f];
+        byte[] expectedPayload1 = [PayloadIdentifierCommand1, AppIdentifier1, AppIdentifier2, 0xff, 0xff, 0x80, 0x80, PayloadIdentifierCommand2];
 
-        float[] setValues_2 = [0.0f, 0.0f, 0.0f, 0.0f];
-        byte[] expectedPayload_2 = [PayloadIdentifierCommand1, AppIdentifier1, AppIdentifier2, 0x00, 0x00, 0x80, 0x80, PayloadIdentifierCommand2];
+        float[] setValues2 = [0.0f, 0.0f, 0.0f, 0.0f];
+        byte[] expectedPayload2 = [PayloadIdentifierCommand1, AppIdentifier1, AppIdentifier2, 0x00, 0x00, 0x80, 0x80, PayloadIdentifierCommand2];
 
-        float[] setValues_3 = [0.0f, 0.0f, 0.0f, 0.0f];
-        byte[] expectedPayload_3 = [PayloadIdentifierCommand1, AppIdentifier1, AppIdentifier2, 0x00, 0x00, 0x80, 0x80, PayloadIdentifierCommand2];
+        float[] setValues3 = [0.0f, 0.0f, 0.0f, 0.0f];
+        byte[] expectedPayload3 = [PayloadIdentifierCommand1, AppIdentifier1, AppIdentifier2, 0x00, 0x00, 0x80, 0x80, PayloadIdentifierCommand2];
 
         JieStarSCM4 device1 = new JieStarSCM4("JieStarSCM4", JieStarSCM4.Device1, [], _deviceRepository.Object, _bluetoothLEService.Object, _jieStarPlatformService, _manager.Object);
         JieStarSCM4 device2 = new JieStarSCM4("JieStarSCM4", JieStarSCM4.Device2, [], _deviceRepository.Object, _bluetoothLEService.Object, _jieStarPlatformService, _manager.Object);
         JieStarSCM4 device3 = new JieStarSCM4("JieStarSCM4", JieStarSCM4.Device3, [], _deviceRepository.Object, _bluetoothLEService.Object, _jieStarPlatformService, _manager.Object);
 
         // Set the output values for the device
-        for (int i = 0; i < setValues_1.Length; i++)
+        for (int i = 0; i < setValues1.Length; i++)
         {
-            device1.SetOutput(i, setValues_1[i]);
-            device2.SetOutput(i, setValues_2[i]);
-            device3.SetOutput(i, setValues_3[i]);
+            device1.SetOutput(i, setValues1[i]);
+            device2.SetOutput(i, setValues2[i]);
+            device3.SetOutput(i, setValues3[i]);
         }
 
         // Get the command datagram payload
@@ -176,11 +173,8 @@ public sealed class JieStarSCM4DatagramTests : JieStarDatagramTestsBase
         device3.TryGetTelegram(false, out byte[] payload3).Should().BeTrue();
 
         // Check that the payload matches the expected values
-        for (int i = 0; i < expectedPayload_1.Length; i++)
-        {
-            payload1[i].Should().Be(expectedPayload_1[i]);
-            payload2[i].Should().Be(expectedPayload_2[i]);
-            payload3[i].Should().Be(expectedPayload_3[i]);
-        }
+        payload1.Should().BeEquivalentTo(expectedPayload1);
+        payload2.Should().BeEquivalentTo(expectedPayload2);
+        payload3.Should().BeEquivalentTo(expectedPayload3);
     }
 }

--- a/BrickController2/BrickController2.Tests/DeviceManagement/JieStar/JieStarSCM4DatagramTests.cs
+++ b/BrickController2/BrickController2.Tests/DeviceManagement/JieStar/JieStarSCM4DatagramTests.cs
@@ -1,0 +1,149 @@
+﻿using BrickController2.DeviceManagement;
+using BrickController2.DeviceManagement.JieStar;
+using FluentAssertions;
+using Moq;
+using System;
+using Xunit;
+
+namespace BrickController2.Tests.DeviceManagement.JieStar;
+
+public sealed class JieStarSCM4DatagramTests : JieStarDatagramTestsBase
+{
+    private const byte PayloadIdentifierConnect1 = 0xa4;
+    private const byte PayloadIdentifierConnect2 = 0x5b;
+    private const byte PayloadIdentifierCommand1 = 0x40;
+    private const byte PayloadIdentifierCommand2 = 0xbf;
+
+    private readonly Mock<IDeviceRepository> _deviceRepository = new(MockBehavior.Strict); // IDeviceRepository is defined as internal, so we can't declare it as a field in the base class. We need to declare it here in the derived class.
+
+    /// <summary>
+    /// This test checks that the payload identifiers are correctly set in the connect datagram for each device address.
+    /// </summary>
+    /// <param name="deviceAddress">The address of the device to test.</param>
+    [Theory]
+    [InlineData(JieStarSCM4.Device1)]
+    [InlineData(JieStarSCM4.Device2)]
+    [InlineData(JieStarSCM4.Device3)]
+    public void TryGetTelegram_ConnectDatagram_PayloadIdentifier(string deviceAddress)
+    {
+        JieStarSCM4 device = new JieStarSCM4("JieStarSCM4", deviceAddress, [], _deviceRepository.Object, _bluetoothLEService.Object, _jieStarPlatformService, _manager.Object);
+
+        device.TryGetTelegram(true, out byte[] payload).Should().BeTrue();
+        payload[0].Should().Be(PayloadIdentifierConnect1);
+        payload[7].Should().Be(PayloadIdentifierConnect2);
+    }
+
+    /// <summary>
+    /// This test checks that the AppIdentifier is correctly included in the connect datagram payload for each device address.
+    /// </summary>
+    /// <param name="deviceAddress">The address of the device to test.</param>
+    [Theory]
+    [InlineData(JieStarSCM4.Device1)]
+    [InlineData(JieStarSCM4.Device2)]
+    [InlineData(JieStarSCM4.Device3)]
+    public void TryGetTelegram_ConnectDatagram_AppIdentifier(string deviceAddress)
+    {
+        JieStarSCM4 device = new JieStarSCM4("JieStarSCM4", deviceAddress, [], _deviceRepository.Object, _bluetoothLEService.Object, _jieStarPlatformService, _manager.Object);
+
+        device.TryGetTelegram(true, out byte[] payload).Should().BeTrue();
+        payload[1].Should().Be(AppIdentifier1);
+        payload[2].Should().Be(AppIdentifier2);
+    }
+
+    /// <summary>
+    /// This test checks that the payload identifiers are correctly set in the command datagram for each device address.
+    /// </summary>
+    /// <param name="deviceAddress">The address of the device to test.</param>
+    [Theory]
+    [InlineData(JieStarSCM4.Device1)]
+    [InlineData(JieStarSCM4.Device2)]
+    [InlineData(JieStarSCM4.Device3)]
+    public void TryGetTelegram_CommandDatagram_PayloadIdentifier(string deviceAddress)
+    {
+        JieStarSCM4 device = new JieStarSCM4("JieStarSCM4", deviceAddress, [], _deviceRepository.Object, _bluetoothLEService.Object, _jieStarPlatformService, _manager.Object);
+
+        device.TryGetTelegram(false, out byte[] payload).Should().BeTrue();
+        payload[0].Should().Be(PayloadIdentifierCommand1);
+        payload[7].Should().Be(PayloadIdentifierCommand2);
+    }
+
+    /// <summary>
+    /// This test checks that the AppIdentifier is correctly included in the command datagram payload for each device address.
+    /// </summary>
+    /// <param name="deviceAddress">The address of the device to test.</param>
+    [Theory]
+    [InlineData(JieStarSCM4.Device1)]
+    [InlineData(JieStarSCM4.Device2)]
+    [InlineData(JieStarSCM4.Device3)]
+    public void TryGetTelegram_CommandDatagram_AppIdentifier(string deviceAddress)
+    {
+        JieStarSCM4 device = new JieStarSCM4("JieStarSCM4", deviceAddress, [], _deviceRepository.Object, _bluetoothLEService.Object, _jieStarPlatformService, _manager.Object);
+
+        device.TryGetTelegram(false, out byte[] payload).Should().BeTrue();
+        payload[1].Should().Be(AppIdentifier1);
+        payload[2].Should().Be(AppIdentifier2);
+    }
+
+    /// <summary>
+    /// This test checks that the command datagram payload is correctly constructed based on the set output values for each device address.
+    /// </summary>
+    /// <param name="deviceAddress">The address of the device to test.</param>
+    /// <param name="setValues">The set values for each channel.</param>
+    /// <param name="expectedPayload">The expected payload for the command datagram.</param>
+    [Theory]
+    [InlineData(JieStarSCM4.Device1, new float[] { 0.0f, 0.0f, 0.0f, 0.0f }, new byte[] { PayloadIdentifierCommand1, AppIdentifier1, AppIdentifier2, 0x00, 0x00, 0x80, 0x80, PayloadIdentifierCommand2 })]      // all channels neutral
+    [InlineData(JieStarSCM4.Device1, new float[] { 1.0f, 0.0f, 0.0f, 0.0f }, new byte[] { PayloadIdentifierCommand1, AppIdentifier1, AppIdentifier2, 0xf0, 0x00, 0x80, 0x80, PayloadIdentifierCommand2 })]      // channel 1 maximum, others neutral
+    [InlineData(JieStarSCM4.Device1, new float[] { 0.0f, 1.0f, 0.0f, 0.0f }, new byte[] { PayloadIdentifierCommand1, AppIdentifier1, AppIdentifier2, 0x0f, 0x00, 0x80, 0x80, PayloadIdentifierCommand2 })]      // channel 2 maximum, others neutral
+    [InlineData(JieStarSCM4.Device1, new float[] { 0.0f, 0.0f, 1.0f, 0.0f }, new byte[] { PayloadIdentifierCommand1, AppIdentifier1, AppIdentifier2, 0x00, 0xf0, 0x80, 0x80, PayloadIdentifierCommand2 })]      // channel 3 maximum, others neutral
+    [InlineData(JieStarSCM4.Device1, new float[] { 0.0f, 0.0f, 0.0f, 1.0f }, new byte[] { PayloadIdentifierCommand1, AppIdentifier1, AppIdentifier2, 0x00, 0x0f, 0x80, 0x80, PayloadIdentifierCommand2 })]      // channel 4 maximum, others neutral
+    [InlineData(JieStarSCM4.Device1, new float[] { -1.0f, 0.0f, 0.0f, 0.0f }, new byte[] { PayloadIdentifierCommand1, AppIdentifier1, AppIdentifier2, 0x70, 0x00, 0x80, 0x80, PayloadIdentifierCommand2 })]     // channel 1 minimum, others neutral
+    [InlineData(JieStarSCM4.Device1, new float[] { 0.0f, -1.0f, 0.0f, 0.0f }, new byte[] { PayloadIdentifierCommand1, AppIdentifier1, AppIdentifier2, 0x07, 0x00, 0x80, 0x80, PayloadIdentifierCommand2 })]     // channel 2 minimum, others neutral
+    [InlineData(JieStarSCM4.Device1, new float[] { 0.0f, 0.0f, -1.0f, 0.0f }, new byte[] { PayloadIdentifierCommand1, AppIdentifier1, AppIdentifier2, 0x00, 0x70, 0x80, 0x80, PayloadIdentifierCommand2 })]     // channel 3 minimum, others neutral
+    [InlineData(JieStarSCM4.Device1, new float[] { 0.0f, 0.0f, 0.0f, -1.0f }, new byte[] { PayloadIdentifierCommand1, AppIdentifier1, AppIdentifier2, 0x00, 0x07, 0x80, 0x80, PayloadIdentifierCommand2 })]     // channel 4 minimum, others neutral
+    [InlineData(JieStarSCM4.Device1, new float[] { 9.0f, 9.0f, 9.0f, 9.0f, }, new byte[] { PayloadIdentifierCommand1, AppIdentifier1, AppIdentifier2, 0xff, 0xff, 0x80, 0x80, PayloadIdentifierCommand2 })]     // all channels above maximum, should be clamped to maximum
+    [InlineData(JieStarSCM4.Device1, new float[] { -9.0f, -9.0f, -9.0f, -9.0f }, new byte[] { PayloadIdentifierCommand1, AppIdentifier1, AppIdentifier2, 0x77, 0x77, 0x80, 0x80, PayloadIdentifierCommand2 })]  // all channels below minimum, should be clamped to minimum
+
+    [InlineData(JieStarSCM4.Device2, new float[] { 0.0f, 0.0f, 0.0f, 0.0f }, new byte[]     { PayloadIdentifierCommand1, AppIdentifier1, AppIdentifier2, 0x00, 0x00, 0x80, 0x80, PayloadIdentifierCommand2 })]      // all channels neutral
+    [InlineData(JieStarSCM4.Device2, new float[] { 9.0f, 9.0f, 9.0f, 9.0f }, new byte[]     { PayloadIdentifierCommand1, AppIdentifier1, AppIdentifier2, 0xff, 0xff, 0x80, 0x80, PayloadIdentifierCommand2 })]      // all channels above maximum, should be clamped to maximum
+    [InlineData(JieStarSCM4.Device2, new float[] { -9.0f, -9.0f, -9.0f, -9.0f }, new byte[] { PayloadIdentifierCommand1, AppIdentifier1, AppIdentifier2, 0x77, 0x77, 0x80, 0x80, PayloadIdentifierCommand2 })]  // all channels below minimum, should be clamped to minimum
+
+    [InlineData(JieStarSCM4.Device3, new float[] { 0.0f, 0.0f, 0.0f, 0.0f }, new byte[]     { PayloadIdentifierCommand1, AppIdentifier1, AppIdentifier2, 0x00, 0x00, 0x80, 0x80, PayloadIdentifierCommand2 })]      // all channels neutral
+    [InlineData(JieStarSCM4.Device3, new float[] { 9.0f, 9.0f, 9.0f, 9.0f }, new byte[]     { PayloadIdentifierCommand1, AppIdentifier1, AppIdentifier2, 0xff, 0xff, 0x80, 0x80, PayloadIdentifierCommand2 })]      // all channels above maximum, should be clamped to maximum
+    [InlineData(JieStarSCM4.Device3, new float[] { -9.0f, -9.0f, -9.0f, -9.0f }, new byte[] { PayloadIdentifierCommand1, AppIdentifier1, AppIdentifier2, 0x77, 0x77, 0x80, 0x80, PayloadIdentifierCommand2 })]  // all channels below minimum, should be clamped to minimum
+    public void TryGetTelegram_CommandDatagram_Payload(string deviceAddress, float[] setValues, byte[] expectedPayload)
+    {
+        JieStarSCM4 device = new JieStarSCM4("JieStarSCM4", deviceAddress, [], _deviceRepository.Object, _bluetoothLEService.Object, _jieStarPlatformService, _manager.Object);
+
+        // Set the output values for the device
+        for (int i = 0; i < setValues.Length; i++)
+        {
+            device.SetOutput(i, setValues[i]);
+        }
+
+        // Get the command datagram payload
+        device.TryGetTelegram(false, out byte[] payload).Should().BeTrue();
+
+        // Check that the payload matches the expected values
+        for (int i = 0; i < expectedPayload.Length; i++)
+        {
+            payload[i].Should().Be(expectedPayload[i]);
+        }
+    }
+
+    /// <summary>
+    /// Tests that setting an illegal channel index throws an ArgumentOutOfRangeException.
+    /// </summary>
+    /// <param name="deviceAddress">The address of the device to test.</param>
+    [Theory]
+    [InlineData(JieStarSCM4.Device1)]
+    [InlineData(JieStarSCM4.Device2)]
+    [InlineData(JieStarSCM4.Device3)]
+    public void TryGetTelegram_CommandDatagram_SetIllegalChannel(string deviceAddress)
+    {
+        JieStarSCM4 device = new JieStarSCM4("JieStarSCM4", deviceAddress, [], _deviceRepository.Object, _bluetoothLEService.Object, _jieStarPlatformService, _manager.Object);
+
+        Action action = () => device.SetOutput(device.NumberOfChannels, 0);
+
+        action.Should().Throw<ArgumentOutOfRangeException>();
+    }
+}

--- a/BrickController2/BrickController2.Tests/DeviceManagement/JieStar/JieStarSCM4DatagramTests.cs
+++ b/BrickController2/BrickController2.Tests/DeviceManagement/JieStar/JieStarSCM4DatagramTests.cs
@@ -1,7 +1,5 @@
-﻿using BrickController2.DeviceManagement;
-using BrickController2.DeviceManagement.JieStar;
+﻿using BrickController2.DeviceManagement.JieStar;
 using FluentAssertions;
-using Moq;
 using System;
 using Xunit;
 
@@ -13,8 +11,6 @@ public sealed class JieStarSCM4DatagramTests : JieStarDatagramTestsBase
     private const byte PayloadIdentifierConnect2 = 0x5b;
     private const byte PayloadIdentifierCommand1 = 0x40;
     private const byte PayloadIdentifierCommand2 = 0xbf;
-
-    private readonly Mock<IDeviceRepository> _deviceRepository = new(MockBehavior.Strict); // IDeviceRepository is defined as internal, so we can't declare it as a field in the base class. We need to declare it here in the derived class.
 
     /// <summary>
     /// This test checks that the payload identifiers are correctly set in the connect datagram for each device address.

--- a/BrickController2/BrickController2.Tests/DeviceManagement/JieStar/JieStarSCM4DatagramTests.cs
+++ b/BrickController2/BrickController2.Tests/DeviceManagement/JieStar/JieStarSCM4DatagramTests.cs
@@ -142,4 +142,45 @@ public sealed class JieStarSCM4DatagramTests : JieStarDatagramTestsBase
 
         action.Should().Throw<ArgumentOutOfRangeException>();
     }
+
+    /// <summary>
+    /// This test checks that the command datagram payload is correctly constructed based on the set output values for multiple devices, ensuring that each device's payload is independent of the others.
+    /// </summary>
+    [Fact]
+    public void TryGetTelegram_CommandDatagram_InstanceInteraction()
+    {
+        float[] setValues_1 = [1.0f, 1.0f, 1.0f, 1.0f];
+        byte[] expectedPayload_1 = [PayloadIdentifierCommand1, AppIdentifier1, AppIdentifier2, 0xff, 0xff, 0x80, 0x80, PayloadIdentifierCommand2];
+
+        float[] setValues_2 = [0.0f, 0.0f, 0.0f, 0.0f];
+        byte[] expectedPayload_2 = [PayloadIdentifierCommand1, AppIdentifier1, AppIdentifier2, 0x00, 0x00, 0x80, 0x80, PayloadIdentifierCommand2];
+
+        float[] setValues_3 = [0.0f, 0.0f, 0.0f, 0.0f];
+        byte[] expectedPayload_3 = [PayloadIdentifierCommand1, AppIdentifier1, AppIdentifier2, 0x00, 0x00, 0x80, 0x80, PayloadIdentifierCommand2];
+
+        JieStarSCM4 device1 = new JieStarSCM4("JieStarSCM4", JieStarSCM4.Device1, [], _deviceRepository.Object, _bluetoothLEService.Object, _jieStarPlatformService, _manager.Object);
+        JieStarSCM4 device2 = new JieStarSCM4("JieStarSCM4", JieStarSCM4.Device2, [], _deviceRepository.Object, _bluetoothLEService.Object, _jieStarPlatformService, _manager.Object);
+        JieStarSCM4 device3 = new JieStarSCM4("JieStarSCM4", JieStarSCM4.Device3, [], _deviceRepository.Object, _bluetoothLEService.Object, _jieStarPlatformService, _manager.Object);
+
+        // Set the output values for the device
+        for (int i = 0; i < setValues_1.Length; i++)
+        {
+            device1.SetOutput(i, setValues_1[i]);
+            device2.SetOutput(i, setValues_2[i]);
+            device3.SetOutput(i, setValues_3[i]);
+        }
+
+        // Get the command datagram payload
+        device1.TryGetTelegram(false, out byte[] payload1).Should().BeTrue();
+        device2.TryGetTelegram(false, out byte[] payload2).Should().BeTrue();
+        device3.TryGetTelegram(false, out byte[] payload3).Should().BeTrue();
+
+        // Check that the payload matches the expected values
+        for (int i = 0; i < expectedPayload_1.Length; i++)
+        {
+            payload1[i].Should().Be(expectedPayload_1[i]);
+            payload2[i].Should().Be(expectedPayload_2[i]);
+            payload3[i].Should().Be(expectedPayload_3[i]);
+        }
+    }
 }

--- a/BrickController2/BrickController2.Tests/DeviceManagement/JieStar/JieStarSCM8DatagramTests.cs
+++ b/BrickController2/BrickController2.Tests/DeviceManagement/JieStar/JieStarSCM8DatagramTests.cs
@@ -148,4 +148,45 @@ public sealed class JieStarSCM8DatagramTests : JieStarDatagramTestsBase
 
         action.Should().Throw<ArgumentOutOfRangeException>();
     }
+
+    /// <summary>
+    /// This test checks that the command datagram payload is correctly constructed based on the set output values for multiple devices, ensuring that each device's payload is independent of the others.
+    /// </summary>
+    [Fact]
+    public void TryGetTelegram_CommandDatagram_InstanceInteraction()
+    {
+        float[] setValues_1 = [1.0f, 1.0f, 1.0f, 1.0f];
+        byte[] expectedPayload_1 = [PayloadIdentifierCommand1_1, AppIdentifier1, AppIdentifier2, 0xff, 0xff, 0x00, 0x00, PayloadIdentifierCommand1_2];
+
+        float[] setValues_2 = [0.0f, 0.0f, 0.0f, 0.0f];
+        byte[] expectedPayload_2 = [PayloadIdentifierCommand2_1, AppIdentifier1, AppIdentifier2, 0x00, 0x00, 0x00, 0x00, PayloadIdentifierCommand2_2];
+
+        float[] setValues_3 = [0.0f, 0.0f, 0.0f, 0.0f];
+        byte[] expectedPayload_3 = [PayloadIdentifierCommand3_1, AppIdentifier1, AppIdentifier2, 0x00, 0x00, 0x00, 0x00, PayloadIdentifierCommand3_2];
+
+        JieStarSCM8 device1 = new JieStarSCM8("JieStarSCM8", JieStarSCM8.Device1, [], _deviceRepository.Object, _bluetoothLEService.Object, _jieStarPlatformService, _manager.Object);
+        JieStarSCM8 device2 = new JieStarSCM8("JieStarSCM8", JieStarSCM8.Device2, [], _deviceRepository.Object, _bluetoothLEService.Object, _jieStarPlatformService, _manager.Object);
+        JieStarSCM8 device3 = new JieStarSCM8("JieStarSCM8", JieStarSCM8.Device3, [], _deviceRepository.Object, _bluetoothLEService.Object, _jieStarPlatformService, _manager.Object);
+
+        // Set the output values for the device
+        for (int i = 0; i < setValues_1.Length; i++)
+        {
+            device1.SetOutput(i, setValues_1[i]);
+            device2.SetOutput(i, setValues_2[i]);
+            device3.SetOutput(i, setValues_3[i]);
+        }
+
+        // Get the command datagram payload
+        device1.TryGetTelegram(false, out byte[] payload1).Should().BeTrue();
+        device2.TryGetTelegram(false, out byte[] payload2).Should().BeTrue();
+        device3.TryGetTelegram(false, out byte[] payload3).Should().BeTrue();
+
+        // Check that the payload matches the expected values
+        for (int i = 0; i < expectedPayload_1.Length; i++)
+        {
+            payload1[i].Should().Be(expectedPayload_1[i]);
+            payload2[i].Should().Be(expectedPayload_2[i]);
+            payload3[i].Should().Be(expectedPayload_3[i]);
+        }
+    }
 }

--- a/BrickController2/BrickController2.Tests/DeviceManagement/JieStar/JieStarSCM8DatagramTests.cs
+++ b/BrickController2/BrickController2.Tests/DeviceManagement/JieStar/JieStarSCM8DatagramTests.cs
@@ -1,0 +1,155 @@
+﻿using BrickController2.DeviceManagement;
+using BrickController2.DeviceManagement.JieStar;
+using FluentAssertions;
+using Moq;
+using System;
+using Xunit;
+
+namespace BrickController2.Tests.DeviceManagement.JieStar;
+
+public sealed class JieStarSCM8DatagramTests : JieStarDatagramTestsBase
+{
+    private const byte PayloadIdentifierConnect1 = 0xa4;
+    private const byte PayloadIdentifierConnect2 = 0x5b;
+    private const byte PayloadIdentifierCommand1_1 = 0x41;
+    private const byte PayloadIdentifierCommand1_2 = 0xbf;
+    private const byte PayloadIdentifierCommand2_1 = 0x42;
+    private const byte PayloadIdentifierCommand2_2 = 0xbe;
+    private const byte PayloadIdentifierCommand3_1 = 0x43;
+    private const byte PayloadIdentifierCommand3_2 = 0xbd;
+
+    private readonly Mock<IDeviceRepository> _deviceRepository = new(MockBehavior.Strict); // IDeviceRepository is defined as internal, so we can't declare it as a field in the base class. We need to declare it here in the derived class.
+
+    /// <summary>
+    /// This test checks that the payload identifiers are correctly set in the connect datagram for each device address.
+    /// </summary>
+    /// <param name="deviceAddress">The address of the device to test.</param>
+    [Theory]
+    [InlineData(JieStarSCM8.Device1)]
+    [InlineData(JieStarSCM8.Device2)]
+    [InlineData(JieStarSCM8.Device3)]
+    public void TryGetTelegram_ConnectDatagram_PayloadIdentifier(string deviceAddress)
+    {
+        JieStarSCM8 device = new JieStarSCM8("JieStarSCM8", deviceAddress, [], _deviceRepository.Object, _bluetoothLEService.Object, _jieStarPlatformService, _manager.Object);
+
+        device.TryGetTelegram(true, out byte[] payload).Should().BeTrue();
+        payload[0].Should().Be(PayloadIdentifierConnect1);
+        payload[7].Should().Be(PayloadIdentifierConnect2);
+    }
+
+    /// <summary>
+    /// This test checks that the AppIdentifier is correctly included in the connect datagram payload for each device address.
+    /// </summary>
+    /// <param name="deviceAddress">The address of the device to test.</param>
+    [Theory]
+    [InlineData(JieStarSCM8.Device1)]
+    [InlineData(JieStarSCM8.Device2)]
+    [InlineData(JieStarSCM8.Device3)]
+    public void TryGetTelegram_ConnectDatagram_AppIdentifier(string deviceAddress)
+    {
+        JieStarSCM8 device = new JieStarSCM8("JieStarSCM8", deviceAddress, [], _deviceRepository.Object, _bluetoothLEService.Object, _jieStarPlatformService, _manager.Object);
+
+        device.TryGetTelegram(true, out byte[] payload).Should().BeTrue();
+        payload[1].Should().Be(AppIdentifier1);
+        payload[2].Should().Be(AppIdentifier2);
+    }
+
+    /// <summary>
+    /// This test checks that the payload identifiers are correctly set in the command datagram for each device address.
+    /// </summary>
+    /// <param name="deviceAddress">The address of the device to test.</param>
+    /// <param name="expectedPayloadIdentifier1">The expected first payload identifier.</param>
+    /// <param name="expectedPayloadIdentifier2">The expected second payload identifier.</param>
+    [Theory]
+    [InlineData(JieStarSCM8.Device1, PayloadIdentifierCommand1_1, PayloadIdentifierCommand1_2)]
+    [InlineData(JieStarSCM8.Device2, PayloadIdentifierCommand2_1, PayloadIdentifierCommand2_2)]
+    [InlineData(JieStarSCM8.Device3, PayloadIdentifierCommand3_1, PayloadIdentifierCommand3_2)]
+    public void TryGetTelegram_CommandDatagram_PayloadIdentifier(string deviceAddress, byte expectedPayloadIdentifier1, byte expectedPayloadIdentifier2)
+    {
+        JieStarSCM8 device = new JieStarSCM8("JieStarSCM8", deviceAddress, [], _deviceRepository.Object, _bluetoothLEService.Object, _jieStarPlatformService, _manager.Object);
+
+        device.TryGetTelegram(false, out byte[] payload).Should().BeTrue();
+        payload[0].Should().Be(expectedPayloadIdentifier1);
+        payload[7].Should().Be(expectedPayloadIdentifier2);
+    }
+
+    /// <summary>
+    /// This test checks that the AppIdentifier is correctly included in the command datagram payload for each device address.
+    /// </summary>
+    /// <param name="deviceAddress">The address of the device to test.</param>
+    [Theory]
+    [InlineData(JieStarSCM8.Device1)]
+    [InlineData(JieStarSCM8.Device2)]
+    [InlineData(JieStarSCM8.Device3)]
+    public void TryGetTelegram_CommandDatagram_AppIdentifier(string deviceAddress)
+    {
+        JieStarSCM8 device = new JieStarSCM8("JieStarSCM8", deviceAddress, [], _deviceRepository.Object, _bluetoothLEService.Object, _jieStarPlatformService, _manager.Object);
+
+        device.TryGetTelegram(false, out byte[] payload).Should().BeTrue();
+        payload[1].Should().Be(AppIdentifier1);
+        payload[2].Should().Be(AppIdentifier2);
+    }
+
+    /// <summary>
+    /// This test checks that the command datagram payload is correctly constructed based on the set output values for each device address.
+    /// </summary>
+    /// <param name="deviceAddress">The address of the device to test.</param>
+    /// <param name="setValues">The set values for each channel.</param>
+    /// <param name="expectedPayload">The expected payload for the command datagram.</param>
+    [Theory]
+    [InlineData(JieStarSCM8.Device1, new float[] { 0.0f, 0.0f, 0.0f, 0.0f }, new byte[] { PayloadIdentifierCommand1_1, AppIdentifier1, AppIdentifier2, 0x00, 0x00, 0x00, 0x00, PayloadIdentifierCommand1_2 })]      // all channels neutral
+    [InlineData(JieStarSCM8.Device1, new float[] { 1.0f, 0.0f, 0.0f, 0.0f }, new byte[] { PayloadIdentifierCommand1_1, AppIdentifier1, AppIdentifier2, 0xf0, 0x00, 0x00, 0x00, PayloadIdentifierCommand1_2 })]      // channel 1 maximum, others neutral
+    [InlineData(JieStarSCM8.Device1, new float[] { 0.0f, 1.0f, 0.0f, 0.0f }, new byte[] { PayloadIdentifierCommand1_1, AppIdentifier1, AppIdentifier2, 0x0f, 0x00, 0x00, 0x00, PayloadIdentifierCommand1_2 })]      // channel 2 maximum, others neutral
+    [InlineData(JieStarSCM8.Device1, new float[] { 0.0f, 0.0f, 1.0f, 0.0f }, new byte[] { PayloadIdentifierCommand1_1, AppIdentifier1, AppIdentifier2, 0x00, 0xf0, 0x00, 0x00, PayloadIdentifierCommand1_2 })]      // channel 3 maximum, others neutral
+    [InlineData(JieStarSCM8.Device1, new float[] { 0.0f, 0.0f, 0.0f, 1.0f }, new byte[] { PayloadIdentifierCommand1_1, AppIdentifier1, AppIdentifier2, 0x00, 0x0f, 0x00, 0x00, PayloadIdentifierCommand1_2 })]      // channel 4 maximum, others neutral
+    [InlineData(JieStarSCM8.Device1, new float[] { -1.0f, 0.0f, 0.0f, 0.0f }, new byte[] { PayloadIdentifierCommand1_1, AppIdentifier1, AppIdentifier2, 0x70, 0x00, 0x00, 0x00, PayloadIdentifierCommand1_2 })]     // channel 1 minimum, others neutral
+    [InlineData(JieStarSCM8.Device1, new float[] { 0.0f, -1.0f, 0.0f, 0.0f }, new byte[] { PayloadIdentifierCommand1_1, AppIdentifier1, AppIdentifier2, 0x07, 0x00, 0x00, 0x00, PayloadIdentifierCommand1_2 })]     // channel 2 minimum, others neutral
+    [InlineData(JieStarSCM8.Device1, new float[] { 0.0f, 0.0f, -1.0f, 0.0f }, new byte[] { PayloadIdentifierCommand1_1, AppIdentifier1, AppIdentifier2, 0x00, 0x70, 0x00, 0x00, PayloadIdentifierCommand1_2 })]     // channel 3 minimum, others neutral
+    [InlineData(JieStarSCM8.Device1, new float[] { 0.0f, 0.0f, 0.0f, -1.0f }, new byte[] { PayloadIdentifierCommand1_1, AppIdentifier1, AppIdentifier2, 0x00, 0x07, 0x00, 0x00, PayloadIdentifierCommand1_2 })]     // channel 4 minimum, others neutral
+    [InlineData(JieStarSCM8.Device1, new float[] { 9.0f, 9.0f, 9.0f, 9.0f, }, new byte[] { PayloadIdentifierCommand1_1, AppIdentifier1, AppIdentifier2, 0xff, 0xff, 0x00, 0x00, PayloadIdentifierCommand1_2 })]     // all channels above maximum, should be clamped to maximum
+    [InlineData(JieStarSCM8.Device1, new float[] { -9.0f, -9.0f, -9.0f, -9.0f }, new byte[] { PayloadIdentifierCommand1_1, AppIdentifier1, AppIdentifier2, 0x77, 0x77, 0x00, 0x00, PayloadIdentifierCommand1_2 })]  // all channels below minimum, should be clamped to minimum
+
+    [InlineData(JieStarSCM8.Device2, new float[] { 0.0f, 0.0f, 0.0f, 0.0f }, new byte[] { PayloadIdentifierCommand2_1, AppIdentifier1, AppIdentifier2, 0x00, 0x00, 0x00, 0x00, PayloadIdentifierCommand2_2 })]      // all channels neutral
+    [InlineData(JieStarSCM8.Device2, new float[] { 9.0f, 9.0f, 9.0f, 9.0f }, new byte[] { PayloadIdentifierCommand2_1, AppIdentifier1, AppIdentifier2, 0xff, 0xff, 0x00, 0x00, PayloadIdentifierCommand2_2 })]      // all channels above maximum, should be clamped to maximum
+    [InlineData(JieStarSCM8.Device2, new float[] { -9.0f, -9.0f, -9.0f, -9.0f }, new byte[] { PayloadIdentifierCommand2_1, AppIdentifier1, AppIdentifier2, 0x77, 0x77, 0x00, 0x00, PayloadIdentifierCommand2_2 })]  // all channels below minimum, should be clamped to minimum
+
+    [InlineData(JieStarSCM8.Device3, new float[] { 0.0f, 0.0f, 0.0f, 0.0f }, new byte[] { PayloadIdentifierCommand3_1, AppIdentifier1, AppIdentifier2, 0x00, 0x00, 0x00, 0x00, PayloadIdentifierCommand3_2 })]      // all channels neutral
+    [InlineData(JieStarSCM8.Device3, new float[] { 9.0f, 9.0f, 9.0f, 9.0f }, new byte[] { PayloadIdentifierCommand3_1, AppIdentifier1, AppIdentifier2, 0xff, 0xff, 0x00, 0x00, PayloadIdentifierCommand3_2 })]      // all channels above maximum, should be clamped to maximum
+    [InlineData(JieStarSCM8.Device3, new float[] { -9.0f, -9.0f, -9.0f, -9.0f }, new byte[] { PayloadIdentifierCommand3_1, AppIdentifier1, AppIdentifier2, 0x77, 0x77, 0x00, 0x00, PayloadIdentifierCommand3_2 })]  // all channels below minimum, should be clamped to minimum
+    public void TryGetTelegram_CommandDatagram_Payload(string deviceAddress, float[] setValues, byte[] expectedPayload)
+    {
+        JieStarSCM8 device = new JieStarSCM8("JieStarSCM8", deviceAddress, [], _deviceRepository.Object, _bluetoothLEService.Object, _jieStarPlatformService, _manager.Object);
+
+        // Set the output values for the device
+        for (int i = 0; i < setValues.Length; i++)
+        {
+            device.SetOutput(i, setValues[i]);
+        }
+
+        // Get the command datagram payload
+        device.TryGetTelegram(false, out byte[] payload).Should().BeTrue();
+
+        // Check that the payload matches the expected values
+        for (int i = 0; i < expectedPayload.Length; i++)
+        {
+            payload[i].Should().Be(expectedPayload[i]);
+        }
+    }
+
+    /// <summary>
+    /// Tests that setting an illegal channel index throws an ArgumentOutOfRangeException.
+    /// </summary>
+    /// <param name="deviceAddress">The address of the device to test.</param>
+    [Theory]
+    [InlineData(JieStarSCM8.Device1)]
+    [InlineData(JieStarSCM8.Device2)]
+    [InlineData(JieStarSCM8.Device3)]
+    public void TryGetTelegram_CommandDatagram_SetIllegalChannel(string deviceAddress)
+    {
+        JieStarSCM8 device = new JieStarSCM8("JieStarSCM8", deviceAddress, [], _deviceRepository.Object, _bluetoothLEService.Object, _jieStarPlatformService, _manager.Object);
+
+        Action action = () => device.SetOutput(device.NumberOfChannels, 0);
+
+        action.Should().Throw<ArgumentOutOfRangeException>();
+    }
+}

--- a/BrickController2/BrickController2.Tests/DeviceManagement/JieStar/JieStarSCM8DatagramTests.cs
+++ b/BrickController2/BrickController2.Tests/DeviceManagement/JieStar/JieStarSCM8DatagramTests.cs
@@ -126,10 +126,7 @@ public sealed class JieStarSCM8DatagramTests : JieStarDatagramTestsBase
         device.TryGetTelegram(false, out byte[] payload).Should().BeTrue();
 
         // Check that the payload matches the expected values
-        for (int i = 0; i < expectedPayload.Length; i++)
-        {
-            payload[i].Should().Be(expectedPayload[i]);
-        }
+        payload.Should().BeEquivalentTo(expectedPayload);
     }
 
     /// <summary>
@@ -155,25 +152,25 @@ public sealed class JieStarSCM8DatagramTests : JieStarDatagramTestsBase
     [Fact]
     public void TryGetTelegram_CommandDatagram_InstanceInteraction()
     {
-        float[] setValues_1 = [1.0f, 1.0f, 1.0f, 1.0f];
-        byte[] expectedPayload_1 = [PayloadIdentifierCommand1_1, AppIdentifier1, AppIdentifier2, 0xff, 0xff, 0x00, 0x00, PayloadIdentifierCommand1_2];
+        float[] setValues1 = [1.0f, 1.0f, 1.0f, 1.0f];
+        byte[] expectedPayload1 = [PayloadIdentifierCommand1_1, AppIdentifier1, AppIdentifier2, 0xff, 0xff, 0x00, 0x00, PayloadIdentifierCommand1_2];
 
-        float[] setValues_2 = [0.0f, 0.0f, 0.0f, 0.0f];
-        byte[] expectedPayload_2 = [PayloadIdentifierCommand2_1, AppIdentifier1, AppIdentifier2, 0x00, 0x00, 0x00, 0x00, PayloadIdentifierCommand2_2];
+        float[] setValues2 = [0.0f, 0.0f, 0.0f, 0.0f];
+        byte[] expectedPayload2 = [PayloadIdentifierCommand2_1, AppIdentifier1, AppIdentifier2, 0x00, 0x00, 0x00, 0x00, PayloadIdentifierCommand2_2];
 
-        float[] setValues_3 = [0.0f, 0.0f, 0.0f, 0.0f];
-        byte[] expectedPayload_3 = [PayloadIdentifierCommand3_1, AppIdentifier1, AppIdentifier2, 0x00, 0x00, 0x00, 0x00, PayloadIdentifierCommand3_2];
+        float[] setValues3 = [0.0f, 0.0f, 0.0f, 0.0f];
+        byte[] expectedPayload3 = [PayloadIdentifierCommand3_1, AppIdentifier1, AppIdentifier2, 0x00, 0x00, 0x00, 0x00, PayloadIdentifierCommand3_2];
 
         JieStarSCM8 device1 = new JieStarSCM8("JieStarSCM8", JieStarSCM8.Device1, [], _deviceRepository.Object, _bluetoothLEService.Object, _jieStarPlatformService, _manager.Object);
         JieStarSCM8 device2 = new JieStarSCM8("JieStarSCM8", JieStarSCM8.Device2, [], _deviceRepository.Object, _bluetoothLEService.Object, _jieStarPlatformService, _manager.Object);
         JieStarSCM8 device3 = new JieStarSCM8("JieStarSCM8", JieStarSCM8.Device3, [], _deviceRepository.Object, _bluetoothLEService.Object, _jieStarPlatformService, _manager.Object);
 
         // Set the output values for the device
-        for (int i = 0; i < setValues_1.Length; i++)
+        for (int i = 0; i < setValues1.Length; i++)
         {
-            device1.SetOutput(i, setValues_1[i]);
-            device2.SetOutput(i, setValues_2[i]);
-            device3.SetOutput(i, setValues_3[i]);
+            device1.SetOutput(i, setValues1[i]);
+            device2.SetOutput(i, setValues2[i]);
+            device3.SetOutput(i, setValues3[i]);
         }
 
         // Get the command datagram payload
@@ -182,11 +179,8 @@ public sealed class JieStarSCM8DatagramTests : JieStarDatagramTestsBase
         device3.TryGetTelegram(false, out byte[] payload3).Should().BeTrue();
 
         // Check that the payload matches the expected values
-        for (int i = 0; i < expectedPayload_1.Length; i++)
-        {
-            payload1[i].Should().Be(expectedPayload_1[i]);
-            payload2[i].Should().Be(expectedPayload_2[i]);
-            payload3[i].Should().Be(expectedPayload_3[i]);
-        }
+        payload1.Should().BeEquivalentTo(expectedPayload1);
+        payload2.Should().BeEquivalentTo(expectedPayload2);
+        payload3.Should().BeEquivalentTo(expectedPayload3);
     }
 }

--- a/BrickController2/BrickController2.Tests/DeviceManagement/JieStar/JieStarSCM8DatagramTests.cs
+++ b/BrickController2/BrickController2.Tests/DeviceManagement/JieStar/JieStarSCM8DatagramTests.cs
@@ -1,7 +1,5 @@
-﻿using BrickController2.DeviceManagement;
-using BrickController2.DeviceManagement.JieStar;
+﻿using BrickController2.DeviceManagement.JieStar;
 using FluentAssertions;
-using Moq;
 using System;
 using Xunit;
 
@@ -17,8 +15,6 @@ public sealed class JieStarSCM8DatagramTests : JieStarDatagramTestsBase
     private const byte PayloadIdentifierCommand2_2 = 0xbe;
     private const byte PayloadIdentifierCommand3_1 = 0x43;
     private const byte PayloadIdentifierCommand3_2 = 0xbd;
-
-    private readonly Mock<IDeviceRepository> _deviceRepository = new(MockBehavior.Strict); // IDeviceRepository is defined as internal, so we can't declare it as a field in the base class. We need to declare it here in the derived class.
 
     /// <summary>
     /// This test checks that the payload identifiers are correctly set in the connect datagram for each device address.

--- a/BrickController2/BrickController2.Tests/DeviceManagement/MouldKing/MouldKingDatagramTestsBase.cs
+++ b/BrickController2/BrickController2.Tests/DeviceManagement/MouldKing/MouldKingDatagramTestsBase.cs
@@ -1,4 +1,5 @@
-﻿using BrickController2.DeviceManagement.MouldKing;
+﻿using BrickController2.DeviceManagement;
+using BrickController2.DeviceManagement.MouldKing;
 using BrickController2.PlatformServices.BluetoothLE;
 using Moq;
 
@@ -27,6 +28,7 @@ public abstract class MouldKingDatagramTestsBase
     protected readonly Mock<IBluetoothLEService> _bluetoothLEService = new(MockBehavior.Strict);
     protected readonly Mock<IMouldKingDeviceManager> _manager = new(MockBehavior.Strict);
     protected readonly TestMKPlatformService _mkPlatformService = new();
+    internal readonly Mock<IDeviceRepository> _deviceRepository = new(MockBehavior.Strict);
 
     protected MouldKingDatagramTestsBase()
     {

--- a/BrickController2/BrickController2.Tests/DeviceManagement/MouldKing/MouldKingDatagramTestsBase.cs
+++ b/BrickController2/BrickController2.Tests/DeviceManagement/MouldKing/MouldKingDatagramTestsBase.cs
@@ -6,7 +6,10 @@ namespace BrickController2.Tests.DeviceManagement.MouldKing;
 
 public abstract class MouldKingDatagramTestsBase
 {
-    protected static readonly byte[] AppIdentifier = [0x61, 0x62];
+    protected const byte AppIdentifier1 = 0x61; // This is the first byte of an randomly choosen AppIdentifier for UnitTesting
+    protected const byte AppIdentifier2 = 0x62; // This is the second byte of an randomly choosen AppIdentifier for UnitTesting
+
+    protected static readonly byte[] AppIdentifier = [AppIdentifier1, AppIdentifier2];
 
     /// <summary>
     /// This class is a test implementation of the IMKPlatformService interface that simulates the behavior of the TryGetRfPayload method for testing purposes.

--- a/BrickController2/BrickController2.Tests/DeviceManagement/MouldKing/MouldKingDatagramTestsBase.cs
+++ b/BrickController2/BrickController2.Tests/DeviceManagement/MouldKing/MouldKingDatagramTestsBase.cs
@@ -1,0 +1,32 @@
+﻿using BrickController2.DeviceManagement.MouldKing;
+using BrickController2.PlatformServices.BluetoothLE;
+using Moq;
+
+namespace BrickController2.Tests.DeviceManagement.MouldKing;
+
+public abstract class MouldKingDatagramTestsBase
+{
+    protected static readonly byte[] AppIdentifier = [0x61, 0x62];
+
+    /// <summary>
+    /// This class is a test implementation of the IMKPlatformService interface that simulates the behavior of the TryGetRfPayload method for testing purposes.
+    /// It always returns true and sets the rfPayload to the rawData provided.
+    /// </summary>
+    protected class TestMKPlatformService : IMKPlatformService
+    {
+        public bool TryGetRfPayload(byte[] rawData, out byte[] rfPayload)
+        {
+            rfPayload = rawData;
+            return true; // Simulate success
+        }
+    }
+
+    protected readonly Mock<IBluetoothLEService> _bluetoothLEService = new(MockBehavior.Strict);
+    protected readonly Mock<IMouldKingDeviceManager> _manager = new(MockBehavior.Strict);
+    protected readonly TestMKPlatformService _mkPlatformService = new();
+
+    protected MouldKingDatagramTestsBase()
+    {
+        _manager.Setup(x => x.GetAppId()).Returns(AppIdentifier);
+    }
+}

--- a/BrickController2/BrickController2.Tests/DeviceManagement/MouldKing/MouldKingDeviceManagerTests.cs
+++ b/BrickController2/BrickController2.Tests/DeviceManagement/MouldKing/MouldKingDeviceManagerTests.cs
@@ -12,16 +12,17 @@ namespace BrickController2.Tests.DeviceManagement.MouldKing;
 
 public class MouldKingDeviceManagerTests
 {
+    private const byte AppIdentifier1 = 0x61; // This is the first byte of an randomly chosen AppIdentifier for UnitTesting
+    private const byte AppIdentifier2 = 0x62; // This is the second byte of an randomly chosen AppIdentifier for UnitTesting
+
     private readonly MouldKingDeviceManager _manager;
-    private readonly Mock<IPreferencesService> _preferencesService = new(MockBehavior.Strict);
+    private readonly Mock<IAppIdentifierService> _appIdentifierService = new(MockBehavior.Strict);
 
     public MouldKingDeviceManagerTests()
     {
-        _preferencesService.Setup(x => x.ContainsKey("Identifier", "App")).Returns(true);
-        _preferencesService.Setup(x => x.Get("Identifier", "", "App")).Returns("YWJj");
+        _appIdentifierService.Setup(x => x.GetAppId(2)).Returns(new byte[] { AppIdentifier1, AppIdentifier2 });
 
-        IAppIdentifierService appIdentifierService = new AppIdentifierService(_preferencesService.Object);
-        _manager = new MouldKingDeviceManager(appIdentifierService);
+        _manager = new MouldKingDeviceManager(_appIdentifierService.Object);
     }
 
     [Fact]

--- a/BrickController2/BrickController2.Tests/DeviceManagement/MouldKing/MouldKingMK3_8DatagramTests.cs
+++ b/BrickController2/BrickController2.Tests/DeviceManagement/MouldKing/MouldKingMK3_8DatagramTests.cs
@@ -1,7 +1,5 @@
-﻿using BrickController2.DeviceManagement;
-using BrickController2.DeviceManagement.MouldKing;
+﻿using BrickController2.DeviceManagement.MouldKing;
 using FluentAssertions;
-using Moq;
 using System;
 using Xunit;
 
@@ -13,8 +11,6 @@ public sealed class MouldKingMK3_8DatagramTests : MouldKingDatagramTestsBase
     private const byte PayloadIdentifierConnect2 = 0xc1;
     private const byte PayloadIdentifierCommand1 = 0x81;
     private const byte PayloadIdentifierCommand2 = 0xc2;
-
-    private readonly Mock<IDeviceRepository> _deviceRepository = new(MockBehavior.Strict); // IDeviceRepository is defined as internal, so we can't declare it as a field in the base class. We need to declare it here in the derived class.
 
     /// <summary>
     /// This test checks that the payload identifiers are correctly set in the connect datagram for each device address.

--- a/BrickController2/BrickController2.Tests/DeviceManagement/MouldKing/MouldKingMK3_8DatagramTests.cs
+++ b/BrickController2/BrickController2.Tests/DeviceManagement/MouldKing/MouldKingMK3_8DatagramTests.cs
@@ -1,0 +1,123 @@
+﻿using BrickController2.DeviceManagement;
+using BrickController2.DeviceManagement.MouldKing;
+using FluentAssertions;
+using Moq;
+using System;
+using Xunit;
+
+namespace BrickController2.Tests.DeviceManagement.MouldKing;
+
+public sealed class MouldKingMK3_8DatagramTests : MouldKingDatagramTestsBase
+{
+    private const byte PayloadIdentifierConnect1 = 0xb1;
+    private const byte PayloadIdentifierConnect2 = 0xc1;
+    private const byte PayloadIdentifierCommand1 = 0x81;
+    private const byte PayloadIdentifierCommand2 = 0xc2;
+
+    private readonly Mock<IDeviceRepository> _deviceRepository = new(MockBehavior.Strict); // IDeviceRepository is defined as internal, so we can't declare it as a field in the base class. We need to declare it here in the derived class.
+
+    /// <summary>
+    /// This test checks that the payload identifiers are correctly set in the connect datagram for each device address.
+    /// </summary>
+    [Fact]
+    public void TryGetTelegram_ConnectDatagram_PayloadIdentifier()
+    {
+        MK3_8 device = new MK3_8("MK3_8", MK3_8.Device, [], _deviceRepository.Object, _bluetoothLEService.Object, _mkPlatformService, _manager.Object);
+
+        device.TryGetTelegram(true, out byte[] payload).Should().BeTrue();
+        payload[0].Should().Be(PayloadIdentifierConnect1);
+        payload[7].Should().Be(PayloadIdentifierConnect2);
+    }
+
+    /// <summary>
+    /// This test checks that the AppIdentifier is correctly included in the connect datagram payload for each device address.
+    /// </summary>
+    /// <param name="deviceAddress">The address of the device to test.</param>
+    [Fact]
+    public void TryGetTelegram_ConnectDatagram_AppIdentifier()
+    {
+        MK3_8 device = new MK3_8("MK3_8", MK3_8.Device, [], _deviceRepository.Object, _bluetoothLEService.Object, _mkPlatformService, _manager.Object);
+
+        device.TryGetTelegram(true, out byte[] payload).Should().BeTrue();
+        payload[1].Should().Be(AppIdentifier1);
+        payload[2].Should().Be(0x00); // This is an exception - the second byte of the AppIdentifier is used as setvalue for channel 5
+    }
+
+    /// <summary>
+    /// This test checks that the payload identifiers are correctly set in the command datagram for each device address.
+    /// </summary>
+    [Fact]
+    public void TryGetTelegram_CommandDatagram_PayloadIdentifier()
+    {
+        MK3_8 device = new MK3_8("MK3_8", MK3_8.Device, [], _deviceRepository.Object, _bluetoothLEService.Object, _mkPlatformService, _manager.Object);
+
+        device.TryGetTelegram(false, out byte[] payload).Should().BeTrue();
+        payload[0].Should().Be(PayloadIdentifierCommand1);
+        payload[9].Should().Be(PayloadIdentifierCommand2);
+    }
+
+    /// <summary>
+    /// This test checks that the AppIdentifier is correctly included in the command datagram payload for each device address.
+    /// </summary>
+    [Fact]
+    public void TryGetTelegram_CommandDatagram_AppIdentifier()
+    {
+        MK3_8 device = new MK3_8("MK3_8", MK3_8.Device, [], _deviceRepository.Object, _bluetoothLEService.Object, _mkPlatformService, _manager.Object);
+
+        device.TryGetTelegram(false, out byte[] payload).Should().BeTrue();
+        payload[1].Should().Be(AppIdentifier1);
+        payload[2].Should().Be(0x00); // This is an exception - the second byte of the AppIdentifier is used as setvalue for channel 5
+    }
+
+    /// <summary>
+    /// This test checks that the command datagram payload is correctly constructed based on the set output values for each device address.
+    /// </summary>
+    /// <param name="setValues">The set values for each channel.</param>
+    /// <param name="expectedPayload">The expected payload for the command datagram.</param>
+    [Theory]
+    [InlineData(new float[] { 0.0f, 0.0f, 0.0f, 0.0f, 0.0f }, new byte[]     { PayloadIdentifierCommand1, AppIdentifier1, 0x0, 0x99, 0x99, 0x99, 0x99, 0x99, 0x99, PayloadIdentifierCommand2 })]        // all channels neutral
+    [InlineData(new float[] { 1.0f, 0.0f, 0.0f, 0.0f, 0.0f }, new byte[]     { PayloadIdentifierCommand1, AppIdentifier1, 0x0, 0xf9, 0x99, 0x99, 0x99, 0x99, 0x99, PayloadIdentifierCommand2 })]        // channel 1 maximum, others neutral
+    [InlineData(new float[] { 0.0f, 1.0f, 0.0f, 0.0f, 0.0f }, new byte[]     { PayloadIdentifierCommand1, AppIdentifier1, 0x0, 0x9f, 0x99, 0x99, 0x99, 0x99, 0x99, PayloadIdentifierCommand2 })]        // channel 2 maximum, others neutral
+    [InlineData(new float[] { 0.0f, 0.0f, 1.0f, 0.0f, 0.0f }, new byte[]     { PayloadIdentifierCommand1, AppIdentifier1, 0x0, 0x99, 0xf9, 0x99, 0x99, 0x99, 0x99, PayloadIdentifierCommand2 })]        // channel 3 maximum, others neutral
+    [InlineData(new float[] { 0.0f, 0.0f, 0.0f, 1.0f, 0.0f }, new byte[]     { PayloadIdentifierCommand1, AppIdentifier1, 0x0, 0x99, 0x9f, 0x99, 0x99, 0x99, 0x99, PayloadIdentifierCommand2 })]        // channel 4 maximum, others neutral
+    [InlineData(new float[] { 0.0f, 0.0f, 0.0f, 0.0f, 1.0f }, new byte[]     { PayloadIdentifierCommand1, AppIdentifier1, 0x2, 0x99, 0x99, 0x99, 0x99, 0x99, 0x99, PayloadIdentifierCommand2 })]        // channel 5 maximum, others neutral
+    [InlineData(new float[] { -1.0f, 0.0f, 0.0f, 0.0f, 0.0f }, new byte[]    { PayloadIdentifierCommand1, AppIdentifier1, 0x0, 0x79, 0x99, 0x99, 0x99, 0x99, 0x99, PayloadIdentifierCommand2 })]       // channel 1 minimum, others neutral
+    [InlineData(new float[] { 0.0f, -1.0f, 0.0f, 0.0f, 0.0f }, new byte[]    { PayloadIdentifierCommand1, AppIdentifier1, 0x0, 0x97, 0x99, 0x99, 0x99, 0x99, 0x99, PayloadIdentifierCommand2 })]       // channel 2 minimum, others neutral
+    [InlineData(new float[] { 0.0f, 0.0f, -1.0f, 0.0f, 0.0f }, new byte[]    { PayloadIdentifierCommand1, AppIdentifier1, 0x0, 0x99, 0x79, 0x99, 0x99, 0x99, 0x99, PayloadIdentifierCommand2 })]       // channel 3 minimum, others neutral
+    [InlineData(new float[] { 0.0f, 0.0f, 0.0f, -1.0f, 0.0f }, new byte[]    { PayloadIdentifierCommand1, AppIdentifier1, 0x0, 0x99, 0x97, 0x99, 0x99, 0x99, 0x99, PayloadIdentifierCommand2 })]       // channel 4 minimum, others neutral
+    [InlineData(new float[] { 0.0f, 0.0f, 0.0f, 0.0f, -1.0f }, new byte[]    { PayloadIdentifierCommand1, AppIdentifier1, 0x1, 0x99, 0x99, 0x99, 0x99, 0x99, 0x99, PayloadIdentifierCommand2 })]       // channel 5 minimum, others neutral
+    [InlineData(new float[] { 9.0f, 9.0f, 9.0f, 9.0f, 9.0f }, new byte[]     { PayloadIdentifierCommand1, AppIdentifier1, 0x2, 0xff, 0xff, 0x99, 0x99, 0x99, 0x99, PayloadIdentifierCommand2 })]        // all channels above maximum, should be clamped to maximum
+    [InlineData(new float[] { -9.0f, -9.0f, -9.0f, -9.0f, -9.0f }, new byte[]{ PayloadIdentifierCommand1, AppIdentifier1, 0x1, 0x77, 0x77, 0x99, 0x99, 0x99, 0x99, PayloadIdentifierCommand2 })]  // all channels below minimum, should be clamped to minimum
+    public void TryGetTelegram_CommandDatagram_Payload(float[] setValues, byte[] expectedPayload)
+    {
+        MK3_8 device = new MK3_8("MK3_8", MK3_8.Device, [], _deviceRepository.Object, _bluetoothLEService.Object, _mkPlatformService, _manager.Object);
+
+        // Set the output values for the device
+        for (int i = 0; i < setValues.Length; i++)
+        {
+            device.SetOutput(i, setValues[i]);
+        }
+
+        // Get the command datagram payload
+        device.TryGetTelegram(false, out byte[] payload).Should().BeTrue();
+
+        // Check that the payload matches the expected values
+        for (int i = 0; i < expectedPayload.Length; i++)
+        {
+            payload[i].Should().Be(expectedPayload[i]);
+        }
+    }
+
+    /// <summary>
+    /// Tests that setting an illegal channel index throws an ArgumentOutOfRangeException.
+    /// </summary>
+    [Fact]
+    public void TryGetTelegram_CommandDatagram_SetIllegalChannel()
+    {
+        MK3_8 device = new MK3_8("MK3_8", MK3_8.Device, [], _deviceRepository.Object, _bluetoothLEService.Object, _mkPlatformService, _manager.Object);
+
+        Action action = () => device.SetOutput(device.NumberOfChannels, 0);
+
+        action.Should().Throw<ArgumentOutOfRangeException>();
+    }
+}

--- a/BrickController2/BrickController2.Tests/DeviceManagement/MouldKing/MouldKingMK3_8DatagramTests.cs
+++ b/BrickController2/BrickController2.Tests/DeviceManagement/MouldKing/MouldKingMK3_8DatagramTests.cs
@@ -98,10 +98,7 @@ public sealed class MouldKingMK3_8DatagramTests : MouldKingDatagramTestsBase
         device.TryGetTelegram(false, out byte[] payload).Should().BeTrue();
 
         // Check that the payload matches the expected values
-        for (int i = 0; i < expectedPayload.Length; i++)
-        {
-            payload[i].Should().Be(expectedPayload[i]);
-        }
+        payload.Should().BeEquivalentTo(expectedPayload);
     }
 
     /// <summary>

--- a/BrickController2/BrickController2.Tests/DeviceManagement/MouldKing/MouldKingMK4DatagramTests.cs
+++ b/BrickController2/BrickController2.Tests/DeviceManagement/MouldKing/MouldKingMK4DatagramTests.cs
@@ -142,4 +142,47 @@ public sealed class MouldKingMK4DatagramTests : MouldKingDatagramTestsBase
 
         action.Should().Throw<ArgumentOutOfRangeException>();
     }
+
+    /// <summary>
+    /// This test checks that the command datagram payload is correctly constructed based on the set output values for multiple devices, ensuring that each device's payload is independent of the others.
+    /// </summary>
+    [Fact]
+    public void TryGetTelegram_CommandDatagram_InstanceInteraction()
+    {
+        // Attention! - the MK4 devices static base telegram is interacted by all instances!
+
+        float[] setValues_1 = [1.0f, 1.0f, 1.0f, 1.0f];
+        byte[] expectedPayload_1 = [PayloadIdentifierCommand1, AppIdentifier1, AppIdentifier2, 0xff, 0xff, 0x88, 0x88, 0x88, 0x88, PayloadIdentifierCommand2];
+
+        float[] setValues_2 = [0.0f, 0.0f, 0.0f, 0.0f];
+        byte[] expectedPayload_2 = [PayloadIdentifierCommand1, AppIdentifier1, AppIdentifier2, 0xff, 0xff, 0x88, 0x88, 0x88, 0x88, PayloadIdentifierCommand2];
+
+        float[] setValues_3 = [0.0f, 0.0f, 0.0f, 0.0f];
+        byte[] expectedPayload_3 = [PayloadIdentifierCommand1, AppIdentifier1, AppIdentifier2, 0xff, 0xff, 0x88, 0x88, 0x88, 0x88, PayloadIdentifierCommand2];
+
+        MK4 device1 = new MK4("MK4", MK4.Device1, [], _deviceRepository.Object, _bluetoothLEService.Object, _mkPlatformService, _manager.Object);
+        MK4 device2 = new MK4("MK4", MK4.Device2, [], _deviceRepository.Object, _bluetoothLEService.Object, _mkPlatformService, _manager.Object);
+        MK4 device3 = new MK4("MK4", MK4.Device3, [], _deviceRepository.Object, _bluetoothLEService.Object, _mkPlatformService, _manager.Object);
+
+        // Set the output values for the device
+        for (int i = 0; i < setValues_1.Length; i++)
+        {
+            device1.SetOutput(i, setValues_1[i]);
+            device2.SetOutput(i, setValues_2[i]);
+            device3.SetOutput(i, setValues_3[i]);
+        }
+
+        // Get the command datagram payload
+        device1.TryGetTelegram(false, out byte[] payload1).Should().BeTrue();
+        device2.TryGetTelegram(false, out byte[] payload2).Should().BeTrue();
+        device3.TryGetTelegram(false, out byte[] payload3).Should().BeTrue();
+
+        // Check that the payload matches the expected values
+        for (int i = 0; i < expectedPayload_1.Length; i++)
+        {
+            payload1[i].Should().Be(expectedPayload_1[i]);
+            payload2[i].Should().Be(expectedPayload_2[i]);
+            payload3[i].Should().Be(expectedPayload_3[i]);
+        }
+    }
 }

--- a/BrickController2/BrickController2.Tests/DeviceManagement/MouldKing/MouldKingMK4DatagramTests.cs
+++ b/BrickController2/BrickController2.Tests/DeviceManagement/MouldKing/MouldKingMK4DatagramTests.cs
@@ -1,7 +1,5 @@
-﻿using BrickController2.DeviceManagement;
-using BrickController2.DeviceManagement.MouldKing;
+﻿using BrickController2.DeviceManagement.MouldKing;
 using FluentAssertions;
-using Moq;
 using System;
 using Xunit;
 
@@ -13,8 +11,6 @@ public sealed class MouldKingMK4DatagramTests : MouldKingDatagramTestsBase
     private const byte PayloadIdentifierConnect2 = 0x52;
     private const byte PayloadIdentifierCommand1 = 0x7d;
     private const byte PayloadIdentifierCommand2 = 0x82;
-
-    private readonly Mock<IDeviceRepository> _deviceRepository = new(MockBehavior.Strict); // IDeviceRepository is defined as internal, so we can't declare it as a field in the base class. We need to declare it here in the derived class.
 
     /// <summary>
     /// This test checks that the payload identifiers are correctly set in the connect datagram for each device address.

--- a/BrickController2/BrickController2.Tests/DeviceManagement/MouldKing/MouldKingMK4DatagramTests.cs
+++ b/BrickController2/BrickController2.Tests/DeviceManagement/MouldKing/MouldKingMK4DatagramTests.cs
@@ -1,0 +1,154 @@
+﻿using BrickController2.DeviceManagement;
+using BrickController2.DeviceManagement.MouldKing;
+using FluentAssertions;
+using Moq;
+using System;
+using Xunit;
+
+namespace BrickController2.Tests.DeviceManagement.MouldKing;
+
+public sealed class MouldKingMK4DatagramTests : MouldKingDatagramTestsBase
+{
+    private const byte PayloadIdentifierConnect1 = 0xad;
+    private const byte PayloadIdentifierConnect2 = 0x52;
+    private const byte PayloadIdentifierCommand1 = 0x7d;
+    private const byte PayloadIdentifierCommand2 = 0x82;
+
+    private readonly Mock<IDeviceRepository> _deviceRepository = new(MockBehavior.Strict); // IDeviceRepository is defined as internal, so we can't declare it as a field in the base class. We need to declare it here in the derived class.
+
+    /// <summary>
+    /// This test checks that the payload identifiers are correctly set in the connect datagram for each device address.
+    /// </summary>
+    /// <param name="deviceAddress">The address of the device to test.</param>
+    [Theory]
+    [InlineData(MK4.Device1)]
+    [InlineData(MK4.Device2)]
+    [InlineData(MK4.Device3)]
+    public void TryGetTelegram_ConnectDatagram_PayloadIdentifier(string deviceAddress)
+    {
+        MK4.ResetBaseTelegram(); // Resets the state of the base telegram.
+        MK4 device = new MK4("MK4", deviceAddress, [], _deviceRepository.Object, _bluetoothLEService.Object, _mkPlatformService, _manager.Object);
+
+        device.TryGetTelegram(true, out byte[] payload).Should().BeTrue();
+        payload[0].Should().Be(PayloadIdentifierConnect1);
+        payload[7].Should().Be(PayloadIdentifierConnect2);
+    }
+
+    /// <summary>
+    /// This test checks that the AppIdentifier is correctly included in the connect datagram payload for each device address.
+    /// </summary>
+    /// <param name="deviceAddress">The address of the device to test.</param>
+    [Theory]
+    [InlineData(MK4.Device1)]
+    [InlineData(MK4.Device2)]
+    [InlineData(MK4.Device3)]
+    public void TryGetTelegram_ConnectDatagram_AppIdentifier(string deviceAddress)
+    {
+        MK4.ResetBaseTelegram(); // Resets the state of the base telegram.
+        MK4 device = new MK4("MK4", deviceAddress, [], _deviceRepository.Object, _bluetoothLEService.Object, _mkPlatformService, _manager.Object);
+
+        device.TryGetTelegram(true, out byte[] payload).Should().BeTrue();
+        payload[1].Should().Be(AppIdentifier1);
+        payload[2].Should().Be(AppIdentifier2);
+    }
+
+    /// <summary>
+    /// This test checks that the payload identifiers are correctly set in the command datagram for each device address.
+    /// </summary>
+    /// <param name="deviceAddress">The address of the device to test.</param>
+    [Theory]
+    [InlineData(MK4.Device1)]
+    [InlineData(MK4.Device2)]
+    [InlineData(MK4.Device3)]
+    public void TryGetTelegram_CommandDatagram_PayloadIdentifier(string deviceAddress)
+    {
+        MK4.ResetBaseTelegram(); // Resets the state of the base telegram.
+        MK4 device = new MK4("MK4", deviceAddress, [], _deviceRepository.Object, _bluetoothLEService.Object, _mkPlatformService, _manager.Object);
+
+        device.TryGetTelegram(false, out byte[] payload).Should().BeTrue();
+        payload[0].Should().Be(PayloadIdentifierCommand1);
+        payload[9].Should().Be(PayloadIdentifierCommand2);
+    }
+
+    /// <summary>
+    /// This test checks that the AppIdentifier is correctly included in the command datagram payload for each device address.
+    /// </summary>
+    /// <param name="deviceAddress">The address of the device to test.</param>
+    [Theory]
+    [InlineData(MK4.Device1)]
+    [InlineData(MK4.Device2)]
+    [InlineData(MK4.Device3)]
+    public void TryGetTelegram_CommandDatagram_AppIdentifier(string deviceAddress)
+    {
+        MK4.ResetBaseTelegram(); // Resets the state of the base telegram.
+        MK4 device = new MK4("MK4", deviceAddress, [], _deviceRepository.Object, _bluetoothLEService.Object, _mkPlatformService, _manager.Object);
+
+        device.TryGetTelegram(false, out byte[] payload).Should().BeTrue();
+        payload[1].Should().Be(AppIdentifier1);
+        payload[2].Should().Be(AppIdentifier2);
+    }
+
+    /// <summary>
+    /// This test checks that the command datagram payload is correctly constructed based on the set output values for each device address.
+    /// </summary>
+    /// <param name="deviceAddress">The address of the device to test.</param>
+    /// <param name="setValues">The set values for each channel.</param>
+    /// <param name="expectedPayload">The expected payload for the command datagram.</param>
+    [Theory]
+    [InlineData(MK4.Device1, new float[] { 0.0f, 0.0f, 0.0f, 0.0f }, new byte[] { PayloadIdentifierCommand1, AppIdentifier1, AppIdentifier2, 0x88, 0x88, 0x88, 0x88, 0x88, 0x88, PayloadIdentifierCommand2 })]      // all channels neutral
+    [InlineData(MK4.Device1, new float[] { 1.0f, 0.0f, 0.0f, 0.0f }, new byte[] { PayloadIdentifierCommand1, AppIdentifier1, AppIdentifier2, 0xf8, 0x88, 0x88, 0x88, 0x88, 0x88, PayloadIdentifierCommand2 })]      // channel 1 maximum, others neutral
+    [InlineData(MK4.Device1, new float[] { 0.0f, 1.0f, 0.0f, 0.0f }, new byte[] { PayloadIdentifierCommand1, AppIdentifier1, AppIdentifier2, 0x8f, 0x88, 0x88, 0x88, 0x88, 0x88, PayloadIdentifierCommand2 })]      // channel 2 maximum, others neutral
+    [InlineData(MK4.Device1, new float[] { 0.0f, 0.0f, 1.0f, 0.0f }, new byte[] { PayloadIdentifierCommand1, AppIdentifier1, AppIdentifier2, 0x88, 0xf8, 0x88, 0x88, 0x88, 0x88, PayloadIdentifierCommand2 })]      // channel 3 maximum, others neutral
+    [InlineData(MK4.Device1, new float[] { 0.0f, 0.0f, 0.0f, 1.0f }, new byte[] { PayloadIdentifierCommand1, AppIdentifier1, AppIdentifier2, 0x88, 0x8f, 0x88, 0x88, 0x88, 0x88, PayloadIdentifierCommand2 })]      // channel 4 maximum, others neutral
+    [InlineData(MK4.Device1, new float[] { -1.0f, 0.0f, 0.0f, 0.0f }, new byte[] { PayloadIdentifierCommand1, AppIdentifier1, AppIdentifier2, 0x78, 0x88, 0x88, 0x88, 0x88, 0x88, PayloadIdentifierCommand2 })]     // channel 1 minimum, others neutral
+    [InlineData(MK4.Device1, new float[] { 0.0f, -1.0f, 0.0f, 0.0f }, new byte[] { PayloadIdentifierCommand1, AppIdentifier1, AppIdentifier2, 0x87, 0x88, 0x88, 0x88, 0x88, 0x88, PayloadIdentifierCommand2 })]     // channel 2 minimum, others neutral
+    [InlineData(MK4.Device1, new float[] { 0.0f, 0.0f, -1.0f, 0.0f }, new byte[] { PayloadIdentifierCommand1, AppIdentifier1, AppIdentifier2, 0x88, 0x78, 0x88, 0x88, 0x88, 0x88, PayloadIdentifierCommand2 })]     // channel 3 minimum, others neutral
+    [InlineData(MK4.Device1, new float[] { 0.0f, 0.0f, 0.0f, -1.0f }, new byte[] { PayloadIdentifierCommand1, AppIdentifier1, AppIdentifier2, 0x88, 0x87, 0x88, 0x88, 0x88, 0x88, PayloadIdentifierCommand2 })]     // channel 4 minimum, others neutral
+    [InlineData(MK4.Device1, new float[] { 9.0f, 9.0f, 9.0f, 9.0f, }, new byte[] { PayloadIdentifierCommand1, AppIdentifier1, AppIdentifier2, 0xff, 0xff, 0x88, 0x88, 0x88, 0x88, PayloadIdentifierCommand2 })]     // all channels above maximum, should be clamped to maximum
+    [InlineData(MK4.Device1, new float[] { -9.0f, -9.0f, -9.0f, -9.0f }, new byte[] { PayloadIdentifierCommand1, AppIdentifier1, AppIdentifier2, 0x77, 0x77, 0x88, 0x88, 0x88, 0x88, PayloadIdentifierCommand2 })]  // all channels below minimum, should be clamped to minimum
+
+    [InlineData(MK4.Device2, new float[] { 0.0f, 0.0f, 0.0f, 0.0f }, new byte[] { PayloadIdentifierCommand1, AppIdentifier1, AppIdentifier2, 0x88, 0x88, 0x88, 0x88, 0x88, 0x88, PayloadIdentifierCommand2 })]      // all channels neutral
+    [InlineData(MK4.Device2, new float[] { 9.0f, 9.0f, 9.0f, 9.0f }, new byte[] { PayloadIdentifierCommand1, AppIdentifier1, AppIdentifier2, 0x88, 0x88, 0xff, 0xff, 0x88, 0x88, PayloadIdentifierCommand2 })]      // all channels above maximum, should be clamped to maximum
+    [InlineData(MK4.Device2, new float[] { -9.0f, -9.0f, -9.0f, -9.0f }, new byte[] { PayloadIdentifierCommand1, AppIdentifier1, AppIdentifier2, 0x88, 0x88, 0x77, 0x77, 0x88, 0x88, PayloadIdentifierCommand2 })]  // all channels below minimum, should be clamped to minimum
+
+    [InlineData(MK4.Device3, new float[] { 0.0f, 0.0f, 0.0f, 0.0f }, new byte[] { PayloadIdentifierCommand1, AppIdentifier1, AppIdentifier2, 0x88, 0x88, 0x88, 0x88, 0x88, 0x88, PayloadIdentifierCommand2 })]      // all channels neutral
+    [InlineData(MK4.Device3, new float[] { 9.0f, 9.0f, 9.0f, 9.0f }, new byte[] { PayloadIdentifierCommand1, AppIdentifier1, AppIdentifier2, 0x88, 0x88, 0x88, 0x88, 0xff, 0xff, PayloadIdentifierCommand2 })]      // all channels above maximum, should be clamped to maximum
+    [InlineData(MK4.Device3, new float[] { -9.0f, -9.0f, -9.0f, -9.0f }, new byte[] { PayloadIdentifierCommand1, AppIdentifier1, AppIdentifier2, 0x88, 0x88, 0x88, 0x88, 0x77, 0x77, PayloadIdentifierCommand2 })]  // all channels below minimum, should be clamped to minimum
+    public void TryGetTelegram_CommandDatagram_Payload(string deviceAddress, float[] setValues, byte[] expectedPayload)
+    {
+        MK4.ResetBaseTelegram(); // Resets the state of the base telegram.
+        MK4 device = new MK4("MK4", deviceAddress, [], _deviceRepository.Object, _bluetoothLEService.Object, _mkPlatformService, _manager.Object);
+
+        // Set the output values for the device
+        for (int i = 0; i < setValues.Length; i++)
+        {
+            device.SetOutput(i, setValues[i]);
+        }
+
+        // Get the command datagram payload
+        device.TryGetTelegram(false, out byte[] payload).Should().BeTrue();
+
+        // Check that the payload matches the expected values
+        for (int i = 0; i < expectedPayload.Length; i++)
+        {
+            payload[i].Should().Be(expectedPayload[i]);
+        }
+    }
+
+    /// <summary>
+    /// Tests that setting an illegal channel index throws an ArgumentOutOfRangeException.
+    /// </summary>
+    /// <param name="deviceAddress">The address of the device to test.</param>
+    [Theory]
+    [InlineData(MK4.Device1)]
+    [InlineData(MK4.Device2)]
+    [InlineData(MK4.Device3)]
+    public void TryGetTelegram_CommandDatagram_SetIllegalChannel(string deviceAddress)
+    {
+        MK4 device = new MK4("MK4", deviceAddress, [], _deviceRepository.Object, _bluetoothLEService.Object, _mkPlatformService, _manager.Object);
+
+        Action action = () => device.SetOutput(device.NumberOfChannels, 0);
+
+        action.Should().Throw<ArgumentOutOfRangeException>();
+    }
+}

--- a/BrickController2/BrickController2.Tests/DeviceManagement/MouldKing/MouldKingMK4DatagramTests.cs
+++ b/BrickController2/BrickController2.Tests/DeviceManagement/MouldKing/MouldKingMK4DatagramTests.cs
@@ -26,7 +26,6 @@ public sealed class MouldKingMK4DatagramTests : MouldKingDatagramTestsBase
     [InlineData(MK4.Device3)]
     public void TryGetTelegram_ConnectDatagram_PayloadIdentifier(string deviceAddress)
     {
-        MK4.ResetBaseTelegram(); // Resets the state of the base telegram.
         MK4 device = new MK4("MK4", deviceAddress, [], _deviceRepository.Object, _bluetoothLEService.Object, _mkPlatformService, _manager.Object);
 
         device.TryGetTelegram(true, out byte[] payload).Should().BeTrue();
@@ -44,7 +43,6 @@ public sealed class MouldKingMK4DatagramTests : MouldKingDatagramTestsBase
     [InlineData(MK4.Device3)]
     public void TryGetTelegram_ConnectDatagram_AppIdentifier(string deviceAddress)
     {
-        MK4.ResetBaseTelegram(); // Resets the state of the base telegram.
         MK4 device = new MK4("MK4", deviceAddress, [], _deviceRepository.Object, _bluetoothLEService.Object, _mkPlatformService, _manager.Object);
 
         device.TryGetTelegram(true, out byte[] payload).Should().BeTrue();
@@ -62,7 +60,6 @@ public sealed class MouldKingMK4DatagramTests : MouldKingDatagramTestsBase
     [InlineData(MK4.Device3)]
     public void TryGetTelegram_CommandDatagram_PayloadIdentifier(string deviceAddress)
     {
-        MK4.ResetBaseTelegram(); // Resets the state of the base telegram.
         MK4 device = new MK4("MK4", deviceAddress, [], _deviceRepository.Object, _bluetoothLEService.Object, _mkPlatformService, _manager.Object);
 
         device.TryGetTelegram(false, out byte[] payload).Should().BeTrue();
@@ -80,7 +77,6 @@ public sealed class MouldKingMK4DatagramTests : MouldKingDatagramTestsBase
     [InlineData(MK4.Device3)]
     public void TryGetTelegram_CommandDatagram_AppIdentifier(string deviceAddress)
     {
-        MK4.ResetBaseTelegram(); // Resets the state of the base telegram.
         MK4 device = new MK4("MK4", deviceAddress, [], _deviceRepository.Object, _bluetoothLEService.Object, _mkPlatformService, _manager.Object);
 
         device.TryGetTelegram(false, out byte[] payload).Should().BeTrue();
@@ -116,7 +112,6 @@ public sealed class MouldKingMK4DatagramTests : MouldKingDatagramTestsBase
     [InlineData(MK4.Device3, new float[] { -9.0f, -9.0f, -9.0f, -9.0f }, new byte[] { PayloadIdentifierCommand1, AppIdentifier1, AppIdentifier2, 0x88, 0x88, 0x88, 0x88, 0x77, 0x77, PayloadIdentifierCommand2 })]  // all channels below minimum, should be clamped to minimum
     public void TryGetTelegram_CommandDatagram_Payload(string deviceAddress, float[] setValues, byte[] expectedPayload)
     {
-        MK4.ResetBaseTelegram(); // Resets the state of the base telegram.
         MK4 device = new MK4("MK4", deviceAddress, [], _deviceRepository.Object, _bluetoothLEService.Object, _mkPlatformService, _manager.Object);
 
         // Set the output values for the device

--- a/BrickController2/BrickController2.Tests/DeviceManagement/MouldKing/MouldKingMK4DatagramTests.cs
+++ b/BrickController2/BrickController2.Tests/DeviceManagement/MouldKing/MouldKingMK4DatagramTests.cs
@@ -120,10 +120,7 @@ public sealed class MouldKingMK4DatagramTests : MouldKingDatagramTestsBase
         device.TryGetTelegram(false, out byte[] payload).Should().BeTrue();
 
         // Check that the payload matches the expected values
-        for (int i = 0; i < expectedPayload.Length; i++)
-        {
-            payload[i].Should().Be(expectedPayload[i]);
-        }
+        payload.Should().BeEquivalentTo(expectedPayload);
     }
 
     /// <summary>
@@ -151,25 +148,25 @@ public sealed class MouldKingMK4DatagramTests : MouldKingDatagramTestsBase
     {
         // Attention! - the MK4 devices static base telegram is interacted by all instances!
 
-        float[] setValues_1 = [1.0f, 1.0f, 1.0f, 1.0f];
-        byte[] expectedPayload_1 = [PayloadIdentifierCommand1, AppIdentifier1, AppIdentifier2, 0xff, 0xff, 0x88, 0x88, 0x88, 0x88, PayloadIdentifierCommand2];
+        float[] setValues1 = [1.0f, 1.0f, 1.0f, 1.0f];
+        byte[] expectedPayload1 = [PayloadIdentifierCommand1, AppIdentifier1, AppIdentifier2, 0xff, 0xff, 0x88, 0x88, 0x88, 0x88, PayloadIdentifierCommand2];
 
-        float[] setValues_2 = [0.0f, 0.0f, 0.0f, 0.0f];
-        byte[] expectedPayload_2 = [PayloadIdentifierCommand1, AppIdentifier1, AppIdentifier2, 0xff, 0xff, 0x88, 0x88, 0x88, 0x88, PayloadIdentifierCommand2];
+        float[] setValues2 = [0.0f, 0.0f, 0.0f, 0.0f];
+        byte[] expectedPayload2 = [PayloadIdentifierCommand1, AppIdentifier1, AppIdentifier2, 0xff, 0xff, 0x88, 0x88, 0x88, 0x88, PayloadIdentifierCommand2];
 
-        float[] setValues_3 = [0.0f, 0.0f, 0.0f, 0.0f];
-        byte[] expectedPayload_3 = [PayloadIdentifierCommand1, AppIdentifier1, AppIdentifier2, 0xff, 0xff, 0x88, 0x88, 0x88, 0x88, PayloadIdentifierCommand2];
+        float[] setValues3 = [0.0f, 0.0f, 0.0f, 0.0f];
+        byte[] expectedPayload3 = [PayloadIdentifierCommand1, AppIdentifier1, AppIdentifier2, 0xff, 0xff, 0x88, 0x88, 0x88, 0x88, PayloadIdentifierCommand2];
 
         MK4 device1 = new MK4("MK4", MK4.Device1, [], _deviceRepository.Object, _bluetoothLEService.Object, _mkPlatformService, _manager.Object);
         MK4 device2 = new MK4("MK4", MK4.Device2, [], _deviceRepository.Object, _bluetoothLEService.Object, _mkPlatformService, _manager.Object);
         MK4 device3 = new MK4("MK4", MK4.Device3, [], _deviceRepository.Object, _bluetoothLEService.Object, _mkPlatformService, _manager.Object);
 
         // Set the output values for the device
-        for (int i = 0; i < setValues_1.Length; i++)
+        for (int i = 0; i < setValues1.Length; i++)
         {
-            device1.SetOutput(i, setValues_1[i]);
-            device2.SetOutput(i, setValues_2[i]);
-            device3.SetOutput(i, setValues_3[i]);
+            device1.SetOutput(i, setValues1[i]);
+            device2.SetOutput(i, setValues2[i]);
+            device3.SetOutput(i, setValues3[i]);
         }
 
         // Get the command datagram payload
@@ -178,11 +175,8 @@ public sealed class MouldKingMK4DatagramTests : MouldKingDatagramTestsBase
         device3.TryGetTelegram(false, out byte[] payload3).Should().BeTrue();
 
         // Check that the payload matches the expected values
-        for (int i = 0; i < expectedPayload_1.Length; i++)
-        {
-            payload1[i].Should().Be(expectedPayload_1[i]);
-            payload2[i].Should().Be(expectedPayload_2[i]);
-            payload3[i].Should().Be(expectedPayload_3[i]);
-        }
+        payload1.Should().BeEquivalentTo(expectedPayload1);
+        payload2.Should().BeEquivalentTo(expectedPayload2);
+        payload3.Should().BeEquivalentTo(expectedPayload3);
     }
 }

--- a/BrickController2/BrickController2.Tests/DeviceManagement/MouldKing/MouldKingMK5DatagramTests.cs
+++ b/BrickController2/BrickController2.Tests/DeviceManagement/MouldKing/MouldKingMK5DatagramTests.cs
@@ -1,7 +1,5 @@
-﻿using BrickController2.DeviceManagement;
-using BrickController2.DeviceManagement.MouldKing;
+﻿using BrickController2.DeviceManagement.MouldKing;
 using FluentAssertions;
-using Moq;
 using System;
 using Xunit;
 
@@ -13,8 +11,6 @@ public sealed class MouldKingMK5DatagramTests : MouldKingDatagramTestsBase
     private const byte PayloadIdentifierConnect2 = 0x52;
     private const byte PayloadIdentifierCommand1 = 0x7d;
     private const byte PayloadIdentifierCommand2 = 0x82;
-
-    private readonly Mock<IDeviceRepository> _deviceRepository = new(MockBehavior.Strict); // IDeviceRepository is defined as internal, so we can't declare it as a field in the base class. We need to declare it here in the derived class.
 
     /// <summary>
     /// This test checks that the payload identifiers are correctly set in the connect datagram for each device address.

--- a/BrickController2/BrickController2.Tests/DeviceManagement/MouldKing/MouldKingMK5DatagramTests.cs
+++ b/BrickController2/BrickController2.Tests/DeviceManagement/MouldKing/MouldKingMK5DatagramTests.cs
@@ -1,0 +1,122 @@
+﻿using BrickController2.DeviceManagement;
+using BrickController2.DeviceManagement.MouldKing;
+using FluentAssertions;
+using Moq;
+using System;
+using Xunit;
+
+namespace BrickController2.Tests.DeviceManagement.MouldKing;
+
+public sealed class MouldKingMK5DatagramTests : MouldKingDatagramTestsBase
+{
+    private const byte PayloadIdentifierConnect1 = 0xad;
+    private const byte PayloadIdentifierConnect2 = 0x52;
+    private const byte PayloadIdentifierCommand1 = 0x7d;
+    private const byte PayloadIdentifierCommand2 = 0x82;
+
+    private readonly Mock<IDeviceRepository> _deviceRepository = new(MockBehavior.Strict); // IDeviceRepository is defined as internal, so we can't declare it as a field in the base class. We need to declare it here in the derived class.
+
+    /// <summary>
+    /// This test checks that the payload identifiers are correctly set in the connect datagram for each device address.
+    /// </summary>
+    [Fact]
+    public void TryGetTelegram_ConnectDatagram_PayloadIdentifier()
+    {
+        MK5 device = new MK5("MK5", MK5.Device, [], _deviceRepository.Object, _bluetoothLEService.Object, _mkPlatformService, _manager.Object);
+
+        device.TryGetTelegram(true, out byte[] payload).Should().BeTrue();
+        payload[0].Should().Be(PayloadIdentifierConnect1);
+        payload[7].Should().Be(PayloadIdentifierConnect2);
+    }
+
+    /// <summary>
+    /// This test checks that the AppIdentifier is correctly included in the connect datagram payload for each device address.
+    /// </summary>
+    [Fact]
+    public void TryGetTelegram_ConnectDatagram_AppIdentifier()
+    {
+        MK5 device = new MK5("MK5", MK5.Device, [], _deviceRepository.Object, _bluetoothLEService.Object, _mkPlatformService, _manager.Object);
+
+        device.TryGetTelegram(true, out byte[] payload).Should().BeTrue();
+        payload[1].Should().Be(AppIdentifier1);
+        payload[2].Should().Be(AppIdentifier2);
+    }
+
+    /// <summary>
+    /// This test checks that the payload identifiers are correctly set in the command datagram for each device address.
+    /// </summary>
+    [Fact]
+    public void TryGetTelegram_CommandDatagram_PayloadIdentifier()
+    {
+        MK5 device = new MK5("MK5", MK5.Device, [], _deviceRepository.Object, _bluetoothLEService.Object, _mkPlatformService, _manager.Object);
+
+        device.TryGetTelegram(false, out byte[] payload).Should().BeTrue();
+        payload[0].Should().Be(PayloadIdentifierCommand1);
+        payload[9].Should().Be(PayloadIdentifierCommand2);
+    }
+
+    /// <summary>
+    /// This test checks that the AppIdentifier is correctly included in the command datagram payload for each device address.
+    /// </summary>
+    [Fact]
+    public void TryGetTelegram_CommandDatagram_AppIdentifier()
+    {
+        MK5 device = new MK5("MK5", MK5.Device, [], _deviceRepository.Object, _bluetoothLEService.Object, _mkPlatformService, _manager.Object);
+
+        device.TryGetTelegram(false, out byte[] payload).Should().BeTrue();
+        payload[1].Should().Be(AppIdentifier1);
+        payload[2].Should().Be(AppIdentifier2);
+    }
+
+    /// <summary>
+    /// This test checks that the command datagram payload is correctly constructed based on the set output values for each device address.
+    /// </summary>
+    /// <param name="setValues">The set values for each channel.</param>
+    /// <param name="expectedPayload">The expected payload for the command datagram.</param>
+    [Theory]
+    [InlineData(new float[] { 0.0f, 0.0f, 0.0f, 0.0f, 0.0f }, new byte[] { PayloadIdentifierCommand1, AppIdentifier1, AppIdentifier2, 0x00, 0x00, 0x80, 0x80, 0x80, 0x80, PayloadIdentifierCommand2 })]        // all channels neutral
+    [InlineData(new float[] { 1.0f, 0.0f, 0.0f, 0.0f, 0.0f }, new byte[] { PayloadIdentifierCommand1, AppIdentifier1, AppIdentifier2, 0xf0, 0x00, 0x80, 0x80, 0x80, 0x80, PayloadIdentifierCommand2 })]        // channel 1 maximum, others neutral
+    [InlineData(new float[] { 0.0f, 1.0f, 0.0f, 0.0f, 0.0f }, new byte[] { PayloadIdentifierCommand1, AppIdentifier1, AppIdentifier2, 0x07, 0x00, 0x80, 0x80, 0x80, 0x80, PayloadIdentifierCommand2 })]        // channel 2 maximum, others neutral
+    [InlineData(new float[] { 0.0f, 0.0f, 1.0f, 0.0f, 0.0f }, new byte[] { PayloadIdentifierCommand1, AppIdentifier1, AppIdentifier2, 0x00, 0xf0, 0x80, 0x80, 0x80, 0x80, PayloadIdentifierCommand2 })]        // channel 3 maximum, others neutral
+    [InlineData(new float[] { 0.0f, 0.0f, 0.0f, 1.0f, 0.0f }, new byte[] { PayloadIdentifierCommand1, AppIdentifier1, AppIdentifier2, 0x00, 0x0f, 0x80, 0x80, 0x80, 0x80, PayloadIdentifierCommand2 })]        // channel 4 maximum, others neutral
+    [InlineData(new float[] { 0.0f, 0.0f, 0.0f, 0.0f, 1.0f }, new byte[] { PayloadIdentifierCommand1, AppIdentifier1, AppIdentifier2, 0x02, 0x00, 0x80, 0x80, 0x80, 0x80, PayloadIdentifierCommand2 })]        // channel 5 maximum, others neutral
+    [InlineData(new float[] { -1.0f, 0.0f, 0.0f, 0.0f, 0.0f }, new byte[] { PayloadIdentifierCommand1, AppIdentifier1, AppIdentifier2, 0x70, 0x00, 0x80, 0x80, 0x80, 0x80, PayloadIdentifierCommand2 })]       // channel 1 minimum, others neutral
+    [InlineData(new float[] { 0.0f, -1.0f, 0.0f, 0.0f, 0.0f }, new byte[] { PayloadIdentifierCommand1, AppIdentifier1, AppIdentifier2, 0x0f, 0x00, 0x80, 0x80, 0x80, 0x80, PayloadIdentifierCommand2 })]       // channel 2 minimum, others neutral
+    [InlineData(new float[] { 0.0f, 0.0f, -1.0f, 0.0f, 0.0f }, new byte[] { PayloadIdentifierCommand1, AppIdentifier1, AppIdentifier2, 0x00, 0xf0, 0x80, 0x80, 0x80, 0x80, PayloadIdentifierCommand2 })]       // channel 3 minimum, others neutral
+    [InlineData(new float[] { 0.0f, 0.0f, 0.0f, -1.0f, 0.0f }, new byte[] { PayloadIdentifierCommand1, AppIdentifier1, AppIdentifier2, 0x00, 0x07, 0x80, 0x80, 0x80, 0x80, PayloadIdentifierCommand2 })]       // channel 4 minimum, others neutral
+    [InlineData(new float[] { 0.0f, 0.0f, 0.0f, 0.0f, -1.0f }, new byte[] { PayloadIdentifierCommand1, AppIdentifier1, AppIdentifier2, 0x02, 0x00, 0x80, 0x80, 0x80, 0x80, PayloadIdentifierCommand2 })]       // channel 5 minimum, others neutral
+    [InlineData(new float[] { 9.0f, 9.0f, 9.0f, 9.0f, 9.0f }, new byte[] { PayloadIdentifierCommand1, AppIdentifier1, AppIdentifier2, 0xf7, 0xff, 0x80, 0x80, 0x80, 0x80, PayloadIdentifierCommand2 })]        // all channels above maximum, should be clamped to maximum
+    [InlineData(new float[] { -9.0f, -9.0f, -9.0f, -9.0f, -9.0f }, new byte[] { PayloadIdentifierCommand1, AppIdentifier1, AppIdentifier2, 0x7f, 0xf7, 0x80, 0x80, 0x80, 0x80, PayloadIdentifierCommand2 })]  // all channels below minimum, should be clamped to minimum
+    public void TryGetTelegram_CommandDatagram_Payload(float[] setValues, byte[] expectedPayload)
+    {
+        MK5 device = new MK5("MK5", MK5.Device, [], _deviceRepository.Object, _bluetoothLEService.Object, _mkPlatformService, _manager.Object);
+
+        // Set the output values for the device
+        for (int i = 0; i < setValues.Length; i++)
+        {
+            device.SetOutput(i, setValues[i]);
+        }
+
+        // Get the command datagram payload
+        device.TryGetTelegram(false, out byte[] payload).Should().BeTrue();
+
+        // Check that the payload matches the expected values
+        for (int i = 0; i < expectedPayload.Length; i++)
+        {
+            payload[i].Should().Be(expectedPayload[i]);
+        }
+    }
+
+    /// <summary>
+    /// Tests that setting an illegal channel index throws an ArgumentOutOfRangeException.
+    /// </summary>
+    [Fact]
+    public void TryGetTelegram_CommandDatagram_SetIllegalChannel()
+    {
+        MK5 device = new MK5("MK5", MK5.Device, [], _deviceRepository.Object, _bluetoothLEService.Object, _mkPlatformService, _manager.Object);
+
+        Action action = () => device.SetOutput(device.NumberOfChannels, 0);
+
+        action.Should().Throw<ArgumentOutOfRangeException>();
+    }
+}

--- a/BrickController2/BrickController2.Tests/DeviceManagement/MouldKing/MouldKingMK5DatagramTests.cs
+++ b/BrickController2/BrickController2.Tests/DeviceManagement/MouldKing/MouldKingMK5DatagramTests.cs
@@ -97,10 +97,7 @@ public sealed class MouldKingMK5DatagramTests : MouldKingDatagramTestsBase
         device.TryGetTelegram(false, out byte[] payload).Should().BeTrue();
 
         // Check that the payload matches the expected values
-        for (int i = 0; i < expectedPayload.Length; i++)
-        {
-            payload[i].Should().Be(expectedPayload[i]);
-        }
+        payload.Should().BeEquivalentTo(expectedPayload);
     }
 
     /// <summary>

--- a/BrickController2/BrickController2.Tests/DeviceManagement/MouldKing/MouldKingMK6DatagramTests.cs
+++ b/BrickController2/BrickController2.Tests/DeviceManagement/MouldKing/MouldKingMK6DatagramTests.cs
@@ -2,31 +2,40 @@
 using BrickController2.DeviceManagement.MouldKing;
 using FluentAssertions;
 using Moq;
+using System;
+using System.Net;
 using Xunit;
 
 namespace BrickController2.Tests.DeviceManagement.MouldKing;
 
 public sealed class MouldKingMK6DatagramTests : MouldKingDatagramTestsBase
 {
+    private const byte PayloadIdentifierConnect1 = 0x6d;
+    private const byte PayloadIdentifierConnect2 = 0x92;
+    private const byte PayloadIdentifierCommand1_1 = 0x61;
+    private const byte PayloadIdentifierCommand1_2 = 0x9e;
+    private const byte PayloadIdentifierCommand2_1 = 0x62;
+    private const byte PayloadIdentifierCommand2_2 = 0x9d;
+    private const byte PayloadIdentifierCommand3_1 = 0x63;
+    private const byte PayloadIdentifierCommand3_2 = 0x9c;
+
     private readonly Mock<IDeviceRepository> _deviceRepository = new(MockBehavior.Strict); // IDeviceRepository is defined as internal, so we can't declare it as a field in the base class. We need to declare it here in the derived class.
 
     /// <summary>
     /// This test checks that the payload identifiers are correctly set in the connect datagram for each device address.
     /// </summary>
     /// <param name="deviceAddress">The address of the device to test.</param>
-    /// <param name="expectedPayloadIdentifier1">The expected first payload identifier.</param>
-    /// <param name="expectedPayloadIdentifier2">The expected second payload identifier.</param>
     [Theory]
-    [InlineData(MK6.Device1, 0x6d, 0x92)]
-    [InlineData(MK6.Device2, 0x6d, 0x92)]
-    [InlineData(MK6.Device3, 0x6d, 0x92)]
-    public void TryGetTelegram_ConnectDatagram_PayloadIdentifier(string deviceAddress, byte expectedPayloadIdentifier1, byte expectedPayloadIdentifier2)
+    [InlineData(MK6.Device1)]
+    [InlineData(MK6.Device2)]
+    [InlineData(MK6.Device3)]
+    public void TryGetTelegram_ConnectDatagram_PayloadIdentifier(string deviceAddress)
     {
         MK6 device = new MK6("MK6", deviceAddress, [], _deviceRepository.Object, _bluetoothLEService.Object, _mkPlatformService, _manager.Object);
 
         device.TryGetTelegram(true, out byte[] payload).Should().BeTrue();
-        payload[0].Should().Be(expectedPayloadIdentifier1);
-        payload[7].Should().Be(expectedPayloadIdentifier2);
+        payload[0].Should().Be(PayloadIdentifierConnect1);
+        payload[7].Should().Be(PayloadIdentifierConnect2);
     }
 
     /// <summary>
@@ -42,8 +51,8 @@ public sealed class MouldKingMK6DatagramTests : MouldKingDatagramTestsBase
         MK6 device = new MK6("MK6", deviceAddress, [], _deviceRepository.Object, _bluetoothLEService.Object, _mkPlatformService, _manager.Object);
 
         device.TryGetTelegram(true, out byte[] payload).Should().BeTrue();
-        payload[1].Should().Be(AppIdentifier[0]);
-        payload[2].Should().Be(AppIdentifier[1]);
+        payload[1].Should().Be(AppIdentifier1);
+        payload[2].Should().Be(AppIdentifier2);
     }
 
     /// <summary>
@@ -53,9 +62,9 @@ public sealed class MouldKingMK6DatagramTests : MouldKingDatagramTestsBase
     /// <param name="expectedPayloadIdentifier1">The expected first payload identifier.</param>
     /// <param name="expectedPayloadIdentifier2">The expected second payload identifier.</param>
     [Theory]
-    [InlineData(MK6.Device1, 0x61, 0x9e)]
-    [InlineData(MK6.Device2, 0x62, 0x9d)]
-    [InlineData(MK6.Device3, 0x63, 0x9c)]
+    [InlineData(MK6.Device1, PayloadIdentifierCommand1_1, PayloadIdentifierCommand1_2)]
+    [InlineData(MK6.Device2, PayloadIdentifierCommand2_1, PayloadIdentifierCommand2_2)]
+    [InlineData(MK6.Device3, PayloadIdentifierCommand3_1, PayloadIdentifierCommand3_2)]
     public void TryGetTelegram_CommandDatagram_PayloadIdentifier(string deviceAddress, byte expectedPayloadIdentifier1, byte expectedPayloadIdentifier2)
     {
         MK6 device = new MK6("MK6", deviceAddress, [], _deviceRepository.Object, _bluetoothLEService.Object, _mkPlatformService, _manager.Object);
@@ -78,8 +87,8 @@ public sealed class MouldKingMK6DatagramTests : MouldKingDatagramTestsBase
         MK6 device = new MK6("MK6", deviceAddress, [], _deviceRepository.Object, _bluetoothLEService.Object, _mkPlatformService, _manager.Object);
 
         device.TryGetTelegram(false, out byte[] payload).Should().BeTrue();
-        payload[1].Should().Be(AppIdentifier[0]);
-        payload[2].Should().Be(AppIdentifier[1]);
+        payload[1].Should().Be(AppIdentifier1);
+        payload[2].Should().Be(AppIdentifier2);
     }
 
     /// <summary>
@@ -89,29 +98,29 @@ public sealed class MouldKingMK6DatagramTests : MouldKingDatagramTestsBase
     /// <param name="setValues">The set values for each channel.</param>
     /// <param name="expectedPayload">The expected payload for the command datagram.</param>
     [Theory]
-    [InlineData(MK6.Device1, new float[] { 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f }, new byte[] { 0x80, 0x80, 0x80, 0x80, 0x80, 0x80 })]        // all channels neutral
-    [InlineData(MK6.Device1, new float[] { 1.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f }, new byte[] { 0xff, 0x80, 0x80, 0x80, 0x80, 0x80 })]        // channel 1 maximum, others neutral
-    [InlineData(MK6.Device1, new float[] { 0.0f, 1.0f, 0.0f, 0.0f, 0.0f, 0.0f }, new byte[] { 0x80, 0xff, 0x80, 0x80, 0x80, 0x80 })]        // channel 2 maximum, others neutral
-    [InlineData(MK6.Device1, new float[] { 0.0f, 0.0f, 1.0f, 0.0f, 0.0f, 0.0f }, new byte[] { 0x80, 0x80, 0xff, 0x80, 0x80, 0x80 })]        // channel 3 maximum, others neutral
-    [InlineData(MK6.Device1, new float[] { 0.0f, 0.0f, 0.0f, 1.0f, 0.0f, 0.0f }, new byte[] { 0x80, 0x80, 0x80, 0xff, 0x80, 0x80 })]        // channel 4 maximum, others neutral
-    [InlineData(MK6.Device1, new float[] { 0.0f, 0.0f, 0.0f, 0.0f, 1.0f, 0.0f }, new byte[] { 0x80, 0x80, 0x80, 0x80, 0xff, 0x80 })]        // channel 5 maximum, others neutral
-    [InlineData(MK6.Device1, new float[] { 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 1.0f }, new byte[] { 0x80, 0x80, 0x80, 0x80, 0x80, 0xff })]        // channel 6 maximum, others neutral
-    [InlineData(MK6.Device1, new float[] { -1.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f }, new byte[] { 0x00, 0x80, 0x80, 0x80, 0x80, 0x80 })]       // channel 1 minimum, others neutral
-    [InlineData(MK6.Device1, new float[] { 0.0f, -1.0f, 0.0f, 0.0f, 0.0f, 0.0f }, new byte[] { 0x80, 0x00, 0x80, 0x80, 0x80, 0x80 })]       // channel 2 minimum, others neutral
-    [InlineData(MK6.Device1, new float[] { 0.0f, 0.0f, -1.0f, 0.0f, 0.0f, 0.0f }, new byte[] { 0x80, 0x80, 0x00, 0x80, 0x80, 0x80 })]       // channel 3 minimum, others neutral
-    [InlineData(MK6.Device1, new float[] { 0.0f, 0.0f, 0.0f, -1.0f, 0.0f, 0.0f }, new byte[] { 0x80, 0x80, 0x80, 0x00, 0x80, 0x80 })]       // channel 4 minimum, others neutral
-    [InlineData(MK6.Device1, new float[] { 0.0f, 0.0f, 0.0f, 0.0f, -1.0f, 0.0f }, new byte[] { 0x80, 0x80, 0x80, 0x80, 0x00, 0x80 })]       // channel 5 minimum, others neutral
-    [InlineData(MK6.Device1, new float[] { 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, -1.0f }, new byte[] { 0x80, 0x80, 0x80, 0x80, 0x80, 0x00 })]       // channel 6 minimum, others neutral
-    [InlineData(MK6.Device1, new float[] { 9.0f, 9.0f, 9.0f, 9.0f, 9.0f, 9.0f }, new byte[] { 0xff, 0xff, 0xff, 0xff, 0xff, 0xff })]        // all channels above maximum, should be clamped to maximum
-    [InlineData(MK6.Device1, new float[] { -9.0f, -9.0f, -9.0f, -9.0f, -9.0f, -9.0f }, new byte[] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 })]  // all channels below minimum, should be clamped to minimum
+    [InlineData(MK6.Device1, new float[] { 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f }, new byte[] { PayloadIdentifierCommand1_1, AppIdentifier1, AppIdentifier2, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, PayloadIdentifierCommand1_2 })]        // all channels neutral
+    [InlineData(MK6.Device1, new float[] { 1.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f }, new byte[] { PayloadIdentifierCommand1_1, AppIdentifier1, AppIdentifier2, 0xff, 0x80, 0x80, 0x80, 0x80, 0x80, PayloadIdentifierCommand1_2 })]        // channel 1 maximum, others neutral
+    [InlineData(MK6.Device1, new float[] { 0.0f, 1.0f, 0.0f, 0.0f, 0.0f, 0.0f }, new byte[] { PayloadIdentifierCommand1_1, AppIdentifier1, AppIdentifier2, 0x80, 0xff, 0x80, 0x80, 0x80, 0x80, PayloadIdentifierCommand1_2 })]        // channel 2 maximum, others neutral
+    [InlineData(MK6.Device1, new float[] { 0.0f, 0.0f, 1.0f, 0.0f, 0.0f, 0.0f }, new byte[] { PayloadIdentifierCommand1_1, AppIdentifier1, AppIdentifier2, 0x80, 0x80, 0xff, 0x80, 0x80, 0x80, PayloadIdentifierCommand1_2 })]        // channel 3 maximum, others neutral
+    [InlineData(MK6.Device1, new float[] { 0.0f, 0.0f, 0.0f, 1.0f, 0.0f, 0.0f }, new byte[] { PayloadIdentifierCommand1_1, AppIdentifier1, AppIdentifier2, 0x80, 0x80, 0x80, 0xff, 0x80, 0x80, PayloadIdentifierCommand1_2 })]        // channel 4 maximum, others neutral
+    [InlineData(MK6.Device1, new float[] { 0.0f, 0.0f, 0.0f, 0.0f, 1.0f, 0.0f }, new byte[] { PayloadIdentifierCommand1_1, AppIdentifier1, AppIdentifier2, 0x80, 0x80, 0x80, 0x80, 0xff, 0x80, PayloadIdentifierCommand1_2 })]        // channel 5 maximum, others neutral
+    [InlineData(MK6.Device1, new float[] { 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 1.0f }, new byte[] { PayloadIdentifierCommand1_1, AppIdentifier1, AppIdentifier2, 0x80, 0x80, 0x80, 0x80, 0x80, 0xff, PayloadIdentifierCommand1_2 })]        // channel 6 maximum, others neutral
+    [InlineData(MK6.Device1, new float[] { -1.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f }, new byte[] { PayloadIdentifierCommand1_1, AppIdentifier1, AppIdentifier2, 0x00, 0x80, 0x80, 0x80, 0x80, 0x80, PayloadIdentifierCommand1_2 })]       // channel 1 minimum, others neutral
+    [InlineData(MK6.Device1, new float[] { 0.0f, -1.0f, 0.0f, 0.0f, 0.0f, 0.0f }, new byte[] { PayloadIdentifierCommand1_1, AppIdentifier1, AppIdentifier2, 0x80, 0x00, 0x80, 0x80, 0x80, 0x80, PayloadIdentifierCommand1_2 })]       // channel 2 minimum, others neutral
+    [InlineData(MK6.Device1, new float[] { 0.0f, 0.0f, -1.0f, 0.0f, 0.0f, 0.0f }, new byte[] { PayloadIdentifierCommand1_1, AppIdentifier1, AppIdentifier2, 0x80, 0x80, 0x00, 0x80, 0x80, 0x80, PayloadIdentifierCommand1_2 })]       // channel 3 minimum, others neutral
+    [InlineData(MK6.Device1, new float[] { 0.0f, 0.0f, 0.0f, -1.0f, 0.0f, 0.0f }, new byte[] { PayloadIdentifierCommand1_1, AppIdentifier1, AppIdentifier2, 0x80, 0x80, 0x80, 0x00, 0x80, 0x80, PayloadIdentifierCommand1_2 })]       // channel 4 minimum, others neutral
+    [InlineData(MK6.Device1, new float[] { 0.0f, 0.0f, 0.0f, 0.0f, -1.0f, 0.0f }, new byte[] { PayloadIdentifierCommand1_1, AppIdentifier1, AppIdentifier2, 0x80, 0x80, 0x80, 0x80, 0x00, 0x80, PayloadIdentifierCommand1_2 })]       // channel 5 minimum, others neutral
+    [InlineData(MK6.Device1, new float[] { 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, -1.0f }, new byte[] { PayloadIdentifierCommand1_1, AppIdentifier1, AppIdentifier2, 0x80, 0x80, 0x80, 0x80, 0x80, 0x00, PayloadIdentifierCommand1_2 })]       // channel 6 minimum, others neutral
+    [InlineData(MK6.Device1, new float[] { 9.0f, 9.0f, 9.0f, 9.0f, 9.0f, 9.0f }, new byte[] { PayloadIdentifierCommand1_1, AppIdentifier1, AppIdentifier2, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, PayloadIdentifierCommand1_2 })]        // all channels above maximum, should be clamped to maximum
+    [InlineData(MK6.Device1, new float[] { -9.0f, -9.0f, -9.0f, -9.0f, -9.0f, -9.0f }, new byte[] { PayloadIdentifierCommand1_1, AppIdentifier1, AppIdentifier2, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, PayloadIdentifierCommand1_2 })]  // all channels below minimum, should be clamped to minimum
 
-    [InlineData(MK6.Device2, new float[] { 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f }, new byte[] { 0x80, 0x80, 0x80, 0x80, 0x80, 0x80 })]        // all channels neutral
-    [InlineData(MK6.Device2, new float[] { 9.0f, 9.0f, 9.0f, 9.0f, 9.0f, 9.0f }, new byte[] { 0xff, 0xff, 0xff, 0xff, 0xff, 0xff })]        // all channels above maximum, should be clamped to maximum
-    [InlineData(MK6.Device2, new float[] { -9.0f, -9.0f, -9.0f, -9.0f, -9.0f, -9.0f }, new byte[] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 })]  // all channels below minimum, should be clamped to minimum
+    [InlineData(MK6.Device2, new float[] { 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f }, new byte[] { PayloadIdentifierCommand2_1, AppIdentifier1, AppIdentifier2, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, PayloadIdentifierCommand2_2 })]        // all channels neutral
+    [InlineData(MK6.Device2, new float[] { 9.0f, 9.0f, 9.0f, 9.0f, 9.0f, 9.0f }, new byte[] { PayloadIdentifierCommand2_1, AppIdentifier1, AppIdentifier2, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, PayloadIdentifierCommand2_2 })]        // all channels above maximum, should be clamped to maximum
+    [InlineData(MK6.Device2, new float[] { -9.0f, -9.0f, -9.0f, -9.0f, -9.0f, -9.0f }, new byte[] { PayloadIdentifierCommand2_1, AppIdentifier1, AppIdentifier2, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, PayloadIdentifierCommand2_2 })]  // all channels below minimum, should be clamped to minimum
 
-    [InlineData(MK6.Device3, new float[] { 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f }, new byte[] { 0x80, 0x80, 0x80, 0x80, 0x80, 0x80 })]        // all channels neutral
-    [InlineData(MK6.Device3, new float[] { 9.0f, 9.0f, 9.0f, 9.0f, 9.0f, 9.0f }, new byte[] { 0xff, 0xff, 0xff, 0xff, 0xff, 0xff })]        // all channels above maximum, should be clamped to maximum
-    [InlineData(MK6.Device3, new float[] { -9.0f, -9.0f, -9.0f, -9.0f, -9.0f, -9.0f }, new byte[] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 })]  // all channels below minimum, should be clamped to minimum
+    [InlineData(MK6.Device3, new float[] { 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f }, new byte[] { PayloadIdentifierCommand3_1, AppIdentifier1, AppIdentifier2, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, PayloadIdentifierCommand3_2 })]        // all channels neutral
+    [InlineData(MK6.Device3, new float[] { 9.0f, 9.0f, 9.0f, 9.0f, 9.0f, 9.0f }, new byte[] { PayloadIdentifierCommand3_1, AppIdentifier1, AppIdentifier2, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, PayloadIdentifierCommand3_2 })]        // all channels above maximum, should be clamped to maximum
+    [InlineData(MK6.Device3, new float[] { -9.0f, -9.0f, -9.0f, -9.0f, -9.0f, -9.0f }, new byte[] { PayloadIdentifierCommand3_1, AppIdentifier1, AppIdentifier2, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, PayloadIdentifierCommand3_2 })]  // all channels below minimum, should be clamped to minimum
     public void TryGetTelegram_CommandDatagram_Payload(string deviceAddress, float[] setValues, byte[] expectedPayload)
     {
         MK6 device = new MK6("MK6", deviceAddress, [], _deviceRepository.Object, _bluetoothLEService.Object, _mkPlatformService, _manager.Object);
@@ -128,7 +137,24 @@ public sealed class MouldKingMK6DatagramTests : MouldKingDatagramTestsBase
         // Check that the payload matches the expected values
         for (int i = 0; i < expectedPayload.Length; i++)
         {
-            payload[i + 3].Should().Be(expectedPayload[i]);
+            payload[i].Should().Be(expectedPayload[i]);
         }
+    }
+
+    /// <summary>
+    /// Tests that setting an illegal channel index throws an ArgumentOutOfRangeException.
+    /// </summary>
+    /// <param name="deviceAddress">The address of the device to test.</param>
+    [Theory]
+    [InlineData(MK6.Device1)]
+    [InlineData(MK6.Device2)]
+    [InlineData(MK6.Device3)]
+    public void TryGetTelegram_CommandDatagram_SetIllegalChannel(string deviceAddress)
+    {
+        MK6 device = new MK6("MK6", deviceAddress, [], _deviceRepository.Object, _bluetoothLEService.Object, _mkPlatformService, _manager.Object);
+
+        Action action = () => device.SetOutput(device.NumberOfChannels, 0);
+
+        action.Should().Throw<ArgumentOutOfRangeException>();
     }
 }

--- a/BrickController2/BrickController2.Tests/DeviceManagement/MouldKing/MouldKingMK6DatagramTests.cs
+++ b/BrickController2/BrickController2.Tests/DeviceManagement/MouldKing/MouldKingMK6DatagramTests.cs
@@ -1,9 +1,6 @@
-﻿using BrickController2.DeviceManagement;
-using BrickController2.DeviceManagement.MouldKing;
+﻿using BrickController2.DeviceManagement.MouldKing;
 using FluentAssertions;
-using Moq;
 using System;
-using System.Net;
 using Xunit;
 
 namespace BrickController2.Tests.DeviceManagement.MouldKing;
@@ -18,8 +15,6 @@ public sealed class MouldKingMK6DatagramTests : MouldKingDatagramTestsBase
     private const byte PayloadIdentifierCommand2_2 = 0x9d;
     private const byte PayloadIdentifierCommand3_1 = 0x63;
     private const byte PayloadIdentifierCommand3_2 = 0x9c;
-
-    private readonly Mock<IDeviceRepository> _deviceRepository = new(MockBehavior.Strict); // IDeviceRepository is defined as internal, so we can't declare it as a field in the base class. We need to declare it here in the derived class.
 
     /// <summary>
     /// This test checks that the payload identifiers are correctly set in the connect datagram for each device address.

--- a/BrickController2/BrickController2.Tests/DeviceManagement/MouldKing/MouldKingMK6DatagramTests.cs
+++ b/BrickController2/BrickController2.Tests/DeviceManagement/MouldKing/MouldKingMK6DatagramTests.cs
@@ -1,4 +1,5 @@
-﻿using BrickController2.DeviceManagement.MouldKing;
+﻿using BrickController2.DeviceManagement.JieStar;
+using BrickController2.DeviceManagement.MouldKing;
 using FluentAssertions;
 using System;
 using Xunit;
@@ -151,5 +152,46 @@ public sealed class MouldKingMK6DatagramTests : MouldKingDatagramTestsBase
         Action action = () => device.SetOutput(device.NumberOfChannels, 0);
 
         action.Should().Throw<ArgumentOutOfRangeException>();
+    }
+
+    /// <summary>
+    /// This test checks that the command datagram payload is correctly constructed based on the set output values for multiple devices, ensuring that each device's payload is independent of the others.
+    /// </summary>
+    [Fact]
+    public void TryGetTelegram_CommandDatagram_InstanceInteraction()
+    {
+        float[] setValues_1 = [1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f];
+        byte[] expectedPayload_1 = [PayloadIdentifierCommand1_1, AppIdentifier1, AppIdentifier2, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, PayloadIdentifierCommand1_2];
+
+        float[] setValues_2 = [0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f];
+        byte[] expectedPayload_2 = [PayloadIdentifierCommand2_1, AppIdentifier1, AppIdentifier2, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, PayloadIdentifierCommand2_2];
+
+        float[] setValues_3 = [0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f];
+        byte[] expectedPayload_3 = [PayloadIdentifierCommand3_1, AppIdentifier1, AppIdentifier2, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, PayloadIdentifierCommand3_2];
+
+        MK6 device1 = new MK6("MK6", MK6.Device1, [], _deviceRepository.Object, _bluetoothLEService.Object, _mkPlatformService, _manager.Object);
+        MK6 device2 = new MK6("MK6", MK6.Device2, [], _deviceRepository.Object, _bluetoothLEService.Object, _mkPlatformService, _manager.Object);
+        MK6 device3 = new MK6("MK6", MK6.Device3, [], _deviceRepository.Object, _bluetoothLEService.Object, _mkPlatformService, _manager.Object);
+
+        // Set the output values for the device
+        for (int i = 0; i < setValues_1.Length; i++)
+        {
+            device1.SetOutput(i, setValues_1[i]);
+            device2.SetOutput(i, setValues_2[i]);
+            device3.SetOutput(i, setValues_3[i]);
+        }
+
+        // Get the command datagram payload
+        device1.TryGetTelegram(false, out byte[] payload1).Should().BeTrue();
+        device2.TryGetTelegram(false, out byte[] payload2).Should().BeTrue();
+        device3.TryGetTelegram(false, out byte[] payload3).Should().BeTrue();
+
+        // Check that the payload matches the expected values
+        for (int i = 0; i < expectedPayload_1.Length; i++)
+        {
+            payload1[i].Should().Be(expectedPayload_1[i]);
+            payload2[i].Should().Be(expectedPayload_2[i]);
+            payload3[i].Should().Be(expectedPayload_3[i]);
+        }
     }
 }

--- a/BrickController2/BrickController2.Tests/DeviceManagement/MouldKing/MouldKingMK6DatagramTests.cs
+++ b/BrickController2/BrickController2.Tests/DeviceManagement/MouldKing/MouldKingMK6DatagramTests.cs
@@ -131,10 +131,7 @@ public sealed class MouldKingMK6DatagramTests : MouldKingDatagramTestsBase
         device.TryGetTelegram(false, out byte[] payload).Should().BeTrue();
 
         // Check that the payload matches the expected values
-        for (int i = 0; i < expectedPayload.Length; i++)
-        {
-            payload[i].Should().Be(expectedPayload[i]);
-        }
+        payload.Should().BeEquivalentTo(expectedPayload);
     }
 
     /// <summary>
@@ -160,25 +157,25 @@ public sealed class MouldKingMK6DatagramTests : MouldKingDatagramTestsBase
     [Fact]
     public void TryGetTelegram_CommandDatagram_InstanceInteraction()
     {
-        float[] setValues_1 = [1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f];
-        byte[] expectedPayload_1 = [PayloadIdentifierCommand1_1, AppIdentifier1, AppIdentifier2, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, PayloadIdentifierCommand1_2];
+        float[] setValues1 = [1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f];
+        byte[] expectedPayload1 = [PayloadIdentifierCommand1_1, AppIdentifier1, AppIdentifier2, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, PayloadIdentifierCommand1_2];
 
-        float[] setValues_2 = [0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f];
-        byte[] expectedPayload_2 = [PayloadIdentifierCommand2_1, AppIdentifier1, AppIdentifier2, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, PayloadIdentifierCommand2_2];
+        float[] setValues2 = [0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f];
+        byte[] expectedPayload2 = [PayloadIdentifierCommand2_1, AppIdentifier1, AppIdentifier2, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, PayloadIdentifierCommand2_2];
 
-        float[] setValues_3 = [0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f];
-        byte[] expectedPayload_3 = [PayloadIdentifierCommand3_1, AppIdentifier1, AppIdentifier2, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, PayloadIdentifierCommand3_2];
+        float[] setValues3 = [0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f];
+        byte[] expectedPayload3 = [PayloadIdentifierCommand3_1, AppIdentifier1, AppIdentifier2, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, PayloadIdentifierCommand3_2];
 
         MK6 device1 = new MK6("MK6", MK6.Device1, [], _deviceRepository.Object, _bluetoothLEService.Object, _mkPlatformService, _manager.Object);
         MK6 device2 = new MK6("MK6", MK6.Device2, [], _deviceRepository.Object, _bluetoothLEService.Object, _mkPlatformService, _manager.Object);
         MK6 device3 = new MK6("MK6", MK6.Device3, [], _deviceRepository.Object, _bluetoothLEService.Object, _mkPlatformService, _manager.Object);
 
         // Set the output values for the device
-        for (int i = 0; i < setValues_1.Length; i++)
+        for (int i = 0; i < setValues1.Length; i++)
         {
-            device1.SetOutput(i, setValues_1[i]);
-            device2.SetOutput(i, setValues_2[i]);
-            device3.SetOutput(i, setValues_3[i]);
+            device1.SetOutput(i, setValues1[i]);
+            device2.SetOutput(i, setValues2[i]);
+            device3.SetOutput(i, setValues3[i]);
         }
 
         // Get the command datagram payload
@@ -187,11 +184,8 @@ public sealed class MouldKingMK6DatagramTests : MouldKingDatagramTestsBase
         device3.TryGetTelegram(false, out byte[] payload3).Should().BeTrue();
 
         // Check that the payload matches the expected values
-        for (int i = 0; i < expectedPayload_1.Length; i++)
-        {
-            payload1[i].Should().Be(expectedPayload_1[i]);
-            payload2[i].Should().Be(expectedPayload_2[i]);
-            payload3[i].Should().Be(expectedPayload_3[i]);
-        }
+        payload1.Should().BeEquivalentTo(expectedPayload1);
+        payload2.Should().BeEquivalentTo(expectedPayload2);
+        payload3.Should().BeEquivalentTo(expectedPayload3);
     }
 }

--- a/BrickController2/BrickController2.Tests/DeviceManagement/MouldKing/MouldKingMK6DatagramTests.cs
+++ b/BrickController2/BrickController2.Tests/DeviceManagement/MouldKing/MouldKingMK6DatagramTests.cs
@@ -1,39 +1,14 @@
 ﻿using BrickController2.DeviceManagement;
 using BrickController2.DeviceManagement.MouldKing;
-using BrickController2.PlatformServices.BluetoothLE;
 using FluentAssertions;
 using Moq;
-using System.Threading.Tasks;
 using Xunit;
 
 namespace BrickController2.Tests.DeviceManagement.MouldKing;
 
-public class MouldKing_MK6_DatagramTests
+public sealed class MouldKingMK6DatagramTests : MouldKingDatagramTestsBase
 {
-    private static readonly byte[] AppIdentifier = [0x61, 0x62];
-
-    /// <summary>
-    /// This class is a test implementation of the IMKPlatformService interface that simulates the behavior of the TryGetRfPayload method for testing purposes.
-    /// It always returns true and sets the rfPayload to the rawData provided.
-    /// </summary>
-    private class TestMKPlatformService : IMKPlatformService
-    {
-        public bool TryGetRfPayload(byte[] rawData, out byte[] rfPayload)
-        {
-            rfPayload = rawData;
-            return true; // Simulate success
-        }
-    }
-
-    private readonly Mock<IDeviceRepository> _deviceRepository = new(MockBehavior.Strict);
-    private readonly Mock<IBluetoothLEService> _bluetoothLEService = new(MockBehavior.Strict);
-    private readonly Mock<IMouldKingDeviceManager> _manager = new(MockBehavior.Strict);
-    private readonly TestMKPlatformService _mkPlatformService = new();
-
-    public MouldKing_MK6_DatagramTests()
-    {
-        _manager.Setup(x => x.GetAppId()).Returns(AppIdentifier);
-    }
+    private readonly Mock<IDeviceRepository> _deviceRepository = new(MockBehavior.Strict); // IDeviceRepository is defined as internal, so we can't declare it as a field in the base class. We need to declare it here in the derived class.
 
     /// <summary>
     /// This test checks that the payload identifiers are correctly set in the connect datagram for each device address.
@@ -45,7 +20,7 @@ public class MouldKing_MK6_DatagramTests
     [InlineData(MK6.Device1, 0x6d, 0x92)]
     [InlineData(MK6.Device2, 0x6d, 0x92)]
     [InlineData(MK6.Device3, 0x6d, 0x92)]
-    public void MK6_TryGetTelegram_ConnectDatagram_PayloadIdentifier(string deviceAddress, byte expectedPayloadIdentifier1, byte expectedPayloadIdentifier2)
+    public void TryGetTelegram_ConnectDatagram_PayloadIdentifier(string deviceAddress, byte expectedPayloadIdentifier1, byte expectedPayloadIdentifier2)
     {
         MK6 device = new MK6("MK6", deviceAddress, [], _deviceRepository.Object, _bluetoothLEService.Object, _mkPlatformService, _manager.Object);
 
@@ -62,7 +37,7 @@ public class MouldKing_MK6_DatagramTests
     [InlineData(MK6.Device1)]
     [InlineData(MK6.Device2)]
     [InlineData(MK6.Device3)]
-    public void MK6_TryGetTelegram_ConnectDatagram_AppIdentifier(string deviceAddress)
+    public void TryGetTelegram_ConnectDatagram_AppIdentifier(string deviceAddress)
     {
         MK6 device = new MK6("MK6", deviceAddress, [], _deviceRepository.Object, _bluetoothLEService.Object, _mkPlatformService, _manager.Object);
 
@@ -81,7 +56,7 @@ public class MouldKing_MK6_DatagramTests
     [InlineData(MK6.Device1, 0x61, 0x9e)]
     [InlineData(MK6.Device2, 0x62, 0x9d)]
     [InlineData(MK6.Device3, 0x63, 0x9c)]
-    public async Task MK6_TryGetTelegram_CommandDatagram_PayloadIdentifier(string deviceAddress, byte expectedPayloadIdentifier1, byte expectedPayloadIdentifier2)
+    public void TryGetTelegram_CommandDatagram_PayloadIdentifier(string deviceAddress, byte expectedPayloadIdentifier1, byte expectedPayloadIdentifier2)
     {
         MK6 device = new MK6("MK6", deviceAddress, [], _deviceRepository.Object, _bluetoothLEService.Object, _mkPlatformService, _manager.Object);
 
@@ -98,7 +73,7 @@ public class MouldKing_MK6_DatagramTests
     [InlineData(MK6.Device1)]
     [InlineData(MK6.Device2)]
     [InlineData(MK6.Device3)]
-    public async Task MK6_TryGetTelegram_CommandDatagram_AppIdentifier(string deviceAddress)
+    public void TryGetTelegram_CommandDatagram_AppIdentifier(string deviceAddress)
     {
         MK6 device = new MK6("MK6", deviceAddress, [], _deviceRepository.Object, _bluetoothLEService.Object, _mkPlatformService, _manager.Object);
 
@@ -137,7 +112,7 @@ public class MouldKing_MK6_DatagramTests
     [InlineData(MK6.Device3, new float[] { 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f }, new byte[] { 0x80, 0x80, 0x80, 0x80, 0x80, 0x80 })]        // all channels neutral
     [InlineData(MK6.Device3, new float[] { 9.0f, 9.0f, 9.0f, 9.0f, 9.0f, 9.0f }, new byte[] { 0xff, 0xff, 0xff, 0xff, 0xff, 0xff })]        // all channels above maximum, should be clamped to maximum
     [InlineData(MK6.Device3, new float[] { -9.0f, -9.0f, -9.0f, -9.0f, -9.0f, -9.0f }, new byte[] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 })]  // all channels below minimum, should be clamped to minimum
-    public async Task MK6_Check_CommandDatagram_Payload(string deviceAddress, float[] setValues, byte[] expectedPayload)
+    public void TryGetTelegram_CommandDatagram_Payload(string deviceAddress, float[] setValues, byte[] expectedPayload)
     {
         MK6 device = new MK6("MK6", deviceAddress, [], _deviceRepository.Object, _bluetoothLEService.Object, _mkPlatformService, _manager.Object);
 

--- a/BrickController2/BrickController2.Tests/DeviceManagement/MouldKing/MouldKing_MK6_DatagramTests.cs
+++ b/BrickController2/BrickController2.Tests/DeviceManagement/MouldKing/MouldKing_MK6_DatagramTests.cs
@@ -1,0 +1,176 @@
+﻿using BrickController2.DeviceManagement;
+using BrickController2.DeviceManagement.MouldKing;
+using BrickController2.PlatformServices.BluetoothLE;
+using FluentAssertions;
+using Moq;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace BrickController2.Tests.DeviceManagement.MouldKing;
+
+public class MouldKing_MK6_DatagramTests
+{
+    private static readonly byte[] AppIdentifier = [0x61, 0x62, 0x63];
+
+    /// <summary>
+    /// This class is a testable subclass of MK6 that exposes the protected TryGetTelegram method for testing purposes.
+    /// </summary>
+    private class TestableMK6 : MK6
+    {
+        public TestableMK6(string name, string address, byte[] deviceData,
+            IDeviceRepository deviceRepository, IBluetoothLEService bleService,
+            IMKPlatformService mkPlatformService, IMouldKingDeviceManager mkDeviceManager)
+            : base(name, address, deviceData, deviceRepository, bleService, mkPlatformService, mkDeviceManager)
+        {
+        }
+
+        // Expose the protected method for testing
+        public bool TestTryGetTelegram(bool getConnectTelegram, out byte[] payload)
+            => TryGetTelegram(getConnectTelegram, out payload);
+    }
+
+    /// <summary>
+    /// This class is a test implementation of the IMKPlatformService interface that simulates the behavior of the TryGetRfPayload method for testing purposes.
+    /// It always returns true and sets the rfPayload to the rawData provided.
+    /// </summary>
+    private class TestMKPlatformService : IMKPlatformService
+    {
+        public bool TryGetRfPayload(byte[] rawData, out byte[] rfPayload)
+        {
+            rfPayload = rawData;
+            return true; // Simulate success
+        }
+    }
+
+    private readonly Mock<IDeviceRepository> _deviceRepository = new(MockBehavior.Strict);
+    private readonly Mock<IBluetoothLEService> _bluetoothLEService = new(MockBehavior.Strict);
+    private readonly Mock<IMouldKingDeviceManager> _manager = new(MockBehavior.Strict);
+    private readonly TestMKPlatformService _mkPlatformService = new();
+
+    public MouldKing_MK6_DatagramTests()
+    {
+        _manager.Setup(x => x.GetAppId()).Returns(AppIdentifier);
+    }
+
+    /// <summary>
+    /// This test checks that the payload identifiers are correctly set in the connect datagram for each device address.
+    /// </summary>
+    /// <param name="deviceAddress">The address of the device to test.</param>
+    /// <param name="expectedPayloadIdentifier1">The expected first payload identifier.</param>
+    /// <param name="expectedPayloadIdentifier2">The expected second payload identifier.</param>
+    [Theory]
+    [InlineData(MK6.Device1, 0x6d, 0x92)]
+    [InlineData(MK6.Device2, 0x6d, 0x92)]
+    [InlineData(MK6.Device3, 0x6d, 0x92)]
+    public void MK6_TryGetTelegram_ConnectDatagram_PayloadIdentifier(string deviceAddress, byte expectedPayloadIdentifier1, byte expectedPayloadIdentifier2)
+    {
+        TestableMK6 device = new TestableMK6("MK6", deviceAddress, [], _deviceRepository.Object, _bluetoothLEService.Object, _mkPlatformService, _manager.Object);
+
+        device.TestTryGetTelegram(true, out byte[] payload).Should().BeTrue();
+        payload[0].Should().Be(expectedPayloadIdentifier1);
+        payload[9].Should().Be(expectedPayloadIdentifier2);
+    }
+
+    /// <summary>
+    /// This test checks that the AppIdentifier is correctly included in the connect datagram payload for each device address.
+    /// </summary>
+    /// <param name="deviceAddress">The address of the device to test.</param>
+    [Theory]
+    [InlineData(MK6.Device1)]
+    [InlineData(MK6.Device2)]
+    [InlineData(MK6.Device3)]
+    public async Task MK6_TryGetTelegram_ConnectDatagram_AppIdentifier(string deviceAddress)
+    {
+        TestableMK6 device = new TestableMK6("MK6", deviceAddress, [], _deviceRepository.Object, _bluetoothLEService.Object, _mkPlatformService, _manager.Object);
+
+        device.TestTryGetTelegram(true, out byte[] payload).Should().BeTrue();
+        payload[1].Should().Be(AppIdentifier[0]);
+        payload[2].Should().Be(AppIdentifier[1]);
+    }
+
+    /// <summary>
+    /// This test checks that the payload identifiers are correctly set in the command datagram for each device address.
+    /// </summary>
+    /// <param name="deviceAddress">The address of the device to test.</param>
+    /// <param name="expectedPayloadIdentifier1">The expected first payload identifier.</param>
+    /// <param name="expectedPayloadIdentifier2">The expected second payload identifier.</param>
+    [Theory]
+    [InlineData(MK6.Device1, 0x61, 0x9e)]
+    [InlineData(MK6.Device2, 0x62, 0x9d)]
+    [InlineData(MK6.Device3, 0x63, 0x9c)]
+    public async Task MK6_TryGetTelegram_CommandDatagram_PayloadIdentifier(string deviceAddress, byte expectedPayloadIdentifier1, byte expectedPayloadIdentifier2)
+    {
+        TestableMK6 device = new TestableMK6("MK6", deviceAddress, [], _deviceRepository.Object, _bluetoothLEService.Object, _mkPlatformService, _manager.Object);
+
+        device.TestTryGetTelegram(false, out byte[] payload).Should().BeTrue();
+        payload[0].Should().Be(expectedPayloadIdentifier1);
+        payload[9].Should().Be(expectedPayloadIdentifier2);
+    }
+
+    /// <summary>
+    /// This test checks that the AppIdentifier is correctly included in the command datagram payload for each device address.
+    /// </summary>
+    /// <param name="deviceAddress">The address of the device to test.</param>
+    [Theory]
+    [InlineData(MK6.Device1)]
+    [InlineData(MK6.Device2)]
+    [InlineData(MK6.Device3)]
+    public async Task MK6_TryGetTelegram_CommandDatagram_AppIdentifier(string deviceAddress)
+    {
+        TestableMK6 device = new TestableMK6("MK6", deviceAddress, [], _deviceRepository.Object, _bluetoothLEService.Object, _mkPlatformService, _manager.Object);
+
+        device.TestTryGetTelegram(false, out byte[] payload).Should().BeTrue();
+        payload[1].Should().Be(AppIdentifier[0]);
+        payload[2].Should().Be(AppIdentifier[1]);
+    }
+
+    /// <summary>
+    /// This test checks that the command datagram payload is correctly constructed based on the set output values for each device address.
+    /// </summary>
+    /// <param name="deviceAddress">The address of the device to test.</param>
+    /// <param name="setValues">The set values for each channel.</param>
+    /// <param name="expectedPayload">The expected payload for the command datagram.</param>
+    [Theory]
+    [InlineData(MK6.Device1, new float[] { 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f }, new byte[] { 0x80, 0x80, 0x80, 0x80, 0x80, 0x80 })]        // all channels neutral
+    [InlineData(MK6.Device1, new float[] { 1.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f }, new byte[] { 0xff, 0x80, 0x80, 0x80, 0x80, 0x80 })]        // channel 1 maximum, others neutral
+    [InlineData(MK6.Device1, new float[] { 0.0f, 1.0f, 0.0f, 0.0f, 0.0f, 0.0f }, new byte[] { 0x80, 0xff, 0x80, 0x80, 0x80, 0x80 })]        // channel 2 maximum, others neutral
+    [InlineData(MK6.Device1, new float[] { 0.0f, 0.0f, 1.0f, 0.0f, 0.0f, 0.0f }, new byte[] { 0x80, 0x80, 0xff, 0x80, 0x80, 0x80 })]        // channel 3 maximum, others neutral
+    [InlineData(MK6.Device1, new float[] { 0.0f, 0.0f, 0.0f, 1.0f, 0.0f, 0.0f }, new byte[] { 0x80, 0x80, 0x80, 0xff, 0x80, 0x80 })]        // channel 4 maximum, others neutral
+    [InlineData(MK6.Device1, new float[] { 0.0f, 0.0f, 0.0f, 0.0f, 1.0f, 0.0f }, new byte[] { 0x80, 0x80, 0x80, 0x80, 0xff, 0x80 })]        // channel 5 maximum, others neutral
+    [InlineData(MK6.Device1, new float[] { 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 1.0f }, new byte[] { 0x80, 0x80, 0x80, 0x80, 0x80, 0xff })]        // channel 6 maximum, others neutral
+    [InlineData(MK6.Device1, new float[] { -1.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f }, new byte[] { 0x00, 0x80, 0x80, 0x80, 0x80, 0x80 })]       // channel 1 minimum, others neutral
+    [InlineData(MK6.Device1, new float[] { 0.0f, -1.0f, 0.0f, 0.0f, 0.0f, 0.0f }, new byte[] { 0x80, 0x00, 0x80, 0x80, 0x80, 0x80 })]       // channel 2 minimum, others neutral
+    [InlineData(MK6.Device1, new float[] { 0.0f, 0.0f, -1.0f, 0.0f, 0.0f, 0.0f }, new byte[] { 0x80, 0x80, 0x00, 0x80, 0x80, 0x80 })]       // channel 3 minimum, others neutral
+    [InlineData(MK6.Device1, new float[] { 0.0f, 0.0f, 0.0f, -1.0f, 0.0f, 0.0f }, new byte[] { 0x80, 0x80, 0x80, 0x00, 0x80, 0x80 })]       // channel 4 minimum, others neutral
+    [InlineData(MK6.Device1, new float[] { 0.0f, 0.0f, 0.0f, 0.0f, -1.0f, 0.0f }, new byte[] { 0x80, 0x80, 0x80, 0x80, 0x00, 0x80 })]       // channel 5 minimum, others neutral
+    [InlineData(MK6.Device1, new float[] { 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, -1.0f }, new byte[] { 0x80, 0x80, 0x80, 0x80, 0x80, 0x00 })]       // channel 6 minimum, others neutral
+    [InlineData(MK6.Device1, new float[] { 9.0f, 9.0f, 9.0f, 9.0f, 9.0f, 9.0f }, new byte[] { 0xff, 0xff, 0xff, 0xff, 0xff, 0xff })]        // all channels above maximum, should be clamped to maximum
+    [InlineData(MK6.Device1, new float[] { -9.0f, -9.0f, -9.0f, -9.0f, -9.0f, -9.0f }, new byte[] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 })]  // all channels below minimum, should be clamped to minimum
+
+    [InlineData(MK6.Device2, new float[] { 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f }, new byte[] { 0x80, 0x80, 0x80, 0x80, 0x80, 0x80 })]        // all channels neutral
+    [InlineData(MK6.Device2, new float[] { 9.0f, 9.0f, 9.0f, 9.0f, 9.0f, 9.0f }, new byte[] { 0xff, 0xff, 0xff, 0xff, 0xff, 0xff })]        // all channels above maximum, should be clamped to maximum
+    [InlineData(MK6.Device2, new float[] { -9.0f, -9.0f, -9.0f, -9.0f, -9.0f, -9.0f }, new byte[] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 })]  // all channels below minimum, should be clamped to minimum
+
+    [InlineData(MK6.Device3, new float[] { 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f }, new byte[] { 0x80, 0x80, 0x80, 0x80, 0x80, 0x80 })]        // all channels neutral
+    [InlineData(MK6.Device3, new float[] { 9.0f, 9.0f, 9.0f, 9.0f, 9.0f, 9.0f }, new byte[] { 0xff, 0xff, 0xff, 0xff, 0xff, 0xff })]        // all channels above maximum, should be clamped to maximum
+    [InlineData(MK6.Device3, new float[] { -9.0f, -9.0f, -9.0f, -9.0f, -9.0f, -9.0f }, new byte[] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 })]  // all channels below minimum, should be clamped to minimum
+    public async Task MK6_Check_CommandDatagram_Payload(string deviceAddress, float[] setValues, byte[] expectedPayload)
+    {
+        TestableMK6 device = new TestableMK6("MK6", deviceAddress, [], _deviceRepository.Object, _bluetoothLEService.Object, _mkPlatformService, _manager.Object);
+
+        // Set the output values for the device
+        for (int i = 0; i < setValues.Length; i++)
+        {
+            device.SetOutput(i, setValues[i]);
+        }
+
+        // Get the command datagram payload
+        device.TestTryGetTelegram(false, out byte[] payload).Should().BeTrue();
+
+        // Check that the payload matches the expected values
+        for (int i = 0; i < expectedPayload.Length; i++)
+        {
+            payload[i + 3].Should().Be(expectedPayload[i]);
+        }
+    }
+}

--- a/BrickController2/BrickController2.Tests/DeviceManagement/MouldKing/MouldKing_MK6_DatagramTests.cs
+++ b/BrickController2/BrickController2.Tests/DeviceManagement/MouldKing/MouldKing_MK6_DatagramTests.cs
@@ -13,23 +13,6 @@ public class MouldKing_MK6_DatagramTests
     private static readonly byte[] AppIdentifier = [0x61, 0x62];
 
     /// <summary>
-    /// This class is a testable subclass of MK6 that exposes the protected TryGetTelegram method for testing purposes.
-    /// </summary>
-    private class TestableMK6 : MK6
-    {
-        public TestableMK6(string name, string address, byte[] deviceData,
-            IDeviceRepository deviceRepository, IBluetoothLEService bleService,
-            IMKPlatformService mkPlatformService, IMouldKingDeviceManager mkDeviceManager)
-            : base(name, address, deviceData, deviceRepository, bleService, mkPlatformService, mkDeviceManager)
-        {
-        }
-
-        // Expose the protected method for testing
-        public bool TestTryGetTelegram(bool getConnectTelegram, out byte[] payload)
-            => TryGetTelegram(getConnectTelegram, out payload);
-    }
-
-    /// <summary>
     /// This class is a test implementation of the IMKPlatformService interface that simulates the behavior of the TryGetRfPayload method for testing purposes.
     /// It always returns true and sets the rfPayload to the rawData provided.
     /// </summary>
@@ -64,9 +47,9 @@ public class MouldKing_MK6_DatagramTests
     [InlineData(MK6.Device3, 0x6d, 0x92)]
     public void MK6_TryGetTelegram_ConnectDatagram_PayloadIdentifier(string deviceAddress, byte expectedPayloadIdentifier1, byte expectedPayloadIdentifier2)
     {
-        TestableMK6 device = new TestableMK6("MK6", deviceAddress, [], _deviceRepository.Object, _bluetoothLEService.Object, _mkPlatformService, _manager.Object);
+        MK6 device = new MK6("MK6", deviceAddress, [], _deviceRepository.Object, _bluetoothLEService.Object, _mkPlatformService, _manager.Object);
 
-        device.TestTryGetTelegram(true, out byte[] payload).Should().BeTrue();
+        device.TryGetTelegram(true, out byte[] payload).Should().BeTrue();
         payload[0].Should().Be(expectedPayloadIdentifier1);
         payload[7].Should().Be(expectedPayloadIdentifier2);
     }
@@ -81,9 +64,9 @@ public class MouldKing_MK6_DatagramTests
     [InlineData(MK6.Device3)]
     public void MK6_TryGetTelegram_ConnectDatagram_AppIdentifier(string deviceAddress)
     {
-        TestableMK6 device = new TestableMK6("MK6", deviceAddress, [], _deviceRepository.Object, _bluetoothLEService.Object, _mkPlatformService, _manager.Object);
+        MK6 device = new MK6("MK6", deviceAddress, [], _deviceRepository.Object, _bluetoothLEService.Object, _mkPlatformService, _manager.Object);
 
-        device.TestTryGetTelegram(true, out byte[] payload).Should().BeTrue();
+        device.TryGetTelegram(true, out byte[] payload).Should().BeTrue();
         payload[1].Should().Be(AppIdentifier[0]);
         payload[2].Should().Be(AppIdentifier[1]);
     }
@@ -100,9 +83,9 @@ public class MouldKing_MK6_DatagramTests
     [InlineData(MK6.Device3, 0x63, 0x9c)]
     public async Task MK6_TryGetTelegram_CommandDatagram_PayloadIdentifier(string deviceAddress, byte expectedPayloadIdentifier1, byte expectedPayloadIdentifier2)
     {
-        TestableMK6 device = new TestableMK6("MK6", deviceAddress, [], _deviceRepository.Object, _bluetoothLEService.Object, _mkPlatformService, _manager.Object);
+        MK6 device = new MK6("MK6", deviceAddress, [], _deviceRepository.Object, _bluetoothLEService.Object, _mkPlatformService, _manager.Object);
 
-        device.TestTryGetTelegram(false, out byte[] payload).Should().BeTrue();
+        device.TryGetTelegram(false, out byte[] payload).Should().BeTrue();
         payload[0].Should().Be(expectedPayloadIdentifier1);
         payload[9].Should().Be(expectedPayloadIdentifier2);
     }
@@ -117,9 +100,9 @@ public class MouldKing_MK6_DatagramTests
     [InlineData(MK6.Device3)]
     public async Task MK6_TryGetTelegram_CommandDatagram_AppIdentifier(string deviceAddress)
     {
-        TestableMK6 device = new TestableMK6("MK6", deviceAddress, [], _deviceRepository.Object, _bluetoothLEService.Object, _mkPlatformService, _manager.Object);
+        MK6 device = new MK6("MK6", deviceAddress, [], _deviceRepository.Object, _bluetoothLEService.Object, _mkPlatformService, _manager.Object);
 
-        device.TestTryGetTelegram(false, out byte[] payload).Should().BeTrue();
+        device.TryGetTelegram(false, out byte[] payload).Should().BeTrue();
         payload[1].Should().Be(AppIdentifier[0]);
         payload[2].Should().Be(AppIdentifier[1]);
     }
@@ -156,7 +139,7 @@ public class MouldKing_MK6_DatagramTests
     [InlineData(MK6.Device3, new float[] { -9.0f, -9.0f, -9.0f, -9.0f, -9.0f, -9.0f }, new byte[] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 })]  // all channels below minimum, should be clamped to minimum
     public async Task MK6_Check_CommandDatagram_Payload(string deviceAddress, float[] setValues, byte[] expectedPayload)
     {
-        TestableMK6 device = new TestableMK6("MK6", deviceAddress, [], _deviceRepository.Object, _bluetoothLEService.Object, _mkPlatformService, _manager.Object);
+        MK6 device = new MK6("MK6", deviceAddress, [], _deviceRepository.Object, _bluetoothLEService.Object, _mkPlatformService, _manager.Object);
 
         // Set the output values for the device
         for (int i = 0; i < setValues.Length; i++)
@@ -165,7 +148,7 @@ public class MouldKing_MK6_DatagramTests
         }
 
         // Get the command datagram payload
-        device.TestTryGetTelegram(false, out byte[] payload).Should().BeTrue();
+        device.TryGetTelegram(false, out byte[] payload).Should().BeTrue();
 
         // Check that the payload matches the expected values
         for (int i = 0; i < expectedPayload.Length; i++)

--- a/BrickController2/BrickController2.Tests/DeviceManagement/MouldKing/MouldKing_MK6_DatagramTests.cs
+++ b/BrickController2/BrickController2.Tests/DeviceManagement/MouldKing/MouldKing_MK6_DatagramTests.cs
@@ -79,7 +79,7 @@ public class MouldKing_MK6_DatagramTests
     [InlineData(MK6.Device1)]
     [InlineData(MK6.Device2)]
     [InlineData(MK6.Device3)]
-    public async Task MK6_TryGetTelegram_ConnectDatagram_AppIdentifier(string deviceAddress)
+    public void MK6_TryGetTelegram_ConnectDatagram_AppIdentifier(string deviceAddress)
     {
         TestableMK6 device = new TestableMK6("MK6", deviceAddress, [], _deviceRepository.Object, _bluetoothLEService.Object, _mkPlatformService, _manager.Object);
 

--- a/BrickController2/BrickController2.Tests/DeviceManagement/MouldKing/MouldKing_MK6_DatagramTests.cs
+++ b/BrickController2/BrickController2.Tests/DeviceManagement/MouldKing/MouldKing_MK6_DatagramTests.cs
@@ -68,7 +68,7 @@ public class MouldKing_MK6_DatagramTests
 
         device.TestTryGetTelegram(true, out byte[] payload).Should().BeTrue();
         payload[0].Should().Be(expectedPayloadIdentifier1);
-        payload[9].Should().Be(expectedPayloadIdentifier2);
+        payload[7].Should().Be(expectedPayloadIdentifier2);
     }
 
     /// <summary>

--- a/BrickController2/BrickController2.Tests/DeviceManagement/MouldKing/MouldKing_MK6_DatagramTests.cs
+++ b/BrickController2/BrickController2.Tests/DeviceManagement/MouldKing/MouldKing_MK6_DatagramTests.cs
@@ -10,7 +10,7 @@ namespace BrickController2.Tests.DeviceManagement.MouldKing;
 
 public class MouldKing_MK6_DatagramTests
 {
-    private static readonly byte[] AppIdentifier = [0x61, 0x62, 0x63];
+    private static readonly byte[] AppIdentifier = [0x61, 0x62];
 
     /// <summary>
     /// This class is a testable subclass of MK6 that exposes the protected TryGetTelegram method for testing purposes.

--- a/BrickController2/BrickController2/DeviceManagement/JieStar/IJieStarDeviceManager.cs
+++ b/BrickController2/BrickController2/DeviceManagement/JieStar/IJieStarDeviceManager.cs
@@ -1,0 +1,11 @@
+using System;
+
+namespace BrickController2.DeviceManagement.JieStar;
+
+/// <summary>
+/// Interface for JieStarDeviceManager.
+/// </summary>
+public interface IJieStarDeviceManager
+{
+    ReadOnlyMemory<byte> GetAppId();
+}

--- a/BrickController2/BrickController2/DeviceManagement/JieStar/JieStar.cs
+++ b/BrickController2/BrickController2/DeviceManagement/JieStar/JieStar.cs
@@ -15,6 +15,7 @@ internal class JieStar : Vendor<JieStar>
     {
         // device manager
         builder.ContainerBuilder.RegisterType<JieStarDeviceManager>()
+            .As<IJieStarDeviceManager>()
             .SingleInstance();
 
         // manually added devices

--- a/BrickController2/BrickController2/DeviceManagement/JieStar/JieStarBase.cs
+++ b/BrickController2/BrickController2/DeviceManagement/JieStar/JieStarBase.cs
@@ -227,7 +227,7 @@ internal abstract class JieStarBase : BluetoothAdvertisingDevice
     /// <param name="payload">When this method returns, contains the RF payload as a byte array if the operation succeeds; otherwise, <see
     /// langword="null"/>.</param>
     /// <returns><see langword="true"/> if the RF payload was successfully retrieved; otherwise, <see langword="false"/>.</returns>
-    protected bool TryGetTelegram(bool getConnectTelegram, out byte[] payload)
+    protected internal bool TryGetTelegram(bool getConnectTelegram, out byte[] payload)
     {
         if (getConnectTelegram)
         {

--- a/BrickController2/BrickController2/DeviceManagement/JieStar/JieStarBase.cs
+++ b/BrickController2/BrickController2/DeviceManagement/JieStar/JieStarBase.cs
@@ -39,7 +39,7 @@ internal abstract class JieStarBase : BluetoothAdvertisingDevice
     /// </summary>
     protected readonly float[] _storedValues;
 
-    protected JieStarBase(string name, string address, byte[] deviceData, IDeviceRepository deviceRepository, IBluetoothLEService bleService, IJieStarPlatformService jieStarPlatformService, JieStarDeviceManager jieStarDeviceManager, byte[] telegram_Connect, byte[] telegram_Base, byte ctxValue2)
+    protected JieStarBase(string name, string address, byte[] deviceData, IDeviceRepository deviceRepository, IBluetoothLEService bleService, IJieStarPlatformService jieStarPlatformService, IJieStarDeviceManager jieStarDeviceManager, byte[] telegram_Connect, byte[] telegram_Base, byte ctxValue2)
         : base(name, address, deviceData, deviceRepository, bleService)
     {
         _telegram_Connect = telegram_Connect;

--- a/BrickController2/BrickController2/DeviceManagement/JieStar/JieStarBase.cs
+++ b/BrickController2/BrickController2/DeviceManagement/JieStar/JieStarBase.cs
@@ -55,6 +55,10 @@ internal abstract class JieStarBase : BluetoothAdvertisingDevice
 
         _telegram_Base[1] = appId[0];
         _telegram_Base[2] = appId[1];
+
+
+        // initialize all channels in _telegram_Base and _storedValues to zero value
+        InitDevice();
     }
 
     /// <summary>

--- a/BrickController2/BrickController2/DeviceManagement/JieStar/JieStarDeviceManager.cs
+++ b/BrickController2/BrickController2/DeviceManagement/JieStar/JieStarDeviceManager.cs
@@ -6,7 +6,7 @@ namespace BrickController2.DeviceManagement.JieStar;
 /// <summary>
 /// Manager for JIESTAR devices
 /// </summary>
-public class JieStarDeviceManager
+public class JieStarDeviceManager : IJieStarDeviceManager
 {
     private const int AppIdentifierLength = 2; // JIESTAR protocol defines 2 bytes for the app identifier
 

--- a/BrickController2/BrickController2/DeviceManagement/JieStar/JieStarSCM4.cs
+++ b/BrickController2/BrickController2/DeviceManagement/JieStar/JieStarSCM4.cs
@@ -29,7 +29,7 @@ internal class JieStarSCM4 : JieStarBase, IDeviceType<JieStarSCM4>
     /// </summary>
     private static readonly TimeSpan ReconnectTimeSpan = TimeSpan.FromSeconds(3);
 
-    public JieStarSCM4(string name, string address, byte[] deviceData, IDeviceRepository deviceRepository, IBluetoothLEService bleService, IJieStarPlatformService jieStarPlatformService, JieStarDeviceManager jieStarDeviceManager)
+    public JieStarSCM4(string name, string address, byte[] deviceData, IDeviceRepository deviceRepository, IBluetoothLEService bleService, IJieStarPlatformService jieStarPlatformService, IJieStarDeviceManager jieStarDeviceManager)
       : base(name, address, deviceData, deviceRepository, bleService, jieStarPlatformService, jieStarDeviceManager, Telegram_Connect_Device, Telegram_Base_Device, GetCTXValue2(address))
     {
     }

--- a/BrickController2/BrickController2/DeviceManagement/JieStar/JieStarSCM4.cs
+++ b/BrickController2/BrickController2/DeviceManagement/JieStar/JieStarSCM4.cs
@@ -20,9 +20,19 @@ internal class JieStarSCM4 : JieStarBase, IDeviceType<JieStarSCM4>
     private static readonly byte[] Telegram_Connect_Device = [0xa4, 0x1d, 0x74, 0x80, 0x80, 0x80, 0x80, 0x5b];
 
     /// <summary>
-    /// Base Telegram for SCM4 devices
+    /// Base Telegram for SCM4 device 1
     /// </summary>
-    private static readonly byte[] Telegram_Base_Device = [0x40, 0x1d, 0x74, 0x80, 0x80, 0x80, 0x80, 0xbf];
+    private static readonly byte[] Telegram_Base_Device_1 = [0x40, 0x1d, 0x74, 0x80, 0x80, 0x80, 0x80, 0xbf];
+
+    /// <summary>
+    /// Base Telegram for SCM4 device 2
+    /// </summary>
+    private static readonly byte[] Telegram_Base_Device_2 = [0x40, 0x1d, 0x74, 0x80, 0x80, 0x80, 0x80, 0xbf];
+
+    /// <summary>
+    /// Base Telegram for SCM4 device 3
+    /// </summary>
+    private static readonly byte[] Telegram_Base_Device_3 = [0x40, 0x1d, 0x74, 0x80, 0x80, 0x80, 0x80, 0xbf];
 
     /// <summary>
     /// after this timespan and all channel's values equal to zero the connect telegram is sent
@@ -30,7 +40,7 @@ internal class JieStarSCM4 : JieStarBase, IDeviceType<JieStarSCM4>
     private static readonly TimeSpan ReconnectTimeSpan = TimeSpan.FromSeconds(3);
 
     public JieStarSCM4(string name, string address, byte[] deviceData, IDeviceRepository deviceRepository, IBluetoothLEService bleService, IJieStarPlatformService jieStarPlatformService, IJieStarDeviceManager jieStarDeviceManager)
-      : base(name, address, deviceData, deviceRepository, bleService, jieStarPlatformService, jieStarDeviceManager, Telegram_Connect_Device, Telegram_Base_Device, GetCTXValue2(address))
+      : base(name, address, deviceData, deviceRepository, bleService, jieStarPlatformService, jieStarDeviceManager, Telegram_Connect_Device, GetTelegramBase(address), GetCTXValue2(address))
     {
     }
 
@@ -81,6 +91,22 @@ internal class JieStarSCM4 : JieStarBase, IDeviceType<JieStarSCM4>
     /// </summary>
     /// <param name="address">address</param>
     /// <returns>reference to Base-Telegram</returns>
+    private static byte[] GetTelegramBase(string address)
+    {
+        return address switch
+        {
+            JieStarSCM4.Device1 => Telegram_Base_Device_1,
+            JieStarSCM4.Device2 => Telegram_Base_Device_2,
+            JieStarSCM4.Device3 => Telegram_Base_Device_3,
+            _ => throw new ArgumentException("Illegal Argument", nameof(address))
+        };
+    }
+
+    /// <summary>
+    /// Get CTXValue2 for the given address
+    /// </summary>
+    /// <param name="address">address</param>
+    /// <returns>CTXValue2</returns>
     private static byte GetCTXValue2(string address)
     {
         return address switch

--- a/BrickController2/BrickController2/DeviceManagement/JieStar/JieStarSCM8.cs
+++ b/BrickController2/BrickController2/DeviceManagement/JieStar/JieStarSCM8.cs
@@ -39,7 +39,7 @@ internal class JieStarSCM8 : JieStarBase, IDeviceType<JieStarSCM8>
     /// </summary>
     private static readonly TimeSpan ReconnectTimeSpan = TimeSpan.FromSeconds(3);
 
-    public JieStarSCM8(string name, string address, byte[] deviceData, IDeviceRepository deviceRepository, IBluetoothLEService bleService, IJieStarPlatformService jieStarPlatformService, JieStarDeviceManager jieStarDeviceManager)
+    public JieStarSCM8(string name, string address, byte[] deviceData, IDeviceRepository deviceRepository, IBluetoothLEService bleService, IJieStarPlatformService jieStarPlatformService, IJieStarDeviceManager jieStarDeviceManager)
       : base(name, address, deviceData, deviceRepository, bleService, jieStarPlatformService, jieStarDeviceManager, JieStarSCM8.Telegram_Connect, GetTelegramBase(address), JieStarProtocol.CTXValue2)
     {
     }

--- a/BrickController2/BrickController2/DeviceManagement/MouldKing/MK3_8.cs
+++ b/BrickController2/BrickController2/DeviceManagement/MouldKing/MK3_8.cs
@@ -36,6 +36,9 @@ internal class MK3_8 : MKBaseNibble, IDeviceType<MK3_8>
     public MK3_8(string name, string address, byte[] deviceData, IDeviceRepository deviceRepository, IBluetoothLEService bleService, IMKPlatformService mkPlatformService, IMouldKingDeviceManager mkDeviceManager)
       : base(name, address, deviceData, deviceRepository, bleService, mkPlatformService, mkDeviceManager, 0, Telegram_Connect, Telegram_Base)
     {
+        // This is an exception - the second byte of the AppIdentifier is used as setvalue for channel 5
+        _telegram_Connect[2] = 0x00;
+        _telegram_Base[2] = 0x00;
     }
 
     public override DeviceType DeviceType => Type;

--- a/BrickController2/BrickController2/DeviceManagement/MouldKing/MK4.cs
+++ b/BrickController2/BrickController2/DeviceManagement/MouldKing/MK4.cs
@@ -17,7 +17,7 @@ internal class MK4 : MKBaseNibble, IDeviceType<MK4>
     /// Telegram to connect to the MK4.0 device(s)
     /// This telegram is sent on init and on reconnect conditions matching
     /// </summary>
-    private static readonly byte[] Telegram_Connect = new byte[] { 0xAD, 0x7B, 0xA7, 0x80, 0x80, 0x80, 0x4F, 0x52 };
+    private static readonly byte[] Telegram_Connect = [0xAD, 0x7B, 0xA7, 0x80, 0x80, 0x80, 0x4F, 0x52];
 
     /// <summary>
     /// Base Telegram for MK4.0
@@ -26,7 +26,7 @@ internal class MK4 : MKBaseNibble, IDeviceType<MK4>
     /// * channels 0..3 for Device2 start at offset 5 and are analog channels
     /// * channels 0..3 for Device3 start at offset 7 and are analog channels
     /// </summary>
-    private static readonly byte[] Telegram_Base = new byte[] { 0x7D, 0x7B, 0xA7, 0x88, 0x88, 0x88, 0x88, 0x88, 0x88, 0x82 };
+    private static readonly byte[] Telegram_Base = [0x7D, 0x7B, 0xA7, 0x88, 0x88, 0x88, 0x88, 0x88, 0x88, 0x82];
 
     /// <summary>
     /// after this timespan and all channel's values equal to zero the connect telegram is sent
@@ -156,4 +156,16 @@ internal class MK4 : MKBaseNibble, IDeviceType<MK4>
         Device3 => 2,
         _ => throw new ArgumentException($"Illegal Argument: \"{address}\"", nameof(address))
     };
+
+    /// <summary>
+    /// Resets the state of the base telegram.
+    /// This is needed for testing purposes to ensure that the base telegram is in a known state before each test is executed.
+    /// </summary>
+    internal static void ResetBaseTelegram()
+    {
+        for (int index = 3; index <= 8; index++)
+        {
+            Telegram_Base[index] = 0x88;
+        }
+    }
 }

--- a/BrickController2/BrickController2/DeviceManagement/MouldKing/MK4.cs
+++ b/BrickController2/BrickController2/DeviceManagement/MouldKing/MK4.cs
@@ -63,6 +63,22 @@ internal class MK4 : MKBaseNibble, IDeviceType<MK4>
     protected override ushort ManufacturerId => MKProtocol.ManufacturerID;
 
     /// <summary>
+    /// This method sets the device to initial state before advertising starts
+    /// All channels are initialized with zeroValue.
+    /// </summary>
+    protected override void InitDevice()
+    {
+        base.InitDevice();
+
+        // Reset the base telegram to its initial state for all channels and all instances to the default value of 0x88.
+        // Because the 3 instances of the MK4.0 device are using the same static Telegram_Base, we need to reset the values for all channels of all instances.
+        for (int index = 3; index <= 8; index++)
+        {
+            Telegram_Base[index] = 0x88;
+        }
+    }
+
+    /// <summary>
     /// Get or create BluetoothAdvertisingDeviceHandler
     /// </summary>
     /// <returns>Instance of BluetoothAdvertisingDeviceHandler</returns>
@@ -156,16 +172,4 @@ internal class MK4 : MKBaseNibble, IDeviceType<MK4>
         Device3 => 2,
         _ => throw new ArgumentException($"Illegal Argument: \"{address}\"", nameof(address))
     };
-
-    /// <summary>
-    /// Resets the state of the base telegram.
-    /// This is needed for testing purposes to ensure that the base telegram is in a known state before each test is executed.
-    /// </summary>
-    internal static void ResetBaseTelegram()
-    {
-        for (int index = 3; index <= 8; index++)
-        {
-            Telegram_Base[index] = 0x88;
-        }
-    }
 }

--- a/BrickController2/BrickController2/DeviceManagement/MouldKing/MKBaseByte.cs
+++ b/BrickController2/BrickController2/DeviceManagement/MouldKing/MKBaseByte.cs
@@ -120,7 +120,7 @@ internal abstract class MKBaseByte : BluetoothAdvertisingDevice
     /// <param name="payload">When this method returns, contains the RF payload as a byte array if the operation succeeds; otherwise, <see
     /// langword="null"/>.</param>
     /// <returns><see langword="true"/> if the RF payload was successfully retrieved; otherwise, <see langword="false"/>.</returns>
-    protected bool TryGetTelegram(bool getConnectTelegram, out byte[] payload)
+    protected internal bool TryGetTelegram(bool getConnectTelegram, out byte[] payload)
     {
         if (getConnectTelegram)
         {

--- a/BrickController2/BrickController2/DeviceManagement/MouldKing/MKBaseByte.cs
+++ b/BrickController2/BrickController2/DeviceManagement/MouldKing/MKBaseByte.cs
@@ -45,6 +45,9 @@ internal abstract class MKBaseByte : BluetoothAdvertisingDevice
 
         _telegram_Base[1] = appId[0];
         _telegram_Base[2] = appId[1];
+
+        // initialize all channels in _telegram_Base and _storedValues to zero value
+        InitDevice();
     }
 
     /// <summary>

--- a/BrickController2/BrickController2/DeviceManagement/MouldKing/MKBaseNibble.cs
+++ b/BrickController2/BrickController2/DeviceManagement/MouldKing/MKBaseNibble.cs
@@ -206,7 +206,7 @@ internal abstract class MKBaseNibble : BluetoothAdvertisingDevice
     /// <param name="payload">When this method returns, contains the RF payload as a byte array if the operation succeeds; otherwise, <see
     /// langword="null"/>.</param>
     /// <returns><see langword="true"/> if the RF payload was successfully retrieved; otherwise, <see langword="false"/>.</returns>
-    protected bool TryGetTelegram(bool getConnectTelegram, out byte[] payload)
+    protected internal bool TryGetTelegram(bool getConnectTelegram, out byte[] payload)
     {
         if (getConnectTelegram)
         {

--- a/BrickController2/BrickController2/DeviceManagement/MouldKing/MKBaseNibble.cs
+++ b/BrickController2/BrickController2/DeviceManagement/MouldKing/MKBaseNibble.cs
@@ -62,6 +62,9 @@ internal abstract class MKBaseNibble : BluetoothAdvertisingDevice
         _telegram_Base[2] = appId[1];
 
         _storedValues = new float[NumberOfChannels]; // initialize output values for all channels
+
+        // initialize all channels in _telegram_Base and _storedValues to zero value
+        InitDevice();
     }
 
     /// <summary>


### PR DESCRIPTION
Added MouldKing_MK6_DatagramTests to verify datagram payload construction for MK6 devices. Introduced TestableMK6 to expose TryGetTelegram for testing and TestMKPlatformService to simulate RF payload extraction. Used Moq for dependency mocking and added tests for payload identifiers, AppIdentifier inclusion, and output value encoding across channels and addresses. Utilized xUnit and FluentAssertions for test structure and assertions.