### PR TITLE
Refactor device reset logic and improve disconnect handling

### DIFF
--- a/BrickController2/BrickController2/DeviceManagement/BluetoothAdvertisingDevice.cs
+++ b/BrickController2/BrickController2/DeviceManagement/BluetoothAdvertisingDevice.cs
@@ -124,6 +124,8 @@ namespace BrickController2.DeviceManagement
             await _bluetoothAdvertisingDeviceHandler.StopOutputTaskAsync(this);
             await _bluetoothAdvertisingDeviceHandler.TryDisconnectAsync(this);
 
+            DisconnectDevice();
+
             DeviceState = DeviceState.Disconnected;
         }
 
@@ -133,7 +135,7 @@ namespace BrickController2.DeviceManagement
         protected abstract void InitDevice();
 
         /// <summary>
-        /// set device to discennected state
+        /// set device to disconnected state
         /// </summary>
         protected abstract void DisconnectDevice();
 

--- a/BrickController2/BrickController2/DeviceManagement/BluetoothAdvertisingDevice.cs
+++ b/BrickController2/BrickController2/DeviceManagement/BluetoothAdvertisingDevice.cs
@@ -121,10 +121,10 @@ namespace BrickController2.DeviceManagement
 
             DeviceState = DeviceState.Disconnecting;
 
+            DisconnectDevice();
+
             await _bluetoothAdvertisingDeviceHandler.StopOutputTaskAsync(this);
             await _bluetoothAdvertisingDeviceHandler.TryDisconnectAsync(this);
-
-            DisconnectDevice();
 
             DeviceState = DeviceState.Disconnected;
         }

--- a/BrickController2/BrickController2/DeviceManagement/JieStar/JieStarBase.cs
+++ b/BrickController2/BrickController2/DeviceManagement/JieStar/JieStarBase.cs
@@ -208,32 +208,14 @@ internal abstract class JieStarBase : BluetoothAdvertisingDevice
     /// This method sets the device to initial state before advertising starts
     /// All channels are initialized with zeroValue.
     /// </summary>
-    protected override void InitDevice()
-    {
-        const float zeroValue = 0.0f;
-
-        for (int channelNo = 0; channelNo < NumberOfChannels; channelNo++)
-        {
-            _storedValues[channelNo] = zeroValue;   // restore stored values to zero
-            SetChannelOutput(channelNo, zeroValue); // set all channels to zero using the channel specific function
-        }
-    }
+    protected override void InitDevice() => ResetAllChannelsToZero();
 
     /// <summary>
     /// Disconnects the device and resets the output state of all channels to zero.
     /// </summary>
     /// <remarks>This method ensures that all channels are set to a zero output state during the disconnection
     /// process. It is intended to be called as part of the device's disconnection workflow.</remarks>
-    protected override void DisconnectDevice()
-    {
-        const float zeroValue = 0.0f;
-
-        for (int channelNo = 0; channelNo < NumberOfChannels; channelNo++)
-        {
-            // call _bluetoothAdvertisingDeviceHandler.SetChannelState() to set global channel state to zero
-            SetChannelOutput(channelNo, zeroValue);
-        }
-    }
+    protected override void DisconnectDevice() => ResetAllChannelsToZero();
 
     /// <summary>
     /// Attempts to retrieve the RF payload for the specified telegram type.
@@ -274,5 +256,19 @@ internal abstract class JieStarBase : BluetoothAdvertisingDevice
             CHANNEL_START_OFFSET + (channelNo >> 1), // div 2 -> 2 channels per byte
             (channelNo & 0x01) == 0x01
         );
+    }
+
+    /// <summary>
+    /// Resets the value and the output state of all channels to zero.
+    /// </summary>
+    private void ResetAllChannelsToZero()
+    {
+        const float zeroValue = 0.0f;
+
+        for (int channelNo = 0; channelNo < NumberOfChannels; channelNo++)
+        {
+            _storedValues[channelNo] = zeroValue;
+            SetChannelOutput(channelNo, zeroValue);
+        }
     }
 }

--- a/BrickController2/BrickController2/DeviceManagement/MouldKing/MKBaseByte.cs
+++ b/BrickController2/BrickController2/DeviceManagement/MouldKing/MKBaseByte.cs
@@ -1,5 +1,5 @@
-﻿using System;
-using BrickController2.PlatformServices.BluetoothLE;
+﻿using BrickController2.PlatformServices.BluetoothLE;
+using System;
 
 namespace BrickController2.DeviceManagement.MouldKing;
 
@@ -101,16 +101,7 @@ internal abstract class MKBaseByte : BluetoothAdvertisingDevice
     /// <summary>
     /// This method sets the device to initial state before advertising starts
     /// </summary>
-    protected override void InitDevice()
-    {
-        // set all channels to zero
-        for (int index = 0; index < BaseTelegram_ChannelBytesCount; index++)
-        {
-            _telegram_Base[BaseTelegram_ChannelStartOffset + index] = 0x80;
-        }
-
-        ResetAllChannelsToZero();
-    }
+    protected override void InitDevice() => ResetAllChannelsToZero();
 
     /// <summary>
     /// Disconnects the device and resets the state of all communication channels.
@@ -141,11 +132,14 @@ internal abstract class MKBaseByte : BluetoothAdvertisingDevice
         }
     }
 
+    /// <summary>
+    /// Resets the value and the output state of all channels to zero.
+    /// </summary>
     private void ResetAllChannelsToZero()
     {
         for (int channelNo = 0; channelNo < NumberOfChannels; channelNo++)
         {
-            // call SetChannelState() to set global channel state to zero
+            _telegram_Base[BaseTelegram_ChannelStartOffset + channelNo] = 0x80;
             _bluetoothAdvertisingDeviceHandler.SetChannelState(channelNo, true);
         }
     }

--- a/BrickController2/BrickController2/DeviceManagement/MouldKing/MKBaseNibble.cs
+++ b/BrickController2/BrickController2/DeviceManagement/MouldKing/MKBaseNibble.cs
@@ -187,32 +187,14 @@ internal abstract class MKBaseNibble : BluetoothAdvertisingDevice
     /// This method sets the device to initial state before advertising starts
     /// All channels are initialized with zeroValue.
     /// </summary>
-    protected override void InitDevice()
-    {
-        const float zeroValue = 0.0f;
-
-        for (int channelNo = 0; channelNo < NumberOfChannels; channelNo++)
-        {
-            _storedValues[channelNo] = zeroValue;   // restore stored values to zero
-            SetChannelOutput(channelNo, zeroValue); // set all channels to zero using the channel specific function
-        }
-    }
+    protected override void InitDevice() => ResetAllChannelsToZero();
 
     /// <summary>
     /// Disconnects the device and resets the output state of all channels to zero.
     /// </summary>
     /// <remarks>This method ensures that all channels are set to a zero output state during the disconnection
     /// process. It is intended to be called as part of the device's disconnection workflow.</remarks>
-    protected override void DisconnectDevice()
-    {
-        const float zeroValue = 0.0f;
-
-        for (int channelNo = 0; channelNo < NumberOfChannels; channelNo++)
-        {
-            // call _bluetoothAdvertisingDeviceHandler.SetChannelState() to set global channel state to zero
-            SetChannelOutput(channelNo, zeroValue);
-        }
-    }
+    protected override void DisconnectDevice() => ResetAllChannelsToZero();
 
     /// <summary>
     /// Attempts to retrieve the RF payload for the specified telegram type.
@@ -272,5 +254,19 @@ internal abstract class MKBaseNibble : BluetoothAdvertisingDevice
         // instance 1:  4.. 7
         // instance 2:  8..11
         return _instanceNo * NumberOfChannels + channelNo;
+    }
+
+    /// <summary>
+    /// Resets the value and the output state of all channels to zero.
+    /// </summary>
+    private void ResetAllChannelsToZero()
+    {
+        const float zeroValue = 0.0f;
+
+        for (int channelNo = 0; channelNo < NumberOfChannels; channelNo++)
+        {
+            _storedValues[channelNo] = zeroValue;
+            SetChannelOutput(channelNo, zeroValue);
+        }
     }
 }


### PR DESCRIPTION
Extract repeated channel reset code into ResetAllChannelsToZero methods in JieStarBase, MKBaseByte, and MKBaseNibble. Simplify InitDevice and DisconnectDevice to use the new method. Ensure DisconnectDevice is called during BluetoothAdvertisingDevice disconnect. Fix minor comment typos.